### PR TITLE
feat: Add integrate-tracing Claude Code skill system and tracing docs

### DIFF
--- a/.claude/skills/add-manual-tracing/SKILL.md
+++ b/.claude/skills/add-manual-tracing/SKILL.md
@@ -1,0 +1,153 @@
+# Add Manual Tracing (Level B and C)
+
+> **Usage:** `/project:add-manual-tracing <agent_path>`
+> **Example:** `/project:add-manual-tracing agents/autogen/chat_agent`
+
+You are adding manual `wrap_func_with_mlflow_trace()` calls to an agent template where autolog does not fully cover all tracing layers.
+
+**This skill is only for Level B (partial autolog) and Level C (no framework autolog).** If the framework is Level A, skip this skill entirely — autolog handles everything.
+
+## Input
+
+You need:
+1. **Agent path**: The agent directory (e.g., `agents/autogen/chat_agent/`)
+2. **Package name**: The Python package name
+3. **Coverage level**: B or C
+4. **Autolog support report**: What the autolog covers and what it misses
+
+## Steps
+
+### 1. Read the agent's code
+
+Read these files to understand how the agent works:
+- `<agent_path>/main.py` — FastAPI app, `_handle_chat`, `_handle_stream`
+- `<agent_path>/src/<package>/agent.py` — Agent class/factory, how tools are registered, the main entry point
+- `<agent_path>/src/<package>/tools.py` — Tool function definitions
+- Any other file where the agent or tools are assembled (e.g., `crew.py` for CrewAI)
+
+Identify:
+- **The agent entry point**: The function that runs the full agent loop (e.g., `agent.query()`, `agent.run()`, `crew.kickoff()`)
+- **Tool registration**: How tools are attached to the agent (function list, tool objects, decorator-based, etc.)
+- **Streaming vs non-streaming**: Whether the streaming path creates the agent differently
+
+### 2. Determine what needs manual wrapping
+
+Compare the autolog report with the three tracing layers:
+
+| Layer | Needs manual wrapping if... |
+|---|---|
+| Agent orchestration | Autolog doesn't create a parent AGENT span for the full request |
+| Tool execution | Autolog doesn't capture tool calls with TOOL spans |
+| LLM calls | Autolog doesn't capture model API calls (rare — usually covered by provider autolog) |
+
+### 3. Add tool wrapping
+
+Wrap each tool so its execution creates a TOOL span. The wrapping location depends on how the agent registers tools:
+
+**If tools are functions registered by name (common in Level C):**
+
+In `agent.py` or wherever tools are registered:
+```python
+from <package>.tracing import wrap_func_with_mlflow_trace
+
+# Wrap each tool function before registering
+for name, func in self._tools:
+    func = wrap_func_with_mlflow_trace(func, span_type="tool")
+    agent.register_tool(name, func)
+```
+
+**If tools are class instances with a `_run` method (common in Level B, e.g., CrewAI):**
+
+In the file where tool objects are created (e.g., `crew.py`):
+```python
+from <package>.tracing import wrap_func_with_mlflow_trace
+
+tools = [MyTool()]
+for tool in tools:
+    tool._run = wrap_func_with_mlflow_trace(tool._run, span_type="tool", name=tool.name)
+```
+
+**If tools are decorated functions (e.g., `@tool` decorator):**
+
+Wrap the underlying function after the agent is assembled:
+```python
+for tool in agent.tools:
+    tool.func = wrap_func_with_mlflow_trace(tool.func, span_type="tool")
+```
+
+### 4. Add agent orchestration wrapping
+
+Wrap the main agent entry point to create a parent AGENT span that groups all LLM calls and tool calls under one trace.
+
+**In `agent.py` (preferred — wrap inside the adapter/closure):**
+```python
+agent.query = wrap_func_with_mlflow_trace(agent.query, span_type="agent")
+```
+
+**Or in `main.py` if the agent is created directly there:**
+```python
+# In _handle_chat:
+agent = get_agent()
+agent.run = wrap_func_with_mlflow_trace(agent.run, span_type="agent")
+result = await agent.run(input=messages)
+```
+
+### 5. Handle the streaming path
+
+This is critical. Read `_handle_stream` in `main.py` carefully.
+
+**If streaming uses the same agent instance as non-streaming** (goes through the same closure/adapter):
+- No extra work — the wrapping from step 3-4 applies to both paths.
+
+**If streaming creates a new agent instance directly** (bypasses the adapter):
+- You MUST duplicate the wrapping inside the streaming path.
+- This is the pattern used by the Vanilla Python agent. See `agents/vanilla_python/openai_responses_agent/main.py` lines 247-258:
+
+```python
+# Inside _handle_stream's run_agent():
+def run_agent():
+    adapter = get_agent()
+    agent = SomeAgent(model=adapter._model_id, ...)
+
+    # Wrap tools
+    for name, func in adapter._tools:
+        func = wrap_func_with_mlflow_trace(func, span_type="tool")
+        agent.register_tool(name, func)
+
+    # Wrap agent entry point
+    agent.query = wrap_func_with_mlflow_trace(agent.query, span_type="agent")
+
+    return agent.query(user_message, ...)
+```
+
+**Why this matters:** Without a parent AGENT span, `mlflow.<provider>.autolog()` creates a separate trace for every LLM call instead of grouping them under one trace. This results in N traces per request instead of 1.
+
+### 6. Verify wrapping is conditional
+
+Confirm that `wrap_func_with_mlflow_trace()` in `tracing.py` returns the original function unchanged when `MLFLOW_TRACKING_URI` is not set. This means the wrapping calls in agent code are always safe — they're no-ops when tracing is disabled.
+
+## Reference Files
+
+- **Level B tool wrapping**: `agents/crewai/websearch_agent/src/crewai_web_search/crew.py` (lines 29-33)
+- **Level C tool + agent wrapping (non-streaming)**: `agents/vanilla_python/openai_responses_agent/src/openai_responses_agent/agent.py` (lines 86-89)
+- **Level C streaming path wrapping**: `agents/vanilla_python/openai_responses_agent/main.py` (lines 247-258)
+
+## Final Checklist
+
+- [ ] Every tool function/method is wrapped with `span_type="tool"`
+- [ ] The main agent entry point is wrapped with `span_type="agent"`
+- [ ] Both streaming and non-streaming paths have wrapping applied
+- [ ] Wrapping is safe when tracing is disabled (no-op via `wrap_func_with_mlflow_trace`)
+- [ ] No duplicate wrapping — each function is wrapped exactly once per request
+- [ ] The `name` parameter is used when wrapping tool objects (so span names are meaningful, not `_run`)
+
+## Self-Update (mandatory)
+
+**Before finishing, you MUST check whether this skill file needs updating.** This is not optional. If any of the following are true, update this file immediately:
+
+- You deviated from these instructions because they were inaccurate, outdated, or insufficient — and your deviation worked.
+- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path). Add it as a variant under the existing levels (A, B, or C) rather than introducing new levels.
+- File paths, function names, or API patterns referenced here have changed.
+- A step didn't work as described and needed a different approach.
+
+If nothing needed changing, move on. But do not skip this check.

--- a/.claude/skills/add-manual-tracing/SKILL.md
+++ b/.claude/skills/add-manual-tracing/SKILL.md
@@ -1,7 +1,14 @@
+---
+name: add-manual-tracing
+description: Adds manual MLflow trace wrapping for tool and agent spans in Level B and C agents where autolog doesn't cover everything.
+argument-hint: "<agent_path>"
+disable-model-invocation: true
+---
+
 # Add Manual Tracing (Level B and C)
 
-> **Usage:** `/project:add-manual-tracing <agent_path>`
-> **Example:** `/project:add-manual-tracing agents/autogen/chat_agent`
+> **Usage:** `/add-manual-tracing <agent_path>`
+> **Example:** `/add-manual-tracing agents/autogen/chat_agent`
 
 You are adding manual `wrap_func_with_mlflow_trace()` calls to an agent template where autolog does not fully cover all tracing layers.
 
@@ -9,11 +16,9 @@ You are adding manual `wrap_func_with_mlflow_trace()` calls to an agent template
 
 ## Input
 
-You need:
-1. **Agent path**: The agent directory (e.g., `agents/autogen/chat_agent/`)
-2. **Package name**: The Python package name
-3. **Coverage level**: B or C
-4. **Autolog support report**: What the autolog covers and what it misses
+The agent path is: $ARGUMENTS
+
+You also need the **package name**, **coverage level** (B or C), and **autolog support report**. If not provided, determine the package name from `pyproject.toml` or `src/`, and the coverage level from the agent's `tracing.py`.
 
 ## Steps
 
@@ -103,7 +108,7 @@ This is critical. Read `_handle_stream` in `main.py` carefully.
 
 **If streaming creates a new agent instance directly** (bypasses the adapter):
 - You MUST duplicate the wrapping inside the streaming path.
-- This is the pattern used by the Vanilla Python agent. See `agents/vanilla_python/openai_responses_agent/main.py` lines 247-258:
+- This is the pattern used by the Vanilla Python agent. See the `run_agent()` function inside `_handle_stream` in `agents/vanilla_python/openai_responses_agent/main.py`:
 
 ```python
 # Inside _handle_stream's run_agent():
@@ -130,9 +135,9 @@ Confirm that `wrap_func_with_mlflow_trace()` in `tracing.py` returns the origina
 
 ## Reference Files
 
-- **Level B tool wrapping**: `agents/crewai/websearch_agent/src/crewai_web_search/crew.py` (lines 29-33)
-- **Level C tool + agent wrapping (non-streaming)**: `agents/vanilla_python/openai_responses_agent/src/openai_responses_agent/agent.py` (lines 86-89)
-- **Level C streaming path wrapping**: `agents/vanilla_python/openai_responses_agent/main.py` (lines 247-258)
+- **Level B tool wrapping**: `agents/crewai/websearch_agent/src/crewai_web_search/crew.py` — `ai_assistant()` method
+- **Level C tool + agent wrapping (non-streaming)**: `agents/vanilla_python/openai_responses_agent/src/openai_responses_agent/agent.py` — `_AIAgentAdapter.run()` method
+- **Level C streaming path wrapping**: `agents/vanilla_python/openai_responses_agent/main.py` — `run_agent()` inside `_handle_stream()`
 
 ## Final Checklist
 
@@ -143,13 +148,13 @@ Confirm that `wrap_func_with_mlflow_trace()` in `tracing.py` returns the origina
 - [ ] No duplicate wrapping — each function is wrapped exactly once per request
 - [ ] The `name` parameter is used when wrapping tool objects (so span names are meaningful, not `_run`)
 
-## Self-Update (mandatory)
+## Self-Update
 
-**Before finishing, you MUST check whether this skill file needs updating.** This is not optional. If any of the following are true, update this file immediately:
+Before finishing, check whether this skill file needs updating. If any of the following are true, **propose the specific changes to the user** and only update this file if they approve:
 
 - You deviated from these instructions because they were inaccurate, outdated, or insufficient — and your deviation worked.
-- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path). Add it as a variant under the existing levels (A, B, or C) rather than introducing new levels.
+- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path).
 - File paths, function names, or API patterns referenced here have changed.
 - A step didn't work as described and needed a different approach.
 
-If nothing needed changing, move on. But do not skip this check.
+If nothing needed changing, move on.

--- a/.claude/skills/add-manual-tracing/SKILL.md
+++ b/.claude/skills/add-manual-tracing/SKILL.md
@@ -46,7 +46,7 @@ Wrap each tool so its execution creates a TOOL span. The wrapping location depen
 
 **If tools are functions registered by name (common in Level C):**
 
-In `agent.py` or wherever tools are registered:
+In `agent.py` or wherever tools are registered (e.g., `from openai_responses_agent.tracing import wrap_func_with_mlflow_trace`):
 ```python
 from <package>.tracing import wrap_func_with_mlflow_trace
 
@@ -58,7 +58,7 @@ for name, func in self._tools:
 
 **If tools are class instances with a `_run` method (common in Level B, e.g., CrewAI):**
 
-In the file where tool objects are created (e.g., `crew.py`):
+In the file where tool objects are created, e.g., `crew.py` (e.g., `from crewai_web_search.tracing import wrap_func_with_mlflow_trace`):
 ```python
 from <package>.tracing import wrap_func_with_mlflow_trace
 
@@ -71,6 +71,8 @@ for tool in tools:
 
 Wrap the underlying function after the agent is assembled:
 ```python
+from <package>.tracing import wrap_func_with_mlflow_trace
+
 for tool in agent.tools:
     tool.func = wrap_func_with_mlflow_trace(tool.func, span_type="tool")
 ```

--- a/.claude/skills/check-autolog-support/SKILL.md
+++ b/.claude/skills/check-autolog-support/SKILL.md
@@ -1,0 +1,85 @@
+# Check MLflow Autolog Support for a Framework
+
+> **Usage:** `/project:check-autolog-support <framework>`
+> **Example:** `/project:check-autolog-support autogen`
+
+You are determining whether MLflow has autolog support for a given agent framework, and what that autolog covers.
+
+## Input
+
+The framework name is: $ARGUMENTS
+
+If no framework name was provided, ask the user which framework they want to check.
+
+## Steps
+
+### 1. Search MLflow's autolog modules
+
+First, check the official MLflow autolog integrations page for the list of supported frameworks and model providers:
+https://mlflow.org/docs/latest/genai/tracing/integrations/
+
+Then, if needed, use WebSearch to find additional details about `mlflow.<framework>.autolog()`:
+- `mlflow <framework> autolog`
+- Check the MLflow documentation and GitHub repo for `mlflow/<framework>` module
+
+### 2. Classify the autolog coverage level
+
+Based on your research, classify the framework into one of these levels:
+
+**Level A — Full auto-tracing**: All three tracing layers are captured automatically:
+- Agent/orchestration spans (agent loops, workflows, task execution)
+- Tool execution spans (tool calls with inputs/outputs)
+- LLM call spans (model API calls with token usage)
+
+There are two variants:
+- **Autolog variant**: `mlflow.<framework>.autolog()` captures everything. Examples: LangGraph (`mlflow.langchain`), LlamaIndex (`mlflow.llama_index`)
+- **OTel variant**: No `mlflow.<framework>.autolog()` exists, but the framework natively emits OpenTelemetry spans that MLflow ingests via OTLP. Requires SQL-based MLflow backend and `opentelemetry-exporter-otlp-proto-http`. Example: Google ADK
+
+**Level B — Partial autolog**: `mlflow.<framework>.autolog()` exists but misses one or more layers. Common gaps:
+- Tool spans not captured (CrewAI >=1.10)
+- LLM calls routed through a different provider path not covered by the framework autolog
+- Only orchestration-level spans, no LLM-level detail
+
+Example in this repo: CrewAI (`mlflow.crewai` covers orchestration, but tools need manual wrapping and LLM calls need a separate provider-specific autolog)
+
+**Level C — No framework autolog**: No `mlflow.<framework>` module exists. All tracing must be done manually using `mlflow.trace()` decorators, but you can still use a provider-level autolog for LLM calls (e.g., `mlflow.openai.autolog()` if the framework uses the OpenAI SDK under the hood).
+
+Example in this repo: Vanilla Python agent (uses `mlflow.openai.autolog()` for LLM calls, manual wrapping for agent loop + tools)
+
+### 3. Identify the LLM provider path
+
+Determine how the framework makes LLM calls:
+- Does it use the OpenAI SDK directly? → `mlflow.openai.autolog()` can capture LLM spans
+- Does it use LangChain's `ChatOpenAI`? → `mlflow.langchain.autolog()` covers it
+- Does it use LiteLLM? → `mlflow.litellm.autolog()`
+- Does it have its own LLM client? → Check if there's a matching MLflow autolog for that client
+- Does it support multiple providers with a factory pattern? → May need provider-specific routing (like CrewAI)
+
+### 4. Report findings
+
+Output a summary in this format:
+
+```
+## Autolog Support Report: <framework>
+
+**Coverage level**: A / B / C
+**Autolog module**: `mlflow.<framework>.autolog()` or "None"
+**What autolog covers**: <list of span types captured>
+**What autolog misses**: <list of gaps, or "Nothing — full coverage">
+**LLM provider path**: <how the framework makes LLM calls>
+**Recommended provider autolog**: `mlflow.<provider>.autolog()` or "Not needed — framework autolog covers LLM calls"
+**Manual tracing needed for**: <list of things that need manual wrapping, or "Nothing">
+```
+
+This report will be used by the orchestrator to decide which tracing pattern to apply.
+
+## Self-Update (mandatory)
+
+**Before finishing, you MUST check whether this skill file needs updating.** This is not optional. If any of the following are true, update this file immediately:
+
+- You deviated from these instructions because they were inaccurate, outdated, or insufficient — and your deviation worked.
+- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path). Add it as a variant under the existing levels (A, B, or C) rather than introducing new levels.
+- File paths, function names, or API patterns referenced here have changed.
+- A step didn't work as described and needed a different approach.
+
+If nothing needed changing, move on. But do not skip this check.

--- a/.claude/skills/check-autolog-support/SKILL.md
+++ b/.claude/skills/check-autolog-support/SKILL.md
@@ -1,7 +1,14 @@
+---
+name: check-autolog-support
+description: Researches and classifies a framework's MLflow autolog support level (A, B, or C) to determine what manual tracing is needed.
+argument-hint: "<framework>"
+disable-model-invocation: true
+---
+
 # Check MLflow Autolog Support for a Framework
 
-> **Usage:** `/project:check-autolog-support <framework>`
-> **Example:** `/project:check-autolog-support autogen`
+> **Usage:** `/check-autolog-support <framework>`
+> **Example:** `/check-autolog-support autogen`
 
 You are determining whether MLflow has autolog support for a given agent framework, and what that autolog covers.
 
@@ -73,13 +80,13 @@ Output a summary in this format:
 
 This report will be used by the orchestrator to decide which tracing pattern to apply.
 
-## Self-Update (mandatory)
+## Self-Update
 
-**Before finishing, you MUST check whether this skill file needs updating.** This is not optional. If any of the following are true, update this file immediately:
+Before finishing, check whether this skill file needs updating. If any of the following are true, **propose the specific changes to the user** and only update this file if they approve:
 
 - You deviated from these instructions because they were inaccurate, outdated, or insufficient — and your deviation worked.
-- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path). Add it as a variant under the existing levels (A, B, or C) rather than introducing new levels.
+- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path).
 - File paths, function names, or API patterns referenced here have changed.
 - A step didn't work as described and needed a different approach.
 
-If nothing needed changing, move on. But do not skip this check.
+If nothing needed changing, move on.

--- a/.claude/skills/create-tracing-module/SKILL.md
+++ b/.claude/skills/create-tracing-module/SKILL.md
@@ -18,7 +18,7 @@ The agent path is: $ARGUMENTS
 
 You also need the **framework name** (e.g., `autogen`, `langgraph`, `crewai`) and the **autolog support report** (which classifies the framework as Level A, B, or C). The framework may be included as a second word in `$ARGUMENTS`. If not provided, determine it from the agent's `pyproject.toml` dependencies.
 
-If the autolog report is not available in the current conversation context, read and follow `.claude/skills/check-autolog-support/SKILL.md` with the framework name to produce the report before continuing.
+If the autolog report is not available in the current conversation context, read and follow check-autolog-support skill from `.claude/skills/check-autolog-support/SKILL.md` with the framework name to produce the report before continuing.
 
 ## Context
 

--- a/.claude/skills/create-tracing-module/SKILL.md
+++ b/.claude/skills/create-tracing-module/SKILL.md
@@ -1,17 +1,24 @@
+---
+name: create-tracing-module
+description: Creates the tracing.py module with enable_tracing(), health check, and framework-specific autolog configuration.
+argument-hint: "<agent_path> [framework]"
+disable-model-invocation: true
+---
+
 # Create the Tracing Module (`tracing.py`)
 
-> **Usage:** `/project:create-tracing-module <agent_path>`
-> **Example:** `/project:create-tracing-module agents/autogen/chat_agent`
+> **Usage:** `/create-tracing-module <agent_path>`
+> **Example:** `/create-tracing-module agents/autogen/chat_agent`
 
 You are creating the `tracing.py` file for a new agent template, following this repo's established patterns.
 
 ## Input
 
-You need two pieces of information before proceeding:
-1. **Agent path**: The agent directory (e.g., `agents/autogen/chat_agent/`)
-2. **Autolog support report**: The output from the `check-autolog-support` skill, which classifies the framework as Level A, B, or C and identifies the autolog module(s) needed.
+The agent path is: $ARGUMENTS
 
-If either is missing, ask the user.
+You also need the **framework name** (e.g., `autogen`, `langgraph`, `crewai`) and the **autolog support report** (which classifies the framework as Level A, B, or C). The framework may be included as a second word in `$ARGUMENTS`. If not provided, determine it from the agent's `pyproject.toml` dependencies.
+
+If the autolog report is not available in the current conversation context, read and follow `.claude/skills/check-autolog-support/SKILL.md` with the framework name to produce the report before continuing.
 
 ## Context
 
@@ -76,13 +83,13 @@ After creating the file, verify:
 - [ ] The correct autolog module is used for the framework
 - [ ] `enable_async_logging()` is called before autolog
 
-## Self-Update (mandatory)
+## Self-Update
 
-**Before finishing, you MUST check whether this skill file needs updating.** This is not optional. If any of the following are true, update this file immediately:
+Before finishing, check whether this skill file needs updating. If any of the following are true, **propose the specific changes to the user** and only update this file if they approve:
 
 - You deviated from these instructions because they were inaccurate, outdated, or insufficient — and your deviation worked.
-- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path). Add it as a variant under the existing levels (A, B, or C) rather than introducing new levels.
+- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path).
 - File paths, function names, or API patterns referenced here have changed.
 - A step didn't work as described and needed a different approach.
 
-If nothing needed changing, move on. But do not skip this check.
+If nothing needed changing, move on.

--- a/.claude/skills/create-tracing-module/SKILL.md
+++ b/.claude/skills/create-tracing-module/SKILL.md
@@ -1,0 +1,88 @@
+# Create the Tracing Module (`tracing.py`)
+
+> **Usage:** `/project:create-tracing-module <agent_path>`
+> **Example:** `/project:create-tracing-module agents/autogen/chat_agent`
+
+You are creating the `tracing.py` file for a new agent template, following this repo's established patterns.
+
+## Input
+
+You need two pieces of information before proceeding:
+1. **Agent path**: The agent directory (e.g., `agents/autogen/chat_agent/`)
+2. **Autolog support report**: The output from the `check-autolog-support` skill, which classifies the framework as Level A, B, or C and identifies the autolog module(s) needed.
+
+If either is missing, ask the user.
+
+## Context
+
+Read `tracing.md` at the repo root for the full tracing architecture, design principles, and how each existing agent integrates with MLflow.
+
+## Reference Files
+
+Read the reference `tracing.py` that matches the coverage level. These are the source of truth — follow their patterns exactly:
+
+- **Level A — autolog variant** (full autolog): `agents/langgraph/react_agent/src/react_agent/tracing.py`
+- **Level A — OTel variant** (framework emits OTel spans): `agents/google/adk/src/adk_agent/tracing.py`
+- **Level B** (partial autolog): `agents/crewai/websearch_agent/src/crewai_web_search/tracing.py`
+- **Level C** (no framework autolog): `agents/vanilla_python/openai_responses_agent/src/openai_responses_agent/tracing.py`
+
+## What to Create
+
+Create the file at: `<agent_path>/src/<package_name>/tracing.py`
+
+The `<package_name>` is the Python package name — find it by looking at the existing `src/` directory or `pyproject.toml` `[tool.setuptools.packages.find]`.
+
+## How to Build It
+
+### Shared code (all levels)
+
+Copy these **exactly** from the reference file — they are identical across all agents:
+- Logger setup (module-level `logging.getLogger("tracing")` with handler)
+- `check_mlflow_health()` function (retry loop with time budget)
+- `enable_tracing()` skeleton (load_dotenv, MLFLOW_TRACKING_URI check, health check with graceful degradation, set_tracking_uri, set_experiment, enable_async_logging)
+
+### Framework-specific code
+
+The **only parts that differ** between levels are inside `enable_tracing()` and whether `wrap_func_with_mlflow_trace()` exists:
+
+**Level A (autolog variant)** — Read the LangGraph reference. Adapt by:
+- Replacing the `import mlflow.langchain` / `mlflow.langchain.autolog()` with the correct module for the new framework (from the autolog report)
+- No `wrap_func_with_mlflow_trace()` needed
+
+**Level A (OTel variant)** — Read the Google ADK reference. Use this when the framework has no `mlflow.<framework>.autolog()` but natively emits OpenTelemetry spans. Adapt by:
+- Setting up `TracerProvider` with `OTLPSpanExporter` pointing at `{tracking_uri}/v1/traces`
+- Passing the experiment ID via the `x-mlflow-experiment-id` header (get it from `mlflow.set_experiment()`)
+- The MLflow server requires a SQL backend (`--backend-store-uri sqlite:///mlflow.db`)
+- Extra package: `opentelemetry-exporter-otlp-proto-http`
+- No `wrap_func_with_mlflow_trace()` needed
+
+**Level B** — Read the CrewAI reference. Adapt by:
+- Replacing the framework autolog module (e.g., `mlflow.crewai` → `mlflow.<new_framework>`)
+- Adjusting the provider autolog routing if the new framework's LLM provider path differs. If the framework uses a single LLM path, simplify by hardcoding the provider autolog instead of the `provider_autolog_map` + `LLM_PROVIDER` routing
+- Copying `wrap_func_with_mlflow_trace()` as-is (with `name` parameter)
+
+**Level C** — Read the Vanilla Python reference. Adapt by:
+- Replacing the provider autolog module if the framework uses a different LLM SDK (from the autolog report)
+- Copying `wrap_func_with_mlflow_trace()` as-is
+
+## Final Checklist
+
+After creating the file, verify:
+- [ ] Logger setup is at module level (not inside a function)
+- [ ] `check_mlflow_health()` is identical to the reference
+- [ ] `enable_tracing()` has graceful degradation (returns on unreachable server, doesn't crash)
+- [ ] MLflow imports are lazy (inside `enable_tracing()` / `wrap_func_with_mlflow_trace()`, not at module top)
+- [ ] `wrap_func_with_mlflow_trace()` returns the original function unchanged when `MLFLOW_TRACKING_URI` is not set
+- [ ] The correct autolog module is used for the framework
+- [ ] `enable_async_logging()` is called before autolog
+
+## Self-Update (mandatory)
+
+**Before finishing, you MUST check whether this skill file needs updating.** This is not optional. If any of the following are true, update this file immediately:
+
+- You deviated from these instructions because they were inaccurate, outdated, or insufficient — and your deviation worked.
+- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path). Add it as a variant under the existing levels (A, B, or C) rather than introducing new levels.
+- File paths, function names, or API patterns referenced here have changed.
+- A step didn't work as described and needed a different approach.
+
+If nothing needed changing, move on. But do not skip this check.

--- a/.claude/skills/integrate-tracing/SKILL.md
+++ b/.claude/skills/integrate-tracing/SKILL.md
@@ -1,7 +1,13 @@
+---
+name: integrate-tracing
+description: Orchestrates end-to-end MLflow tracing integration into an agent template, coordinating all sub-skills from research through verification.
+argument-hint: "<framework> <agent_path>"
+---
+
 # Integrate MLflow Tracing into an Agent Template
 
-> **Usage:** `/project:integrate-tracing <framework> <agent_path>`
-> **Example:** `/project:integrate-tracing autogen agents/autogen/chat_agent`
+> **Usage:** `/integrate-tracing <framework> <agent_path>`
+> **Example:** `/integrate-tracing autogen agents/autogen/chat_agent`
 
 You are integrating MLflow tracing into a new agent template in this repository. This is the orchestrator skill that coordinates the full end-to-end process by following a structured sequence of steps, deferring to reference skills for each step.
 
@@ -20,7 +26,7 @@ Read `tracing.md` at the repo root for full context on the tracing architecture,
 
 ## Workflow
 
-**IMPORTANT: You must follow these steps in exact sequential order (1 → 2 → 3 → ... → 9). Do not skip ahead, reorder, or combine steps. Each step depends on the output of previous steps — especially the autolog report from Step 1, which drives decisions in Steps 4, 5, 6, and 7. Complete each step fully before moving to the next.**
+**IMPORTANT: You must follow these steps in exact sequential order (1 → 2 → 3 → ... → 10). Do not skip ahead, reorder, or combine steps. Each step depends on the output of previous steps — especially the autolog report from Step 1, which drives decisions in Steps 4, 5, 6, and 7. Complete each step fully before moving to the next.**
 
 **IMPORTANT: Always create a demo agent first (Step 2) and implement all tracing and testing on the demo copy (Steps 3–7). Only after everything works correctly on the demo — traces land in MLflow, spans are correct, both streaming and non-streaming paths are verified — apply the same changes to the actual agent template (Steps 4–9). Never modify the real agent template until the demo is fully working.**
 
@@ -28,7 +34,7 @@ Read `tracing.md` at the repo root for full context on the tracing architecture,
 
 **Goal**: Determine what MLflow autolog covers for this framework.
 
-Follow the `check-autolog-support` skill with the framework name. This will produce an autolog support report classifying the framework as:
+Read and follow `.claude/skills/check-autolog-support/SKILL.md` with the framework name. This will produce an autolog support report classifying the framework as:
 
 - **Level A** — Full autolog (like LangGraph, LlamaIndex)
 - **Level B** — Partial autolog (like CrewAI)
@@ -76,7 +82,7 @@ Identify:
 
 **Goal**: Create `tracing.py` with the correct pattern for this framework.
 
-Follow the `create-tracing-module` skill, providing:
+Read and follow `.claude/skills/create-tracing-module/SKILL.md`, providing:
 - The agent path
 - The autolog support report from Step 1
 
@@ -89,7 +95,7 @@ This creates `src/<package>/tracing.py` with:
 
 **Goal**: Connect tracing to the app startup.
 
-Follow the `wire-into-lifespan` skill, providing:
+Read and follow `.claude/skills/wire-into-lifespan/SKILL.md`, providing:
 - The agent path
 - The package name
 - The coverage level
@@ -102,7 +108,7 @@ This adds the import and `enable_tracing()` call to `main.py`.
 
 **Skip this step entirely for Level A** — autolog handles everything.
 
-For Level B or C, follow the `add-manual-tracing` skill, providing:
+For Level B or C, read and follow `.claude/skills/add-manual-tracing/SKILL.md`, providing:
 - The agent path
 - The package name
 - The coverage level
@@ -117,7 +123,7 @@ This adds `wrap_func_with_mlflow_trace()` calls for:
 
 **Goal**: Confirm traces land correctly in MLflow.
 
-Read and execute every step in the `verify-traces` skill yourself, which in turn requires you to execute the `review-tracing-code` and `test-tracing` skills. You must do everything hands-on — install MLflow if needed, start the MLflow server, start the agent, send requests, query the MLflow API, inspect spans. Do NOT stop here and tell the user to test manually. Do NOT summarize what the user should do. Execute it all yourself.
+Read and follow `.claude/skills/verify-traces/SKILL.md` yourself, which in turn requires you to read and follow `.claude/skills/review-tracing-code/SKILL.md` and `.claude/skills/test-tracing/SKILL.md`. You must do everything hands-on — install MLflow if needed, start the MLflow server, start the agent, send requests, query the MLflow API, inspect spans. Do NOT stop here and tell the user to test manually. Do NOT summarize what the user should do. Execute it all yourself.
 
 After verification, always report these three values to the user:
 - **MLflow Server URI** — the URI used to connect to the MLflow server (e.g., `http://localhost:5000`)
@@ -126,7 +132,21 @@ After verification, always report these three values to the user:
 
 If verification fails, the report will indicate which step to revisit.
 
-### Step 8: Update .env.example
+### Step 8: Update Makefile
+
+**Goal**: Ensure `make run` auto-installs MLflow when `MLFLOW_TRACKING_URI` is set.
+
+In the agent's `Makefile`, add `$${MLFLOW_TRACKING_URI:+--extra tracing}` to the `uv run` command in the `run` target (and `run-cli` if it exists). For example:
+
+```makefile
+run:
+	@set -a && source .env && set +a && \
+	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
+```
+
+This bash parameter expansion adds `--extra tracing` only when `MLFLOW_TRACKING_URI` is set, which tells `uv run` to install the `tracing` optional dependency from `pyproject.toml`.
+
+### Step 9: Update .env.example
 
 **Goal**: Add MLflow environment variables to `.env.example` so users know which variables to configure.
 
@@ -152,7 +172,7 @@ Add the following sections to the agent's `.env.example` file (if not already pr
 # MLFLOW_TRACKING_AUTH= # Use Kubernetes service account for authentication (if running inside the cluster)
 ```
 
-### Step 9: Update README.md
+### Step 10: Update README.md
 
 **Goal**: Document tracing setup for both local and OpenShift deployments.
 
@@ -205,8 +225,9 @@ All files that must be created or updated when integrating tracing:
 | 5. Wire into lifespan | `wire-into-lifespan` | Run | Run | Run |
 | 6. Add manual tracing | `add-manual-tracing` | **Skip** | Run | Run |
 | 7. Verify | `verify-traces` | Run | Run | Run |
-| 8. Update .env.example | (inline) | Run | Run | Run |
-| 9. Update README.md | (inline) | Run | Run | Run |
+| 8. Update Makefile | (inline) | Run | Run | Run |
+| 9. Update .env.example | (inline) | Run | Run | Run |
+| 10. Update README.md | (inline) | Run | Run | Run |
 
 ## Keeping Skills Up to Date
 

--- a/.claude/skills/integrate-tracing/SKILL.md
+++ b/.claude/skills/integrate-tracing/SKILL.md
@@ -197,6 +197,7 @@ All files that must be created or updated when integrating tracing:
 | 4 | `.env.example` | **Edit** | Add local + OpenShift MLflow variable sections |
 | 5 | `README.md` | **Edit** | Add local tracing config, OpenShift tracing config, MLflow server start |
 | 6 | `pyproject.toml` | **Edit** | Add `tracing = ["mlflow>=3.10.0"]` to `[project.optional-dependencies]` |
+| 7 | `Makefile` | **Edit** | Add `$${MLFLOW_TRACKING_URI:+--extra tracing}` to `uv run` in `run` and `run-cli` targets |
 
 ## Summary
 

--- a/.claude/skills/integrate-tracing/SKILL.md
+++ b/.claude/skills/integrate-tracing/SKILL.md
@@ -202,7 +202,7 @@ All files that must be created or updated when integrating tracing:
 | 3 | `main.py` | **Edit** (Level B/C only) | Import `wrap_func_with_mlflow_trace`, wrap tools/agent entry points |
 | 4 | `.env.example` | **Edit** | Add local + OpenShift MLflow variable sections |
 | 5 | `README.md` | **Edit** | Add local MLflow install, local tracing config, OpenShift tracing config, MLflow server start, RHOAI install |
-| 6 | `pyproject.toml` | **Do NOT edit** | MLflow is installed manually, not listed as a dependency |
+| 6 | `pyproject.toml` | **Edit** | Add `tracing = ["mlflow>=3.10.0"]` to `[project.optional-dependencies]` |
 
 ## Summary
 

--- a/.claude/skills/integrate-tracing/SKILL.md
+++ b/.claude/skills/integrate-tracing/SKILL.md
@@ -185,12 +185,6 @@ Add these sections to the agent's `README.md` (use an existing agent like `langg
    mlflow server --port 5000
    ```
 
-5. **RHOAI MLflow install** — in the OpenShift Deployment section, add:
-   ```bash
-   uv pip install "git+https://github.com/red-hat-data-services/mlflow@rhoai-3.3"
-   ```
-   with a note: *Optional: Only required if tracing is enabled*
-
 ## Complete Checklist
 
 All files that must be created or updated when integrating tracing:
@@ -201,7 +195,7 @@ All files that must be created or updated when integrating tracing:
 | 2 | `main.py` | **Edit** | Import `enable_tracing`, call it first in `lifespan()` |
 | 3 | `main.py` | **Edit** (Level B/C only) | Import `wrap_func_with_mlflow_trace`, wrap tools/agent entry points |
 | 4 | `.env.example` | **Edit** | Add local + OpenShift MLflow variable sections |
-| 5 | `README.md` | **Edit** | Add local MLflow install, local tracing config, OpenShift tracing config, MLflow server start, RHOAI install |
+| 5 | `README.md` | **Edit** | Add local tracing config, OpenShift tracing config, MLflow server start |
 | 6 | `pyproject.toml` | **Edit** | Add `tracing = ["mlflow>=3.10.0"]` to `[project.optional-dependencies]` |
 
 ## Summary

--- a/.claude/skills/integrate-tracing/SKILL.md
+++ b/.claude/skills/integrate-tracing/SKILL.md
@@ -194,8 +194,7 @@ Add these sections to the agent's `README.md` (use an existing agent like `langg
      - If set but unreachable, the app logs a warning and continues without tracing
      - `MLFLOW_HEALTH_CHECK_TIMEOUT` controls wait time (default: 5s)
 
-3. **Local MLflow install** — in the Local Usage section, after `uv pip install -e .`, add:
-4. **MLflow server start** — in the Local Usage section, add a step to start the MLflow server:
+3. **MLflow server start** — in the Local Usage section, add a step to start the MLflow server (this also installs MLflow as an optional dependency):
    ```bash
    uv run --extra tracing mlflow server --port 5000
    ```
@@ -231,7 +230,7 @@ All files that must be created or updated when integrating tracing:
 
 ## Keeping Skills Up to Date
 
-If at any point during this workflow you deviate from a skill's instructions because they were inaccurate, outdated, or insufficient — and your deviation works — **update the skill file** with what you learned. This includes:
+If at any point during this workflow you deviate from a skill's instructions because they were inaccurate, outdated, or insufficient — and your deviation works — **propose the specific changes to the user** and only update the skill file if they approve. This includes:
 
 - A step that didn't work as described and needed a different approach
 - A new pattern or edge case not covered by the skill

--- a/.claude/skills/integrate-tracing/SKILL.md
+++ b/.claude/skills/integrate-tracing/SKILL.md
@@ -133,7 +133,7 @@ If verification fails, the report will indicate which step to revisit.
 Add the following sections to the agent's `.env.example` file (if not already present):
 
 ```ini
-## LOCAL TRACING
+# LOCAL TRACING
 
 # MLFLOW_TRACKING_URI=
 # MLFLOW_EXPERIMENT_NAME=
@@ -175,14 +175,9 @@ Add these sections to the agent's `README.md` (use an existing agent like `langg
      - `MLFLOW_HEALTH_CHECK_TIMEOUT` controls wait time (default: 5s)
 
 3. **Local MLflow install** — in the Local Usage section, after `uv pip install -e .`, add:
-   ```bash
-   uv pip install "mlflow>=3.10.0"
-   ```
-   with a note: *Optional: Only required if tracing is enabled*
-
 4. **MLflow server start** — in the Local Usage section, add a step to start the MLflow server:
    ```bash
-   mlflow server --port 5000
+   uv run --extra tracing mlflow server --port 5000
    ```
 
 ## Complete Checklist

--- a/.claude/skills/integrate-tracing/SKILL.md
+++ b/.claude/skills/integrate-tracing/SKILL.md
@@ -1,0 +1,234 @@
+# Integrate MLflow Tracing into an Agent Template
+
+> **Usage:** `/project:integrate-tracing <framework> <agent_path>`
+> **Example:** `/project:integrate-tracing autogen agents/autogen/chat_agent`
+
+You are integrating MLflow tracing into a new agent template in this repository. This is the orchestrator skill that coordinates the full end-to-end process by following a structured sequence of steps, deferring to reference skills for each step.
+
+## Input
+
+The framework name and agent path are: $ARGUMENTS
+
+Expected format: `<framework> <agent_path>`
+Example: `autogen agents/autogen/chat_agent`
+
+If either is missing, ask the user for both.
+
+## Before You Start
+
+Read `tracing.md` at the repo root for full context on the tracing architecture, design principles, and how the existing four agents integrate with MLflow. This is essential background.
+
+## Workflow
+
+**IMPORTANT: You must follow these steps in exact sequential order (1 → 2 → 3 → ... → 9). Do not skip ahead, reorder, or combine steps. Each step depends on the output of previous steps — especially the autolog report from Step 1, which drives decisions in Steps 4, 5, 6, and 7. Complete each step fully before moving to the next.**
+
+**IMPORTANT: Always create a demo agent first (Step 2) and implement all tracing and testing on the demo copy (Steps 3–7). Only after everything works correctly on the demo — traces land in MLflow, spans are correct, both streaming and non-streaming paths are verified — apply the same changes to the actual agent template (Steps 4–9). Never modify the real agent template until the demo is fully working.**
+
+### Step 1: Check Autolog Support
+
+**Goal**: Determine what MLflow autolog covers for this framework.
+
+Follow the `check-autolog-support` skill with the framework name. This will produce an autolog support report classifying the framework as:
+
+- **Level A** — Full autolog (like LangGraph, LlamaIndex)
+- **Level B** — Partial autolog (like CrewAI)
+- **Level C** — No framework autolog (like Vanilla Python)
+
+Save the report — it drives all subsequent decisions.
+
+### Step 2: Create a Demo Agent
+
+**Goal**: Create a working demo copy of the agent for testing tracing before modifying the actual agent.
+
+1. Copy the agent directory to `agents/demo/<framework>_<agent_name>_demo/`
+2. **Replace dummy tools with proper test tools** — the demo MUST have tools that return meaningful responses so traces can be properly verified. Use these standard demo tools (adapted to the framework's tool format):
+   - `search_knowledge_base(query)` — looks up a hardcoded knowledge base dict
+   - `search_price(brand)` — returns `"Price of {brand} is $400"`
+   - `search_reviews(brand)` — returns `"Reviews of {brand} are good"`
+   - `current_time()` — returns current datetime
+   - `calculate(query)` — evaluates a math expression
+3. Update the tools export (`__init__.py` or equivalent) to include all new tools
+4. Update the agent's system prompt to mention the available tools
+5. Create a `.env` file with OpenAI credentials and MLflow config for local testing
+6. If the agent requires external dependencies (MCP server, vector store, database), add a fallback in the demo's `main.py` so it can run with dummy tools when the dependency is unavailable
+
+This step is critical — without proper tools, you cannot verify that tool spans appear in traces.
+
+### Step 3: Understand the Agent's Code
+
+**Goal**: Map the agent's architecture before making changes.
+
+Read these files in the agent directory:
+- `README.md` — What the agent does, its architecture, tools, and any framework-specific details
+- `main.py` — FastAPI app, lifespan, `_handle_chat`, `_handle_stream`
+- `src/<package>/agent.py` — Agent class/factory, how tools are registered
+- `src/<package>/tools.py` — Tool definitions
+- `pyproject.toml` — Package name and dependencies
+
+Identify:
+- The Python package name (from `pyproject.toml` or `src/` directory)
+- How the agent initializes (closure pattern, class instantiation, etc.)
+- How tools are registered (function list, tool objects, decorators)
+- Whether streaming creates the agent differently from non-streaming
+- What LLM SDK the framework uses under the hood (OpenAI, LangChain, LiteLLM, etc.)
+
+### Step 4: Create the Tracing Module
+
+**Goal**: Create `tracing.py` with the correct pattern for this framework.
+
+Follow the `create-tracing-module` skill, providing:
+- The agent path
+- The autolog support report from Step 1
+
+This creates `src/<package>/tracing.py` with:
+- Level A: `enable_tracing()` with framework autolog only
+- Level B: `enable_tracing()` with framework + provider autolog, plus `wrap_func_with_mlflow_trace()`
+- Level C: `enable_tracing()` with provider autolog only, plus `wrap_func_with_mlflow_trace()`
+
+### Step 5: Wire into the FastAPI Lifespan
+
+**Goal**: Connect tracing to the app startup.
+
+Follow the `wire-into-lifespan` skill, providing:
+- The agent path
+- The package name
+- The coverage level
+
+This adds the import and `enable_tracing()` call to `main.py`.
+
+### Step 6: Add Manual Tracing (Level B and C only)
+
+**Goal**: Wrap tools and agent entry points with trace spans where autolog doesn't cover.
+
+**Skip this step entirely for Level A** — autolog handles everything.
+
+For Level B or C, follow the `add-manual-tracing` skill, providing:
+- The agent path
+- The package name
+- The coverage level
+- What the autolog covers and misses (from the report)
+
+This adds `wrap_func_with_mlflow_trace()` calls for:
+- Tool functions/methods → `span_type="tool"`
+- Agent entry point → `span_type="agent"`
+- Both streaming and non-streaming paths
+
+### Step 7: Verify
+
+**Goal**: Confirm traces land correctly in MLflow.
+
+Read and execute every step in the `verify-traces` skill yourself, which in turn requires you to execute the `review-tracing-code` and `test-tracing` skills. You must do everything hands-on — install MLflow if needed, start the MLflow server, start the agent, send requests, query the MLflow API, inspect spans. Do NOT stop here and tell the user to test manually. Do NOT summarize what the user should do. Execute it all yourself.
+
+After verification, always report these three values to the user:
+- **MLflow Server URI** — the URI used to connect to the MLflow server (e.g., `http://localhost:5000`)
+- **Experiment Name** — the MLflow experiment name used (e.g., `agentic-rag-experiment`)
+- **Test Query** — the exact query sent to the agent during testing (e.g., `"How much does a Lenovo laptop cost?"`)
+
+If verification fails, the report will indicate which step to revisit.
+
+### Step 8: Update .env.example
+
+**Goal**: Add MLflow environment variables to `.env.example` so users know which variables to configure.
+
+Add the following sections to the agent's `.env.example` file (if not already present):
+
+```ini
+## LOCAL TRACING
+
+# MLFLOW_TRACKING_URI=
+# MLFLOW_EXPERIMENT_NAME=
+# MLFLOW_HEALTH_CHECK_TIMEOUT=      # (default is 5s)
+# MLFLOW_HTTP_REQUEST_TIMEOUT=      # (default is 120s)
+# MLFLOW_HTTP_REQUEST_MAX_RETRIES=
+
+## OPENSHIFT CLUSTER TRACING
+
+# Openshift Cluster
+# MLFLOW_TRACKING_URI=
+# MLFLOW_TRACKING_TOKEN=
+# MLFLOW_EXPERIMENT_NAME=
+# MLFLOW_TRACKING_INSECURE_TLS=
+# MLFLOW_WORKSPACE=
+# MLFLOW_TRACKING_AUTH= # Use Kubernetes service account for authentication (if running inside the cluster)
+```
+
+### Step 9: Update README.md
+
+**Goal**: Document tracing setup for both local and OpenShift deployments.
+
+Add these sections to the agent's `README.md` (use an existing agent like `langgraph/react_agent` as reference):
+
+1. **Local Tracing config** — under the Local `.env` configuration section, add a `##### Tracing` subsection with example MLflow env vars:
+   ```ini
+   MLFLOW_TRACKING_URI="http://localhost:5000"
+   MLFLOW_EXPERIMENT_NAME="<Agent Name> Local Experiment"
+   MLFLOW_HTTP_REQUEST_TIMEOUT=2
+   MLFLOW_HTTP_REQUEST_MAX_RETRIES=0
+   ```
+
+2. **OpenShift Tracing config** — under the OpenShift `.env` configuration section, add a `##### Tracing` subsection with:
+   - Example env vars (`MLFLOW_TRACKING_URI`, `MLFLOW_TRACKING_TOKEN`, `MLFLOW_EXPERIMENT_NAME`, `MLFLOW_TRACKING_INSECURE_TLS`, `MLFLOW_WORKSPACE`)
+   - Notes explaining each variable
+   - Three behavioral notes:
+     - Tracing is optional; if `MLFLOW_TRACKING_URI` is not set, the app runs without MLflow logging
+     - If set but unreachable, the app logs a warning and continues without tracing
+     - `MLFLOW_HEALTH_CHECK_TIMEOUT` controls wait time (default: 5s)
+
+3. **Local MLflow install** — in the Local Usage section, after `uv pip install -e .`, add:
+   ```bash
+   uv pip install "mlflow>=3.10.0"
+   ```
+   with a note: *Optional: Only required if tracing is enabled*
+
+4. **MLflow server start** — in the Local Usage section, add a step to start the MLflow server:
+   ```bash
+   mlflow server --port 5000
+   ```
+
+5. **RHOAI MLflow install** — in the OpenShift Deployment section, add:
+   ```bash
+   uv pip install "git+https://github.com/red-hat-data-services/mlflow@rhoai-3.3"
+   ```
+   with a note: *Optional: Only required if tracing is enabled*
+
+## Complete Checklist
+
+All files that must be created or updated when integrating tracing:
+
+| # | File | Action | Description |
+|---|------|--------|-------------|
+| 1 | `src/<package>/tracing.py` | **Create** | `enable_tracing()`, health check, autolog, `wrap_func_with_mlflow_trace()` (Level B/C) |
+| 2 | `main.py` | **Edit** | Import `enable_tracing`, call it first in `lifespan()` |
+| 3 | `main.py` | **Edit** (Level B/C only) | Import `wrap_func_with_mlflow_trace`, wrap tools/agent entry points |
+| 4 | `.env.example` | **Edit** | Add local + OpenShift MLflow variable sections |
+| 5 | `README.md` | **Edit** | Add local MLflow install, local tracing config, OpenShift tracing config, MLflow server start, RHOAI install |
+| 6 | `pyproject.toml` | **Do NOT edit** | MLflow is installed manually, not listed as a dependency |
+
+## Summary
+
+| Step | Skill | Level A | Level B | Level C |
+|------|-------|---------|---------|---------|
+| 1. Check autolog | `check-autolog-support` | Run | Run | Run |
+| 2. Create demo agent | (inline) | Run | Run | Run |
+| 3. Read agent code | (inline) | Run | Run | Run |
+| 4. Create tracing.py | `create-tracing-module` | Run | Run | Run |
+| 5. Wire into lifespan | `wire-into-lifespan` | Run | Run | Run |
+| 6. Add manual tracing | `add-manual-tracing` | **Skip** | Run | Run |
+| 7. Verify | `verify-traces` | Run | Run | Run |
+| 8. Update .env.example | (inline) | Run | Run | Run |
+| 9. Update README.md | (inline) | Run | Run | Run |
+
+## Keeping Skills Up to Date
+
+If at any point during this workflow you deviate from a skill's instructions because they were inaccurate, outdated, or insufficient — and your deviation works — **update the skill file** with what you learned. This includes:
+
+- A step that didn't work as described and needed a different approach
+- A new pattern or edge case not covered by the skill
+- File paths or function names that have changed
+- A new framework behavior that the skill should account for
+
+Also update `tracing.md` at the repo root:
+
+- **Always** add the new framework to the Autolog Coverage Levels table and the Tracing Layers table, so every framework's level is recorded.
+- **Always** add a new Framework-Specific Integration section for the agent (like the existing LangGraph, CrewAI, etc. sections), documenting the autolog module used, whether manual tracing was needed, and the resulting span structure.
+- Add any new findings, edge cases, or architectural patterns discovered during integration. Keep these short and direct — a few sentences, not paragraphs.

--- a/.claude/skills/integrate-tracing/SKILL.md
+++ b/.claude/skills/integrate-tracing/SKILL.md
@@ -199,6 +199,14 @@ Add these sections to the agent's `README.md` (use an existing agent like `langg
    uv run --extra tracing mlflow server --port 5000
    ```
 
+### Step 11: Update Dockerfile
+
+**Goal**: Ensure containerized deployments include MLflow.
+
+If the agent has a `Dockerfile`, make sure the package install step includes the `tracing` extra (e.g., `".[tracing]"` instead of `"."`).
+
+Without this, deployed agents with `MLFLOW_TRACKING_URI` set will fail at startup because `mlflow` won't be installed.
+
 ## Complete Checklist
 
 All files that must be created or updated when integrating tracing:
@@ -212,6 +220,7 @@ All files that must be created or updated when integrating tracing:
 | 5 | `README.md` | **Edit** | Add local tracing config, OpenShift tracing config, MLflow server start |
 | 6 | `pyproject.toml` | **Edit** | Add `tracing = ["mlflow>=3.10.0"]` to `[project.optional-dependencies]` |
 | 7 | `Makefile` | **Edit** | Add `$${MLFLOW_TRACKING_URI:+--extra tracing}` to `uv run` in `run` and `run-cli` targets |
+| 8 | `Dockerfile` | **Edit** | Change `"."` to `".[tracing]"` in `uv pip install` line |
 
 ## Summary
 
@@ -227,6 +236,7 @@ All files that must be created or updated when integrating tracing:
 | 8. Update Makefile | (inline) | Run | Run | Run |
 | 9. Update .env.example | (inline) | Run | Run | Run |
 | 10. Update README.md | (inline) | Run | Run | Run |
+| 11. Update Dockerfile | (inline) | Run | Run | Run |
 
 ## Keeping Skills Up to Date
 

--- a/.claude/skills/review-tracing-code/SKILL.md
+++ b/.claude/skills/review-tracing-code/SKILL.md
@@ -1,0 +1,159 @@
+# Review Tracing Code
+
+> **Usage:** `/project:review-tracing-code <agent_path>`
+> **Example:** `/project:review-tracing-code agents/autogen/chat_agent`
+
+You are reviewing the MLflow tracing integration code for an agent template to confirm it follows the repo's established patterns and is correctly wired.
+
+**You must read every file and check every item yourself.** Do not ask the user to review files or run checks. Execute the full checklist and produce the report.
+
+## Input
+
+You need:
+1. **Agent path**: The agent directory (e.g., `agents/autogen/chat_agent/`)
+2. **Package name**: The Python package name (find from `pyproject.toml` or `src/` directory)
+3. **Coverage level**: A, B, or C (from the autolog support report)
+
+If any are missing, determine them by reading the agent's files.
+
+## Review Checklist
+
+### 1. `tracing.py` exists and follows the pattern
+
+Read `<agent_path>/src/<package>/tracing.py` and verify:
+
+- [ ] Logger setup is at module level with `logging.getLogger("tracing")`
+- [ ] `check_mlflow_health()` is present and matches the reference (retry loop with time budget)
+- [ ] `enable_tracing()` is present with the correct structure:
+  - [ ] Calls `load_dotenv()` first
+  - [ ] Returns early if `MLFLOW_TRACKING_URI` is not set
+  - [ ] MLflow imports are lazy (inside the function, not at module top)
+  - [ ] Health check with `MLFLOW_HEALTH_CHECK_TIMEOUT` support
+  - [ ] Graceful degradation — returns without crashing if server is unreachable
+  - [ ] Calls `mlflow.set_tracking_uri()`, `mlflow.set_experiment()`, `mlflow.config.enable_async_logging()` in that order
+  - [ ] Calls the correct framework/provider autolog (see level-specific checks below)
+
+**Level A**: Verify `mlflow.<framework>.autolog()` is called. No `wrap_func_with_mlflow_trace()` should exist.
+
+**Level B**: Verify:
+- [ ] Framework autolog is called (e.g., `mlflow.crewai.autolog()`)
+- [ ] Provider-specific autolog is called (either hardcoded or via `LLM_PROVIDER` routing map)
+- [ ] `wrap_func_with_mlflow_trace()` function exists with `span_type` and `name` parameters
+- [ ] `wrap_func_with_mlflow_trace()` returns original function when `MLFLOW_TRACKING_URI` is not set
+
+**Level C**: Verify:
+- [ ] Provider autolog is called (e.g., `mlflow.openai.autolog()`)
+- [ ] No framework autolog (since none exists)
+- [ ] `wrap_func_with_mlflow_trace()` function exists
+- [ ] `wrap_func_with_mlflow_trace()` returns original function when `MLFLOW_TRACKING_URI` is not set
+
+Compare against the reference file for the matching level:
+- Level A: `agents/langgraph/react_agent/src/react_agent/tracing.py`
+- Level B: `agents/crewai/websearch_agent/src/crewai_web_search/tracing.py`
+- Level C: `agents/vanilla_python/openai_responses_agent/src/openai_responses_agent/tracing.py`
+
+### 2. `main.py` wiring
+
+Read `<agent_path>/main.py` and verify:
+
+- [ ] `enable_tracing` is imported from `<package>.tracing`
+- [ ] `enable_tracing()` is called as the **first line** inside the `lifespan()` function (before agent initialization)
+- [ ] For Level B/C: `wrap_func_with_mlflow_trace` is also imported
+
+### 3. Manual wrapping (Level B and C only)
+
+Skip this section for Level A.
+
+**Tool wrapping** — find where tools are registered/created and verify:
+- [ ] Every tool function/method is wrapped with `wrap_func_with_mlflow_trace(..., span_type="tool")`
+- [ ] The `name` parameter is used when wrapping tool objects (so span names are meaningful)
+- [ ] Wrapping happens before tools are passed to the agent
+
+**Agent wrapping** — find the main agent entry point and verify:
+- [ ] The agent's main function (e.g., `query()`, `run()`) is wrapped with `wrap_func_with_mlflow_trace(..., span_type="agent")`
+- [ ] This creates a parent span that groups all tool and LLM calls under one trace
+
+**Streaming path** — read `_handle_stream` in `main.py` and verify:
+- [ ] If streaming creates a new agent instance (bypasses the adapter/closure), wrapping is duplicated in the streaming path
+- [ ] Both tool wrapping and agent wrapping are applied in the streaming code
+- [ ] If streaming uses the same agent instance as non-streaming, no duplication is needed
+
+### 4. No direct MLflow imports in `main.py`
+
+- [ ] `main.py` does NOT import `mlflow` directly — all MLflow interaction goes through `tracing.py`
+- [ ] No `mlflow.trace()` calls appear in `main.py` — only `wrap_func_with_mlflow_trace()` from `tracing.py`
+
+### 5. `.env.example` has MLflow variables
+
+Read `<agent_path>/.env.example` and verify:
+
+- [ ] **Local tracing section** exists with: `MLFLOW_TRACKING_URI`, `MLFLOW_EXPERIMENT_NAME`, `MLFLOW_HEALTH_CHECK_TIMEOUT`, `MLFLOW_HTTP_REQUEST_TIMEOUT`, `MLFLOW_HTTP_REQUEST_MAX_RETRIES`
+- [ ] **OpenShift tracing section** exists with: `MLFLOW_TRACKING_URI`, `MLFLOW_TRACKING_TOKEN`, `MLFLOW_EXPERIMENT_NAME`, `MLFLOW_TRACKING_INSECURE_TLS`, `MLFLOW_WORKSPACE`, `MLFLOW_TRACKING_AUTH`
+- [ ] All variables are commented out (optional by default)
+
+### 6. `README.md` has tracing documentation
+
+Read `<agent_path>/README.md` and verify:
+
+- [ ] **Local tracing config** — `##### Tracing` subsection under Local `.env` config with example MLflow env vars
+- [ ] **OpenShift tracing config** — `##### Tracing` subsection under OpenShift `.env` config with variable explanations and behavioral notes (optional, graceful degradation, health check timeout)
+- [ ] **Local MLflow install** — `uv pip install "mlflow>=3.10.0"` step after `uv pip install -e .` (marked as optional)
+- [ ] **MLflow server start** — `mlflow server --port 5000` step in the Local Usage section
+- [ ] **RHOAI MLflow install** — `uv pip install "git+https://github.com/red-hat-data-services/mlflow@rhoai-3.3"` in the OpenShift Deployment section (marked as optional)
+
+### 7. `pyproject.toml` does NOT list MLflow
+
+- [ ] `mlflow` is NOT in `dependencies` or `optional-dependencies` — it is installed manually per README instructions
+
+## Output
+
+```
+## Code Review Report: <agent_name>
+
+### tracing.py
+- Exists: YES / NO
+- Follows pattern: YES / NO
+- Issues: <list or "None">
+
+### main.py wiring
+- enable_tracing() imported: YES / NO
+- Called first in lifespan: YES / NO
+- Issues: <list or "None">
+
+### Manual wrapping (Level B/C only)
+- Tools wrapped: YES / NO / N/A
+- Agent entry point wrapped: YES / NO / N/A
+- Streaming path covered: YES / NO / N/A
+- Issues: <list or "None">
+
+### .env.example
+- Local tracing section: YES / NO
+- OpenShift tracing section: YES / NO
+- Issues: <list or "None">
+
+### README.md
+- Local tracing config: YES / NO
+- OpenShift tracing config: YES / NO
+- Local MLflow install step: YES / NO
+- MLflow server start step: YES / NO
+- RHOAI MLflow install step: YES / NO
+- Issues: <list or "None">
+
+### pyproject.toml
+- MLflow NOT in dependencies: YES / NO
+
+### Overall: PASS / FAIL
+```
+
+If FAIL, specify which skill or step to re-run to fix the issues (e.g., "`create-tracing-module` — missing graceful degradation", "`integrate-tracing` Step 7 — .env.example missing OpenShift section", or "`integrate-tracing` Step 8 — README missing local MLflow install").
+
+## Self-Update (mandatory)
+
+**Before finishing, you MUST check whether this skill file needs updating.** This is not optional. If any of the following are true, update this file immediately:
+
+- You deviated from these instructions because they were inaccurate, outdated, or insufficient — and your deviation worked.
+- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path). Add it as a variant under the existing levels (A, B, or C) rather than introducing new levels.
+- File paths, function names, or API patterns referenced here have changed.
+- A step didn't work as described and needed a different approach.
+
+If nothing needed changing, move on. But do not skip this check.

--- a/.claude/skills/review-tracing-code/SKILL.md
+++ b/.claude/skills/review-tracing-code/SKILL.md
@@ -112,6 +112,10 @@ Read `<agent_path>/README.md` and verify:
 - [ ] `run` target uses `$${MLFLOW_TRACKING_URI:+--extra tracing}` in the `uv run` command
 - [ ] `run-cli` target (if it exists) uses the same flag
 
+### 9. Dockerfile installs tracing extra (if Dockerfile exists)
+
+- [ ] The package install step in `Dockerfile` includes the `tracing` extra (e.g., `".[tracing]"` instead of `"."`)
+
 ## Output
 
 ```text
@@ -150,6 +154,9 @@ Read `<agent_path>/README.md` and verify:
 ### Makefile
 - run target has --extra tracing flag: YES / NO
 - run-cli target has --extra tracing flag: YES / NO / N/A
+
+### Dockerfile
+- Installs .[tracing] extra: YES / NO
 
 ### Overall: PASS / FAIL
 ```

--- a/.claude/skills/review-tracing-code/SKILL.md
+++ b/.claude/skills/review-tracing-code/SKILL.md
@@ -154,7 +154,7 @@ Read `<agent_path>/README.md` and verify:
 ### Overall: PASS / FAIL
 ```
 
-If FAIL, specify which skill or step to re-run to fix the issues (e.g., "`create-tracing-module` — missing graceful degradation", "`integrate-tracing` Step 7 — .env.example missing OpenShift section", or "`integrate-tracing` Step 8 — README missing local MLflow install").
+If FAIL, specify which skill or step to re-run to fix the issues (e.g., "`create-tracing-module` — missing graceful degradation", "`integrate-tracing` Step 9 — .env.example missing OpenShift section", or "`integrate-tracing` Step 10 — README missing local MLflow install").
 
 ## Self-Update
 

--- a/.claude/skills/review-tracing-code/SKILL.md
+++ b/.claude/skills/review-tracing-code/SKILL.md
@@ -103,6 +103,11 @@ Read `<agent_path>/README.md` and verify:
 
 - [ ] `mlflow>=3.10.0` is in `[project.optional-dependencies]` under a `tracing` extra — NOT in core `dependencies`
 
+### 8. `Makefile` auto-installs MLflow when tracing is enabled
+
+- [ ] `run` target uses `$${MLFLOW_TRACKING_URI:+--extra tracing}` in the `uv run` command
+- [ ] `run-cli` target (if it exists) uses the same flag
+
 ## Output
 
 ```
@@ -136,7 +141,11 @@ Read `<agent_path>/README.md` and verify:
 - Issues: <list or "None">
 
 ### pyproject.toml
-- MLflow NOT in dependencies: YES / NO
+- MLflow in optional tracing extra: YES / NO
+
+### Makefile
+- run target has --extra tracing flag: YES / NO
+- run-cli target has --extra tracing flag: YES / NO / N/A
 
 ### Overall: PASS / FAIL
 ```

--- a/.claude/skills/review-tracing-code/SKILL.md
+++ b/.claude/skills/review-tracing-code/SKILL.md
@@ -110,7 +110,7 @@ Read `<agent_path>/README.md` and verify:
 
 ## Output
 
-```
+```text
 ## Code Review Report: <agent_name>
 
 ### tracing.py

--- a/.claude/skills/review-tracing-code/SKILL.md
+++ b/.claude/skills/review-tracing-code/SKILL.md
@@ -1,7 +1,14 @@
+---
+name: review-tracing-code
+description: Reviews tracing integration code for correctness against the repo's established patterns and checklists.
+argument-hint: "<agent_path>"
+disable-model-invocation: true
+---
+
 # Review Tracing Code
 
-> **Usage:** `/project:review-tracing-code <agent_path>`
-> **Example:** `/project:review-tracing-code agents/autogen/chat_agent`
+> **Usage:** `/review-tracing-code <agent_path>`
+> **Example:** `/review-tracing-code agents/autogen/chat_agent`
 
 You are reviewing the MLflow tracing integration code for an agent template to confirm it follows the repo's established patterns and is correctly wired.
 
@@ -9,12 +16,9 @@ You are reviewing the MLflow tracing integration code for an agent template to c
 
 ## Input
 
-You need:
-1. **Agent path**: The agent directory (e.g., `agents/autogen/chat_agent/`)
-2. **Package name**: The Python package name (find from `pyproject.toml` or `src/` directory)
-3. **Coverage level**: A, B, or C (from the autolog support report)
+The agent path is: $ARGUMENTS
 
-If any are missing, determine them by reading the agent's files.
+You also need the **package name** and **coverage level** (A, B, or C). If not provided, determine them by reading the agent's `pyproject.toml`, `src/` directory, and `tracing.py`.
 
 ## Review Checklist
 
@@ -152,13 +156,13 @@ Read `<agent_path>/README.md` and verify:
 
 If FAIL, specify which skill or step to re-run to fix the issues (e.g., "`create-tracing-module` — missing graceful degradation", "`integrate-tracing` Step 7 — .env.example missing OpenShift section", or "`integrate-tracing` Step 8 — README missing local MLflow install").
 
-## Self-Update (mandatory)
+## Self-Update
 
-**Before finishing, you MUST check whether this skill file needs updating.** This is not optional. If any of the following are true, update this file immediately:
+Before finishing, check whether this skill file needs updating. If any of the following are true, **propose the specific changes to the user** and only update this file if they approve:
 
 - You deviated from these instructions because they were inaccurate, outdated, or insufficient — and your deviation worked.
-- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path). Add it as a variant under the existing levels (A, B, or C) rather than introducing new levels.
+- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path).
 - File paths, function names, or API patterns referenced here have changed.
 - A step didn't work as described and needed a different approach.
 
-If nothing needed changing, move on. But do not skip this check.
+If nothing needed changing, move on.

--- a/.claude/skills/review-tracing-code/SKILL.md
+++ b/.claude/skills/review-tracing-code/SKILL.md
@@ -101,9 +101,9 @@ Read `<agent_path>/README.md` and verify:
 - [ ] **MLflow server start** — `mlflow server --port 5000` step in the Local Usage section
 - [ ] **RHOAI MLflow install** — `uv pip install "git+https://github.com/red-hat-data-services/mlflow@rhoai-3.3"` in the OpenShift Deployment section (marked as optional)
 
-### 7. `pyproject.toml` does NOT list MLflow
+### 7. `pyproject.toml` lists MLflow as optional
 
-- [ ] `mlflow` is NOT in `dependencies` or `optional-dependencies` — it is installed manually per README instructions
+- [ ] `mlflow>=3.10.0` is in `[project.optional-dependencies]` under a `tracing` extra — NOT in core `dependencies`
 
 ## Output
 

--- a/.claude/skills/review-tracing-code/SKILL.md
+++ b/.claude/skills/review-tracing-code/SKILL.md
@@ -97,9 +97,7 @@ Read `<agent_path>/README.md` and verify:
 
 - [ ] **Local tracing config** — `##### Tracing` subsection under Local `.env` config with example MLflow env vars
 - [ ] **OpenShift tracing config** — `##### Tracing` subsection under OpenShift `.env` config with variable explanations and behavioral notes (optional, graceful degradation, health check timeout)
-- [ ] **Local MLflow install** — `uv pip install "mlflow>=3.10.0"` step after `uv pip install -e .` (marked as optional)
-- [ ] **MLflow server start** — `mlflow server --port 5000` step in the Local Usage section
-- [ ] **RHOAI MLflow install** — `uv pip install "git+https://github.com/red-hat-data-services/mlflow@rhoai-3.3"` in the OpenShift Deployment section (marked as optional)
+- [ ] **MLflow server start** — `uv run --extra tracing mlflow server --port 5000` step in the Local Usage section
 
 ### 7. `pyproject.toml` lists MLflow as optional
 
@@ -134,9 +132,7 @@ Read `<agent_path>/README.md` and verify:
 ### README.md
 - Local tracing config: YES / NO
 - OpenShift tracing config: YES / NO
-- Local MLflow install step: YES / NO
 - MLflow server start step: YES / NO
-- RHOAI MLflow install step: YES / NO
 - Issues: <list or "None">
 
 ### pyproject.toml

--- a/.claude/skills/test-tracing/SKILL.md
+++ b/.claude/skills/test-tracing/SKILL.md
@@ -72,7 +72,7 @@ Confirm `BASE_URL` and `MODEL_ID` are also set in `.env`.
 Check if an MLflow server is already running:
 
 ```bash
-curl -s http://localhost:5000/health
+curl -s http://localhost:<MLFLOW_PORT>/health
 ```
 
 If not running, start one. Try port 5000 first; if occupied, increment:
@@ -87,7 +87,9 @@ If port 5000 is occupied:
 mlflow server --port 5001
 ```
 
-Keep incrementing until you find an open port. Record the port and make sure `MLFLOW_TRACKING_URI` in the agent's `.env` matches (e.g., `http://localhost:5001`).
+Keep incrementing until you find an open port. Record the port as `<MLFLOW_PORT>` and make sure `MLFLOW_TRACKING_URI` in the agent's `.env` matches (e.g., `http://localhost:5001`).
+
+**Use `http://localhost:<MLFLOW_PORT>` consistently for ALL MLflow API calls below.** Do not hardcode port 5000 — always use the actual port the server is running on.
 
 **The MLflow server must keep running in the background.** Tell the user to keep that terminal open, or run it in the background.
 
@@ -120,13 +122,13 @@ Check the agent's startup logs for the `[Tracing Enabled]` message confirming ML
 Get the experiment ID first so you can track trace counts before and after test requests.
 
 ```bash
-curl -s "http://localhost:5000/api/2.0/mlflow/experiments/get-by-name?experiment_name=<EXPERIMENT_NAME>" | python3 -m json.tool
+curl -s "http://localhost:<MLFLOW_PORT>/api/2.0/mlflow/experiments/get-by-name?experiment_name=<EXPERIMENT_NAME>" | python3 -m json.tool
 ```
 
 Extract the `experiment_id` from the response. Then record how many traces exist before testing:
 
 ```bash
-curl -s "http://localhost:5000/api/2.0/mlflow/traces?experiment_ids=<EXPERIMENT_ID>&max_results=0" | python3 -c "
+curl -s "http://localhost:<MLFLOW_PORT>/api/2.0/mlflow/traces?experiment_ids=<EXPERIMENT_ID>&max_results=0" | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
 print('Traces before test:', len(data.get('traces', [])))
@@ -135,7 +137,7 @@ print('Traces before test:', len(data.get('traces', [])))
 
 If the experiment doesn't exist yet (first run), the baseline is 0.
 
-## Step 4: Send a test request (non-streaming)
+## Step 6: Send a test request (non-streaming)
 
 Craft a message based on the agent's tools. The message should trigger at least one tool call so you can verify tool spans.
 
@@ -147,10 +149,10 @@ curl -s -X POST http://localhost:<PORT>/chat/completions \
 
 Verify the response has a valid `chat.completion` structure with an assistant message.
 
-## Step 5: Verify exactly 1 new trace from non-streaming request
+## Step 7: Verify exactly 1 new trace from non-streaming request
 
 ```bash
-curl -s "http://localhost:5000/api/2.0/mlflow/traces?experiment_ids=<EXPERIMENT_ID>&max_results=5" | python3 -c "
+curl -s "http://localhost:<MLFLOW_PORT>/api/2.0/mlflow/traces?experiment_ids=<EXPERIMENT_ID>&max_results=5" | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
 traces = data.get('traces', [])
@@ -163,7 +165,7 @@ Compare with the baseline from Step 3. Exactly **1 new trace** should have appea
 
 Record the non-streaming trace's `request_id`.
 
-## Step 6: Send a test request (streaming)
+## Step 8: Send a test request (streaming)
 
 ```bash
 curl -s -X POST http://localhost:<PORT>/chat/completions \
@@ -173,10 +175,10 @@ curl -s -X POST http://localhost:<PORT>/chat/completions \
 
 Verify SSE chunks arrive with `chat.completion.chunk` objects, ending with `data: [DONE]`.
 
-## Step 7: Verify exactly 1 new trace from streaming request
+## Step 9: Verify exactly 1 new trace from streaming request
 
 ```bash
-curl -s "http://localhost:5000/api/2.0/mlflow/traces?experiment_ids=<EXPERIMENT_ID>&max_results=5" | python3 -c "
+curl -s "http://localhost:<MLFLOW_PORT>/api/2.0/mlflow/traces?experiment_ids=<EXPERIMENT_ID>&max_results=5" | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
 traces = data.get('traces', [])
@@ -189,7 +191,7 @@ Exactly **1 more trace** should have appeared since Step 5. If more, streaming i
 
 Record the streaming trace's `request_id`.
 
-## Step 8: Inspect spans for both traces
+## Step 10: Inspect spans for both traces
 
 For each trace (non-streaming and streaming), inspect the individual spans.
 
@@ -203,7 +205,7 @@ If MLflow is available, inspect spans using the Python SDK:
 
 ```python
 import mlflow
-mlflow.set_tracking_uri("http://localhost:5000")
+mlflow.set_tracking_uri("http://localhost:<MLFLOW_PORT>")
 
 for label, trace_id in [("Non-streaming", "<non_streaming_trace_id>"), ("Streaming", "<streaming_trace_id>")]:
     print(f"\n{label} trace: {trace_id}")
@@ -215,7 +217,7 @@ for label, trace_id in [("Non-streaming", "<non_streaming_trace_id>"), ("Streami
 If MLflow is not installed in the current env, use the REST API as a fallback:
 
 ```bash
-curl -s "http://localhost:5000/api/2.0/mlflow/traces/<TRACE_ID>/spans" | python3 -c "
+curl -s "http://localhost:<MLFLOW_PORT>/api/2.0/mlflow/traces/<TRACE_ID>/spans" | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
 for span in data.get('spans', []):
@@ -223,7 +225,7 @@ for span in data.get('spans', []):
 "
 ```
 
-## Step 9: Compare streaming and non-streaming traces
+## Step 11: Compare streaming and non-streaming traces
 
 Both traces should have the **same span structure** — same span types and roughly the same span names. Compare:
 
@@ -233,7 +235,7 @@ Both traces should have the **same span structure** — same span types and roug
 
 If streaming has fewer spans or is missing tool/agent spans, the streaming path is not properly traced — see the `add-manual-tracing` skill.
 
-## Step 10: Validate the spans
+## Step 12: Validate the spans
 
 Check the span output against expected patterns for the agent's coverage level:
 
@@ -270,7 +272,7 @@ Expected span types:
 
 Report the results:
 
-```
+```text
 ## Tracing Test Report: <agent_name>
 
 **MLflow URL**: <mlflow_url>

--- a/.claude/skills/test-tracing/SKILL.md
+++ b/.claude/skills/test-tracing/SKILL.md
@@ -1,0 +1,315 @@
+# Test MLflow Tracing
+
+> **Usage:** `/project:test-tracing <agent_path>`
+> **Example:** `/project:test-tracing agents/langgraph/react_agent`
+
+You are testing that MLflow tracing is working correctly for an agent template — verifying that traces land in the MLflow server with the expected spans.
+
+**You must execute every step yourself.** Run all commands, start all servers, send all requests, and query all APIs. Do not tell the user to do any of this manually. Do not stop partway and summarize remaining steps. You own the entire testing workflow end-to-end.
+
+## Input
+
+The agent path is: $ARGUMENTS
+
+If no agent path was provided, ask the user which agent they want to test.
+
+## Pre-Test Checklist
+
+Before sending any requests, gather this information by reading the agent's files:
+
+1. **Agent tools**: Read the agent's `agent.py`, `crew.py`, or `tools.py` to understand what tools are available and what dummy responses they return. Craft test messages that will trigger tool calls.
+2. **App port**: Confirm which port the agent is running on (check `.env` or ask the user). Default is `8000`.
+3. **LLM provider** (CrewAI only): Check `LLM_PROVIDER` in `.env` to know which autolog to expect.
+4. **Coverage level**: Know whether the agent uses Level A (full autolog), B (partial), or C (no framework autolog) — this determines what spans to expect.
+
+## Step 1: Ensure MLflow is installed
+
+Check if MLflow is available in the current Python environment:
+
+```bash
+python3 -c "import mlflow; print('MLflow version:', mlflow.__version__)"
+```
+
+If not installed, install it:
+
+```bash
+uv pip install "mlflow>=3.10.0"
+```
+
+## Step 2: Set up the agent's `.env`
+
+Read the agent's `.env.example` to see what variables are needed:
+
+```bash
+cat <agent_path>/.env.example
+```
+
+Check if `<agent_path>/.env` already exists. If not, create it from the example:
+
+```bash
+cp <agent_path>/.env.example <agent_path>/.env
+```
+
+Ensure these tracing variables are set in `.env`:
+
+```ini
+MLFLOW_TRACKING_URI=http://localhost:<MLFLOW_PORT>
+MLFLOW_EXPERIMENT_NAME=<descriptive-experiment-name>
+```
+
+For the LLM API key: check if `API_KEY` is already set in the shell environment:
+
+```bash
+echo $API_KEY
+```
+
+If not set, ask the user for it. Do not guess or skip — the agent won't work without it.
+
+Confirm `BASE_URL` and `MODEL_ID` are also set in `.env`.
+
+## Step 3: Start the MLflow server
+
+Check if an MLflow server is already running:
+
+```bash
+curl -s http://localhost:5000/health
+```
+
+If not running, start one. Try port 5000 first; if occupied, increment:
+
+```bash
+mlflow server --port 5000
+```
+
+If port 5000 is occupied:
+
+```bash
+mlflow server --port 5001
+```
+
+Keep incrementing until you find an open port. Record the port and make sure `MLFLOW_TRACKING_URI` in the agent's `.env` matches (e.g., `http://localhost:5001`).
+
+**The MLflow server must keep running in the background.** Tell the user to keep that terminal open, or run it in the background.
+
+## Step 4: Start the agent
+
+Set up the environment and start the agent:
+
+```bash
+cd <agent_path>
+make init              # Copy .env.example → .env (if .env doesn't exist)
+# Edit .env with the correct values (API keys, MLflow URI, etc.)
+source .env
+uvicorn main:app --port <PORT>
+```
+
+**The agent must keep running in the background.** Tell the user to keep that terminal open, or run it in the background.
+
+Verify the agent is healthy:
+
+```bash
+curl -s http://localhost:<PORT>/health | python3 -m json.tool
+```
+
+Expect: `{"status": "healthy", "agent_initialized": true}`
+
+Check the agent's startup logs for the `[Tracing Enabled]` message confirming MLflow tracing is active. If you see `[Tracing] MLFLOW_TRACKING_URI not set` or `MLflow server is unreachable`, fix the `.env` or MLflow server before proceeding.
+
+## Step 5: Get the experiment ID and record baseline trace count
+
+Get the experiment ID first so you can track trace counts before and after test requests.
+
+```bash
+curl -s "http://localhost:5000/api/2.0/mlflow/experiments/get-by-name?experiment_name=<EXPERIMENT_NAME>" | python3 -m json.tool
+```
+
+Extract the `experiment_id` from the response. Then record how many traces exist before testing:
+
+```bash
+curl -s "http://localhost:5000/api/2.0/mlflow/traces?experiment_ids=<EXPERIMENT_ID>&max_results=0" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print('Traces before test:', len(data.get('traces', [])))
+"
+```
+
+If the experiment doesn't exist yet (first run), the baseline is 0.
+
+## Step 4: Send a test request (non-streaming)
+
+Craft a message based on the agent's tools. The message should trigger at least one tool call so you can verify tool spans.
+
+```bash
+curl -s -X POST http://localhost:<PORT>/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"messages": [{"role": "user", "content": "<message that triggers tools>"}], "stream": false}' | python3 -m json.tool
+```
+
+Verify the response has a valid `chat.completion` structure with an assistant message.
+
+## Step 5: Verify exactly 1 new trace from non-streaming request
+
+```bash
+curl -s "http://localhost:5000/api/2.0/mlflow/traces?experiment_ids=<EXPERIMENT_ID>&max_results=5" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+traces = data.get('traces', [])
+print('Total traces now:', len(traces))
+print('Latest trace ID:', traces[0]['request_id'] if traces else 'NONE')
+"
+```
+
+Compare with the baseline from Step 3. Exactly **1 new trace** should have appeared. If more than 1 appeared, the agent is producing fragmented traces (missing parent AGENT span — see Common Problems).
+
+Record the non-streaming trace's `request_id`.
+
+## Step 6: Send a test request (streaming)
+
+```bash
+curl -s -X POST http://localhost:<PORT>/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"messages": [{"role": "user", "content": "<message that triggers tools>"}], "stream": true}'
+```
+
+Verify SSE chunks arrive with `chat.completion.chunk` objects, ending with `data: [DONE]`.
+
+## Step 7: Verify exactly 1 new trace from streaming request
+
+```bash
+curl -s "http://localhost:5000/api/2.0/mlflow/traces?experiment_ids=<EXPERIMENT_ID>&max_results=5" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+traces = data.get('traces', [])
+print('Total traces now:', len(traces))
+print('Latest trace ID:', traces[0]['request_id'] if traces else 'NONE')
+"
+```
+
+Exactly **1 more trace** should have appeared since Step 5. If more, streaming is producing fragmented traces.
+
+Record the streaming trace's `request_id`.
+
+## Step 8: Inspect spans for both traces
+
+For each trace (non-streaming and streaming), inspect the individual spans.
+
+First check if `mlflow` is available in the current Python environment:
+
+```bash
+python3 -c "import mlflow; print('MLflow available:', mlflow.__version__)"
+```
+
+If MLflow is available, inspect spans using the Python SDK:
+
+```python
+import mlflow
+mlflow.set_tracking_uri("http://localhost:5000")
+
+for label, trace_id in [("Non-streaming", "<non_streaming_trace_id>"), ("Streaming", "<streaming_trace_id>")]:
+    print(f"\n{label} trace: {trace_id}")
+    trace = mlflow.get_trace(trace_id)
+    for span in trace.search_spans():
+        print(f"  {span.name} (type: {span.span_type})")
+```
+
+If MLflow is not installed in the current env, use the REST API as a fallback:
+
+```bash
+curl -s "http://localhost:5000/api/2.0/mlflow/traces/<TRACE_ID>/spans" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for span in data.get('spans', []):
+    print(f'  {span[\"name\"]} (type: {span[\"span_type\"]})')
+"
+```
+
+## Step 9: Compare streaming and non-streaming traces
+
+Both traces should have the **same span structure** — same span types and roughly the same span names. Compare:
+
+- Same number of spans (or close — minor differences are acceptable)
+- Same span types present (CHAIN, CHAT_MODEL, TOOL, AGENT)
+- No missing layers in either trace
+
+If streaming has fewer spans or is missing tool/agent spans, the streaming path is not properly traced — see the `add-manual-tracing` skill.
+
+## Step 10: Validate the spans
+
+Check the span output against expected patterns for the agent's coverage level:
+
+### Level A (Full autolog — e.g., LangGraph, LlamaIndex)
+Expected span types:
+- CHAIN spans for orchestration (e.g., `LangGraph`, `FunctionCallingAgent.run`)
+- CHAT_MODEL spans for LLM calls (e.g., `ChatOpenAI`, `OpenAILike.achat`)
+- TOOL spans for tool calls (e.g., `dummy_web_search`)
+
+### Level B (Partial autolog — e.g., CrewAI)
+Expected span types:
+- AGENT/CHAIN spans from framework autolog (e.g., `CrewAI`, `Task`, `Agent`)
+- TOOL spans from manual wrapping (e.g., `WebSearchTool`)
+- CHAT_MODEL or LLM spans from provider autolog (e.g., `Completions`, `litellm-completion`)
+
+### Level C (No framework autolog — e.g., Vanilla Python)
+Expected span types:
+- AGENT span from manual wrapping (e.g., `query`)
+- TOOL spans from manual wrapping (e.g., `search_price`, `search_reviews`)
+- CHAT_MODEL spans from provider autolog (e.g., `Responses`)
+
+## Common Problems and Fixes
+
+| Problem | Symptom | Fix |
+|---|---|---|
+| Multiple traces per request | Span count is low (1-2), multiple trace IDs for one request | Missing parent AGENT span — add `wrap_func_with_mlflow_trace(agent.run, span_type="agent")` |
+| No tool spans | Only LLM/orchestration spans visible | Tools not wrapped — add `wrap_func_with_mlflow_trace` for each tool |
+| No LLM spans | Only orchestration/tool spans, no token usage | Wrong or missing provider autolog — check `LLM_PROVIDER` env var (CrewAI) or add `mlflow.<provider>.autolog()` |
+| No traces at all | Experiment exists but no traces | Check agent startup logs for `[Tracing Enabled]` message. If missing, check `MLFLOW_TRACKING_URI` is set and MLflow is reachable. |
+| Streaming creates separate traces | Non-streaming works fine, streaming produces N traces | Streaming path missing wrapping — see `add-manual-tracing` skill, streaming section |
+| Token usage is null | Traces exist with spans but no token counts | LLM span not capturing usage — provider autolog may not support it for this model/endpoint |
+
+## Output
+
+Report the results:
+
+```
+## Tracing Test Report: <agent_name>
+
+**MLflow URL**: <mlflow_url>
+**Experiment name**: <experiment_name>
+**Test query used**: "<the message sent to the agent>"
+
+### Non-streaming
+**Request**: PASS / FAIL
+**Trace appeared in MLflow**: YES / NO
+**Traces produced**: <number> (expected: 1)
+**Span count**: <number>
+**Span breakdown**:
+  - <span_name> (<span_type>) — <source: autolog or manual>
+  - ...
+
+### Streaming
+**Request**: PASS / FAIL
+**Trace appeared in MLflow**: YES / NO
+**Traces produced**: <number> (expected: 1)
+**Span count**: <number>
+**Span breakdown**:
+  - <span_name> (<span_type>) — <source: autolog or manual>
+  - ...
+
+### Comparison
+**Streaming and non-streaming span structures match**: YES / NO
+
+### Summary
+**Token usage captured**: YES / NO
+**Issues found**: <list or "None">
+```
+
+## Self-Update (mandatory)
+
+**Before finishing, you MUST check whether this skill file needs updating.** This is not optional. If any of the following are true, update this file immediately:
+
+- You deviated from these instructions because they were inaccurate, outdated, or insufficient — and your deviation worked.
+- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path). Add it as a variant under the existing levels (A, B, or C) rather than introducing new levels.
+- File paths, function names, or API patterns referenced here have changed.
+- A step didn't work as described and needed a different approach.
+
+If nothing needed changing, move on. But do not skip this check.

--- a/.claude/skills/test-tracing/SKILL.md
+++ b/.claude/skills/test-tracing/SKILL.md
@@ -1,7 +1,14 @@
+---
+name: test-tracing
+description: Tests MLflow tracing end-to-end by starting servers, sending requests, and verifying spans appear correctly in the MLflow API.
+argument-hint: "<agent_path>"
+disable-model-invocation: true
+---
+
 # Test MLflow Tracing
 
-> **Usage:** `/project:test-tracing <agent_path>`
-> **Example:** `/project:test-tracing agents/langgraph/react_agent`
+> **Usage:** `/test-tracing <agent_path>`
+> **Example:** `/test-tracing agents/langgraph/react_agent`
 
 You are testing that MLflow tracing is working correctly for an agent template — verifying that traces land in the MLflow server with the expected spans.
 
@@ -305,13 +312,13 @@ Report the results:
 **Issues found**: <list or "None">
 ```
 
-## Self-Update (mandatory)
+## Self-Update
 
-**Before finishing, you MUST check whether this skill file needs updating.** This is not optional. If any of the following are true, update this file immediately:
+Before finishing, check whether this skill file needs updating. If any of the following are true, **propose the specific changes to the user** and only update this file if they approve:
 
 - You deviated from these instructions because they were inaccurate, outdated, or insufficient — and your deviation worked.
-- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path). Add it as a variant under the existing levels (A, B, or C) rather than introducing new levels.
+- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path).
 - File paths, function names, or API patterns referenced here have changed.
 - A step didn't work as described and needed a different approach.
 
-If nothing needed changing, move on. But do not skip this check.
+If nothing needed changing, move on.

--- a/.claude/skills/verify-traces/SKILL.md
+++ b/.claude/skills/verify-traces/SKILL.md
@@ -9,7 +9,7 @@ You are verifying that MLflow tracing works correctly after integrating it into 
 
 You need:
 1. **Agent path**: The agent directory (e.g., `agents/autogen/chat_agent/`)
-2. **Coverage level**: A, B, or C (from the autolog support report)
+2. **Coverage level**: A, B, or C — if not provided, determine it by reading the agent's `tracing.py`. If it has `wrap_func_with_mlflow_trace()` and a framework autolog, it's Level B. If it has `wrap_func_with_mlflow_trace()` but no framework autolog, it's Level C. If it has neither, it's Level A.
 
 ## Important
 
@@ -38,7 +38,7 @@ Do not skip any of these steps or ask the user to do them.
 
 Combine the outputs from both steps into a single verification report:
 
-```
+```text
 ## Tracing Verification Report: <agent_name>
 
 ### Code Review

--- a/.claude/skills/verify-traces/SKILL.md
+++ b/.claude/skills/verify-traces/SKILL.md
@@ -1,0 +1,64 @@
+# Verify Traces After Tracing Integration
+
+> **Usage:** `/project:verify-traces <agent_path>`
+> **Example:** `/project:verify-traces agents/autogen/chat_agent`
+
+You are verifying that MLflow tracing works correctly after integrating it into a new agent template. This is the final validation step in the tracing integration workflow.
+
+## Input
+
+You need:
+1. **Agent path**: The agent directory (e.g., `agents/autogen/chat_agent/`)
+2. **Coverage level**: A, B, or C (from the autolog support report)
+
+## Important
+
+You must execute every step yourself — do NOT tell the user to do it manually or suggest they run commands. You are responsible for running all commands, starting servers, sending requests, and inspecting traces. Do not stop partway through and summarize what the user should do next.
+
+## Steps
+
+### 1. Code review
+
+Read and execute every step in the `review-tracing-code` skill yourself. Read the agent's `tracing.py`, `main.py`, and any manual wrapping files. Check each item in the review checklist and produce the code review report.
+
+### 2. Live trace testing
+
+Read and execute every step in the `test-tracing` skill yourself. This means YOU must:
+- Check if MLflow is installed and install it if not
+- Set up the agent's `.env` from `.env.example`
+- Start the MLflow server (finding an open port)
+- Start the agent
+- Send test requests (both streaming and non-streaming)
+- Query the MLflow API to verify traces appeared
+- Inspect spans and validate them
+
+Do not skip any of these steps or ask the user to do them.
+
+### 3. Combined report
+
+Combine the outputs from both steps into a single verification report:
+
+```
+## Tracing Verification Report: <agent_name>
+
+### Code Review
+<output from review-tracing-code>
+
+### Live Test Results
+<output from test-tracing>
+
+### Overall Status: PASS / FAIL
+```
+
+If FAIL, list specific issues and which skill to re-run to fix them (e.g., "Missing tool wrapping in streaming path — re-run `add-manual-tracing`").
+
+## Self-Update (mandatory)
+
+**Before finishing, you MUST check whether this skill file needs updating.** This is not optional. If any of the following are true, update this file immediately:
+
+- You deviated from these instructions because they were inaccurate, outdated, or insufficient — and your deviation worked.
+- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path). Add it as a variant under the existing levels (A, B, or C) rather than introducing new levels.
+- File paths, function names, or API patterns referenced here have changed.
+- A step didn't work as described and needed a different approach.
+
+If nothing needed changing, move on. But do not skip this check.

--- a/.claude/skills/verify-traces/SKILL.md
+++ b/.claude/skills/verify-traces/SKILL.md
@@ -1,15 +1,22 @@
+---
+name: verify-traces
+description: Verifies tracing works correctly after integration by running both code review and live trace testing.
+argument-hint: "<agent_path>"
+disable-model-invocation: true
+---
+
 # Verify Traces After Tracing Integration
 
-> **Usage:** `/project:verify-traces <agent_path>`
-> **Example:** `/project:verify-traces agents/autogen/chat_agent`
+> **Usage:** `/verify-traces <agent_path>`
+> **Example:** `/verify-traces agents/autogen/chat_agent`
 
 You are verifying that MLflow tracing works correctly after integrating it into a new agent template. This is the final validation step in the tracing integration workflow.
 
 ## Input
 
-You need:
-1. **Agent path**: The agent directory (e.g., `agents/autogen/chat_agent/`)
-2. **Coverage level**: A, B, or C — if not provided, determine it by reading the agent's `tracing.py`. If it has `wrap_func_with_mlflow_trace()` and a framework autolog, it's Level B. If it has `wrap_func_with_mlflow_trace()` but no framework autolog, it's Level C. If it has neither, it's Level A.
+The agent path is: $ARGUMENTS
+
+You also need the **coverage level** (A, B, or C). If not provided, determine it by reading the agent's `tracing.py`. If it has `wrap_func_with_mlflow_trace()` and a framework autolog, it's Level B. If it has `wrap_func_with_mlflow_trace()` but no framework autolog, it's Level C. If it has neither, it's Level A.
 
 ## Important
 
@@ -19,11 +26,11 @@ You must execute every step yourself — do NOT tell the user to do it manually 
 
 ### 1. Code review
 
-Read and execute every step in the `review-tracing-code` skill yourself. Read the agent's `tracing.py`, `main.py`, and any manual wrapping files. Check each item in the review checklist and produce the code review report.
+Read and follow `.claude/skills/review-tracing-code/SKILL.md` yourself. Read the agent's `tracing.py`, `main.py`, and any manual wrapping files. Check each item in the review checklist and produce the code review report.
 
 ### 2. Live trace testing
 
-Read and execute every step in the `test-tracing` skill yourself. This means YOU must:
+Read and follow `.claude/skills/test-tracing/SKILL.md` yourself. This means YOU must:
 - Check if MLflow is installed and install it if not
 - Set up the agent's `.env` from `.env.example`
 - Start the MLflow server (finding an open port)
@@ -52,13 +59,13 @@ Combine the outputs from both steps into a single verification report:
 
 If FAIL, list specific issues and which skill to re-run to fix them (e.g., "Missing tool wrapping in streaming path — re-run `add-manual-tracing`").
 
-## Self-Update (mandatory)
+## Self-Update
 
-**Before finishing, you MUST check whether this skill file needs updating.** This is not optional. If any of the following are true, update this file immediately:
+Before finishing, check whether this skill file needs updating. If any of the following are true, **propose the specific changes to the user** and only update this file if they approve:
 
 - You deviated from these instructions because they were inaccurate, outdated, or insufficient — and your deviation worked.
-- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path). Add it as a variant under the existing levels (A, B, or C) rather than introducing new levels.
+- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path).
 - File paths, function names, or API patterns referenced here have changed.
 - A step didn't work as described and needed a different approach.
 
-If nothing needed changing, move on. But do not skip this check.
+If nothing needed changing, move on.

--- a/.claude/skills/wire-into-lifespan/SKILL.md
+++ b/.claude/skills/wire-into-lifespan/SKILL.md
@@ -1,18 +1,22 @@
+---
+name: wire-into-lifespan
+description: Wires enable_tracing() into the FastAPI lifespan and adds manual trace wrapping imports to main.py.
+argument-hint: "<agent_path>"
+disable-model-invocation: true
+---
+
 # Wire Tracing into the FastAPI Lifespan
 
-> **Usage:** `/project:wire-into-lifespan <agent_path>`
-> **Example:** `/project:wire-into-lifespan agents/autogen/chat_agent`
+> **Usage:** `/wire-into-lifespan <agent_path>`
+> **Example:** `/wire-into-lifespan agents/autogen/chat_agent`
 
 You are connecting the `tracing.py` module to the agent's FastAPI app so that tracing is initialized at startup.
 
 ## Input
 
-You need:
-1. **Agent path**: The agent directory (e.g., `agents/autogen/chat_agent/`)
-2. **Package name**: The Python package name (e.g., `autogen_chat`)
-3. **Coverage level**: A, B, or C (from the autolog support report)
+The agent path is: $ARGUMENTS
 
-If any are missing, determine them by reading the agent's `pyproject.toml` and `src/` directory.
+You also need the **package name** and **coverage level** (A, B, or C). If not provided, determine them by reading the agent's `pyproject.toml` and `src/` directory.
 
 ## Steps
 
@@ -87,15 +91,15 @@ agent.run = wrap_func_with_mlflow_trace(agent.run, span_type="agent")
 #### Streaming path
 Check if `_handle_stream` in `main.py` creates the agent differently from `_handle_chat`. If it does (e.g., creates a new agent instance directly instead of using the closure), the wrapping must be duplicated in the streaming path.
 
-Reference: In the Vanilla Python agent, `_handle_stream` creates `AIAgent` directly and wraps tools + `agent.query` inside the `run_agent()` function. See `agents/vanilla_python/openai_responses_agent/main.py` lines 247-258.
+Reference: In the Vanilla Python agent, `_handle_stream` creates `AIAgent` directly and wraps tools + `agent.query` inside the `run_agent()` function. See `agents/vanilla_python/openai_responses_agent/main.py`, search for `def run_agent()`.
 
 ## Reference Files
 
 Read these to see the wiring patterns in practice:
-- `agents/vanilla_python/openai_responses_agent/main.py` — Level C wiring (import on line 13, `enable_tracing()` on line 124, streaming wrapping on lines 254-257)
-- `agents/langgraph/react_agent/main.py` — Level A wiring (import on line 17, `enable_tracing()` on line 120)
-- `agents/crewai/websearch_agent/main.py` — Level B wiring (import on line 17, `enable_tracing()` on line 153)
-- `agents/crewai/websearch_agent/src/crewai_web_search/crew.py` — Level B tool wrapping (lines 30-33)
+- `agents/vanilla_python/openai_responses_agent/main.py` — Level C wiring (search for `import enable_tracing`, `enable_tracing()` in `lifespan()`, and `run_agent()` in `_handle_stream`)
+- `agents/langgraph/react_agent/main.py` — Level A wiring (search for `import enable_tracing` and `enable_tracing()` in `lifespan()`)
+- `agents/crewai/websearch_agent/main.py` — Level B wiring (search for `import enable_tracing` and `enable_tracing()` in `lifespan()`)
+- `agents/crewai/websearch_agent/src/crewai_web_search/crew.py` — Level B tool wrapping (search for `wrap_func_with_mlflow_trace` in `ai_assistant()`)
 
 ## Final Checklist
 
@@ -105,13 +109,13 @@ Read these to see the wiring patterns in practice:
 - [ ] For Level B/C: Both streaming and non-streaming paths have wrapping applied
 - [ ] No MLflow imports are added directly to `main.py` — all MLflow interaction goes through `tracing.py`
 
-## Self-Update (mandatory)
+## Self-Update
 
-**Before finishing, you MUST check whether this skill file needs updating.** This is not optional. If any of the following are true, update this file immediately:
+Before finishing, check whether this skill file needs updating. If any of the following are true, **propose the specific changes to the user** and only update this file if they approve:
 
 - You deviated from these instructions because they were inaccurate, outdated, or insufficient — and your deviation worked.
-- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path). Add it as a variant under the existing levels (A, B, or C) rather than introducing new levels.
+- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path).
 - File paths, function names, or API patterns referenced here have changed.
 - A step didn't work as described and needed a different approach.
 
-If nothing needed changing, move on. But do not skip this check.
+If nothing needed changing, move on.

--- a/.claude/skills/wire-into-lifespan/SKILL.md
+++ b/.claude/skills/wire-into-lifespan/SKILL.md
@@ -1,0 +1,117 @@
+# Wire Tracing into the FastAPI Lifespan
+
+> **Usage:** `/project:wire-into-lifespan <agent_path>`
+> **Example:** `/project:wire-into-lifespan agents/autogen/chat_agent`
+
+You are connecting the `tracing.py` module to the agent's FastAPI app so that tracing is initialized at startup.
+
+## Input
+
+You need:
+1. **Agent path**: The agent directory (e.g., `agents/autogen/chat_agent/`)
+2. **Package name**: The Python package name (e.g., `autogen_chat`)
+3. **Coverage level**: A, B, or C (from the autolog support report)
+
+If any are missing, determine them by reading the agent's `pyproject.toml` and `src/` directory.
+
+## Steps
+
+### 1. Read the agent's `main.py`
+
+Read `<agent_path>/main.py` to understand:
+- The existing `lifespan()` function
+- How the agent is initialized (what global variables, closures, etc.)
+- Whether there's a streaming path that creates the agent differently from non-streaming
+
+### 2. Add the tracing import
+
+Add the import at the top of `main.py`, near the other package imports:
+
+**Level A (full autolog):**
+```python
+from <package_name>.tracing import enable_tracing
+```
+
+**Level B or C (needs manual wrapping):**
+```python
+from <package_name>.tracing import enable_tracing, wrap_func_with_mlflow_trace
+```
+
+### 3. Add `enable_tracing()` to the lifespan
+
+Add `enable_tracing()` as the **first call** inside the `lifespan()` async context manager, before any agent initialization:
+
+```python
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    enable_tracing()       # <-- ADD THIS LINE
+
+    # ... existing agent initialization code ...
+    yield
+    # ... existing cleanup code ...
+```
+
+This placement ensures tracing is configured before any autolog-patched code runs.
+
+### 4. Wire `wrap_func_with_mlflow_trace` (Level B and C only)
+
+Skip this step for Level A — autolog handles everything.
+
+For Level B/C, you need to wrap agent and tool functions with trace spans. **Where** you add the wrapping depends on how the agent initializes its components. Read the agent's code to find:
+
+#### Tool wrapping
+Find where tools are registered or instantiated. Wrap each tool's callable:
+
+**Pattern 1 — Tool objects with `_run` method (CrewAI-style, Level B):**
+```python
+# In crew.py or wherever tools are created
+tool._run = wrap_func_with_mlflow_trace(tool._run, span_type="tool", name=tool.name)
+```
+
+**Pattern 2 — Tool functions registered by name (Vanilla Python-style, Level C):**
+```python
+# In agent.py or main.py, wherever tools are registered
+func = wrap_func_with_mlflow_trace(func, span_type="tool")
+agent.register_tool(name, func)
+```
+
+#### Agent orchestration wrapping
+Find the main agent entry point (the function that runs the full agent loop) and wrap it:
+
+```python
+agent.query = wrap_func_with_mlflow_trace(agent.query, span_type="agent")
+# or
+agent.run = wrap_func_with_mlflow_trace(agent.run, span_type="agent")
+```
+
+#### Streaming path
+Check if `_handle_stream` in `main.py` creates the agent differently from `_handle_chat`. If it does (e.g., creates a new agent instance directly instead of using the closure), the wrapping must be duplicated in the streaming path.
+
+Reference: In the Vanilla Python agent, `_handle_stream` creates `AIAgent` directly and wraps tools + `agent.query` inside the `run_agent()` function. See `agents/vanilla_python/openai_responses_agent/main.py` lines 247-258.
+
+## Reference Files
+
+Read these to see the wiring patterns in practice:
+- `agents/vanilla_python/openai_responses_agent/main.py` — Level C wiring (import on line 13, `enable_tracing()` on line 124, streaming wrapping on lines 254-257)
+- `agents/langgraph/react_agent/main.py` — Level A wiring (import on line 17, `enable_tracing()` on line 120)
+- `agents/crewai/websearch_agent/main.py` — Level B wiring (import on line 17, `enable_tracing()` on line 153)
+- `agents/crewai/websearch_agent/src/crewai_web_search/crew.py` — Level B tool wrapping (lines 30-33)
+
+## Final Checklist
+
+- [ ] `enable_tracing()` is called **before** agent initialization in `lifespan()`
+- [ ] Import statement is at the top of `main.py` with other package imports
+- [ ] For Level B/C: `wrap_func_with_mlflow_trace` is imported
+- [ ] For Level B/C: Both streaming and non-streaming paths have wrapping applied
+- [ ] No MLflow imports are added directly to `main.py` — all MLflow interaction goes through `tracing.py`
+
+## Self-Update (mandatory)
+
+**Before finishing, you MUST check whether this skill file needs updating.** This is not optional. If any of the following are true, update this file immediately:
+
+- You deviated from these instructions because they were inaccurate, outdated, or insufficient — and your deviation worked.
+- You encountered a new pattern not covered here (e.g., a framework that uses OpenTelemetry instead of autolog, or a new provider path). Add it as a variant under the existing levels (A, B, or C) rather than introducing new levels.
+- File paths, function names, or API patterns referenced here have changed.
+- A step didn't work as described and needed a different approach.
+
+If nothing needed changing, move on. But do not skip this check.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ These are the files you need to create or update when adding tracing to your age
 
 **1. Create `src/<package>/tracing.py`**
 
-This module exports `enable_tracing()` (and `wrap_func_with_mlflow_trace()` if your framework's autolog doesn't cover everything). It handles health-checking the MLflow server with retry logic, configuring the experiment, enabling the correct autolog for your framework, and gracefully degrading if the server is unreachable. All MLflow imports must be lazy (inside functions, not at module top) so the agent starts cleanly without MLflow installed.
+This module exports `enable_tracing()` (and `wrap_func_with_mlflow_trace()` if your framework's autolog doesn't cover everything). It handles health-checking the MLflow server with retry logic, configuring the experiment, enabling the correct autolog for your framework, and gracefully degrading if the server is unreachable. MLflow imports are inside `enable_tracing()` (not at module top) so the module can be imported without MLflow installed — but if `MLFLOW_TRACKING_URI` is set and MLflow is missing, the agent will fail at startup with a clear error.
 
 See existing examples:
 - Full autolog (no manual wrapping needed): `agents/langgraph/react_agent/src/react_agent/tracing.py`
@@ -74,14 +74,18 @@ Add commented-out MLflow environment variable sections for both local and OpenSh
 
 Add tracing configuration examples (local and OpenShift), the `uv pip install "mlflow>=3.10.0"` install step (marked as optional), and the `mlflow server --port 5000` start step.
 
-**5. Do not add MLflow to `pyproject.toml`**
+**5. Add MLflow as an optional dependency in `pyproject.toml`**
 
-MLflow is installed manually by the user, not listed as a package dependency. This is because two different MLflow builds are used depending on the environment:
+MLflow is listed as an optional dependency under the `tracing` extra:
 
-- **Local development:** upstream MLflow (`uv pip install "mlflow>=3.10.0"`)
-- **RHOAI (Red Hat OpenAI):** Red Hat's own build (`uv pip install "git+https://github.com/red-hat-data-services/mlflow@rhoai-3.3"`)
+```toml
+[project.optional-dependencies]
+tracing = [
+    "mlflow>=3.10.0",
+]
+```
 
-The RHOAI build is not yet compatible with the upstream package, so both install paths must be supported. Listing MLflow in `pyproject.toml` would force one build and break the other. Instead, the README documents both install commands and users choose the one that matches their environment.
+This allows `make run` to auto-install MLflow when `MLFLOW_TRACKING_URI` is set (via `uv run --extra tracing`). MLflow is not a core dependency — agents run without it when tracing is disabled.
 
 ### Using the `integrate-tracing` Claude Code skill
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ Add commented-out MLflow environment variable sections for both local and OpenSh
 
 **4. Edit `README.md`**
 
-Add tracing configuration examples (local and OpenShift), the `uv pip install "mlflow>=3.10.0"` install step (marked as optional), and the `mlflow server --port 5000` start step.
+Add tracing configuration examples (local and OpenShift) and the `uv run --extra tracing mlflow server --port 5000` server start step.
 
 **5. Add MLflow as an optional dependency in `pyproject.toml`**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,13 +98,13 @@ If you have [Claude Code](https://docs.anthropic.com/en/docs/claude-code) set up
 
 #### Running the full integration
 
-```
+```text
 /project:integrate-tracing <framework> <agent_path>
 ```
 
 For example:
 
-```
+```text
 /project:integrate-tracing autogen agents/autogen/chat_agent
 ```
 
@@ -126,7 +126,7 @@ This single command runs the entire pipeline end-to-end. The skill always create
 
 Each step of the pipeline is also available as a standalone skill. This is useful if you want to run just one phase, re-run a step after a fix, or integrate tracing manually with some automation:
 
-```
+```text
 /project:check-autolog-support <framework>         # Research MLflow autolog support for a framework
 /project:create-tracing-module <agent_path>         # Create tracing.py only
 /project:wire-into-lifespan <agent_path>            # Wire tracing into main.py only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,16 +99,16 @@ If you have [Claude Code](https://docs.anthropic.com/en/docs/claude-code) set up
 #### Running the full integration
 
 ```text
-/project:integrate-tracing <framework> <agent_path>
+/integrate-tracing <framework> <agent_path>
 ```
 
 For example:
 
 ```text
-/project:integrate-tracing autogen agents/autogen/chat_agent
+/integrate-tracing autogen agents/autogen/chat_agent
 ```
 
-You can also prompt Claude Code directly (e.g., "integrate tracing into the autogen chat agent using the `/project:integrate-tracing` skill") and it will follow the same workflow.
+You can also prompt Claude Code directly (e.g., "integrate tracing into the autogen chat agent using the `/integrate-tracing` skill") and it will follow the same workflow.
 
 This single command runs the entire pipeline end-to-end. The skill always creates a demo copy of the agent first, implements and verifies tracing on the demo, and only applies the changes to the actual agent template once everything works correctly.
 
@@ -127,13 +127,13 @@ This single command runs the entire pipeline end-to-end. The skill always create
 Each step of the pipeline is also available as a standalone skill. This is useful if you want to run just one phase, re-run a step after a fix, or integrate tracing manually with some automation:
 
 ```text
-/project:check-autolog-support <framework>         # Research MLflow autolog support for a framework
-/project:create-tracing-module <agent_path>         # Create tracing.py only
-/project:wire-into-lifespan <agent_path>            # Wire tracing into main.py only
-/project:add-manual-tracing <agent_path>            # Add manual trace wrapping only
-/project:verify-traces <agent_path>                 # Run code review + live trace testing
-/project:review-tracing-code <agent_path>           # Code review only (no live testing)
-/project:test-tracing <agent_path>                  # Live trace testing only (no code review)
+/check-autolog-support <framework>         # Research MLflow autolog support for a framework
+/create-tracing-module <agent_path> [framework]  # Create tracing.py only
+/wire-into-lifespan <agent_path>            # Wire tracing into main.py only
+/add-manual-tracing <agent_path>            # Add manual trace wrapping only
+/verify-traces <agent_path>                 # Run code review + live trace testing
+/review-tracing-code <agent_path>           # Code review only (no live testing)
+/test-tracing <agent_path>                  # Live trace testing only (no code review)
 ```
 
 #### How the skill system works

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ This is optional but appreciated; maintainers may ask you to reword commits when
 
 ## Adding MLflow tracing to your agent template
 
-All agent templates in this repo must include MLflow tracing integration. Tracing lets users optionally capture LLM calls, tool executions, and agent orchestration spans in MLflow — it's opt-in via the `MLFLOW_TRACKING_URI` environment variable and must never prevent the agent from starting if MLflow is unavailable.
+All agent templates in this repo must include MLflow tracing integration. Tracing lets users optionally capture LLM calls, tool executions, and agent orchestration spans in MLflow — it's opt-in via the `MLFLOW_TRACKING_URI` environment variable. If `MLFLOW_TRACKING_URI` is set but the server is unreachable, the agent logs a warning and continues without tracing. Note: if `MLFLOW_TRACKING_URI` is set but the MLflow package is not installed, the agent will fail at startup with an `ImportError` — MLflow must be installed when the env var is set.
 
 Read [tracing.md](tracing.md) for the full tracing architecture, design principles, and how the existing agents integrate with MLflow. In particular, see the [Autolog Coverage Levels](tracing.md#autolog-coverage-levels) section — the amount of work required depends on whether your framework is Level A (full autolog), B (partial), or C (no framework autolog).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,105 @@ chore: bump python-dotenv in requirements
 
 This is optional but appreciated; maintainers may ask you to reword commits when preparing a release.
 
+## Adding MLflow tracing to your agent template
+
+All agent templates in this repo must include MLflow tracing integration. Tracing lets users optionally capture LLM calls, tool executions, and agent orchestration spans in MLflow — it's opt-in via the `MLFLOW_TRACKING_URI` environment variable and must never prevent the agent from starting if MLflow is unavailable.
+
+Read [tracing.md](tracing.md) for the full tracing architecture, design principles, and how the existing agents integrate with MLflow. In particular, see the [Autolog Coverage Levels](tracing.md#autolog-coverage-levels) section — the amount of work required depends on whether your framework is Level A (full autolog), B (partial), or C (no framework autolog).
+
+### What you need to do
+
+These are the files you need to create or update when adding tracing to your agent:
+
+**1. Create `src/<package>/tracing.py`**
+
+This module exports `enable_tracing()` (and `wrap_func_with_mlflow_trace()` if your framework's autolog doesn't cover everything). It handles health-checking the MLflow server with retry logic, configuring the experiment, enabling the correct autolog for your framework, and gracefully degrading if the server is unreachable. All MLflow imports must be lazy (inside functions, not at module top) so the agent starts cleanly without MLflow installed.
+
+See existing examples:
+- Full autolog (no manual wrapping needed): `agents/langgraph/react_agent/src/react_agent/tracing.py`
+- Partial autolog (tools need manual wrapping): `agents/crewai/websearch_agent/src/crewai_web_search/tracing.py`
+- No framework autolog (tools + agent entry point need manual wrapping): `agents/vanilla_python/openai_responses_agent/src/openai_responses_agent/tracing.py`
+
+**2. Edit `main.py`**
+
+Import `enable_tracing` and call it as the **first line** inside your `lifespan()` function, before any agent initialization. If your framework needs manual wrapping, also import `wrap_func_with_mlflow_trace` and wrap tool functions (`span_type="tool"`) and the agent entry point (`span_type="agent"`) — in both the streaming and non-streaming code paths.
+
+**3. Edit `.env.example`**
+
+Add commented-out MLflow environment variable sections for both local and OpenShift deployment (see any existing agent's `.env.example` for the format).
+
+**4. Edit `README.md`**
+
+Add tracing configuration examples (local and OpenShift), the `uv pip install "mlflow>=3.10.0"` install step (marked as optional), and the `mlflow server --port 5000` start step.
+
+**5. Do not add MLflow to `pyproject.toml`**
+
+MLflow is installed manually by the user, not listed as a package dependency. This is because two different MLflow builds are used depending on the environment:
+
+- **Local development:** upstream MLflow (`uv pip install "mlflow>=3.10.0"`)
+- **RHOAI (Red Hat OpenAI):** Red Hat's own build (`uv pip install "git+https://github.com/red-hat-data-services/mlflow@rhoai-3.3"`)
+
+The RHOAI build is not yet compatible with the upstream package, so both install paths must be supported. Listing MLflow in `pyproject.toml` would force one build and break the other. Instead, the README documents both install commands and users choose the one that matches their environment.
+
+### Using the `integrate-tracing` Claude Code skill
+
+If you have [Claude Code](https://docs.anthropic.com/en/docs/claude-code) set up, this repo includes a skill that automates the entire process described above.
+
+#### Prerequisites
+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and configured
+- Run Claude Code from the repo root so it discovers the skills in `.claude/skills/`
+
+#### Running the full integration
+
+```
+/project:integrate-tracing <framework> <agent_path>
+```
+
+For example:
+
+```
+/project:integrate-tracing autogen agents/autogen/chat_agent
+```
+
+You can also prompt Claude Code directly (e.g., "integrate tracing into the autogen chat agent using the `/project:integrate-tracing` skill") and it will follow the same workflow.
+
+This single command runs the entire pipeline end-to-end. The skill always creates a demo copy of the agent first, implements and verifies tracing on the demo, and only applies the changes to the actual agent template once everything works correctly.
+
+1. Researches your framework's MLflow autolog support and classifies it (Level A/B/C)
+2. Creates a demo copy of the agent with test tools for trace verification
+3. Reads the agent's code to understand its architecture
+4. Creates `tracing.py` with the correct pattern for the autolog level
+5. Wires `enable_tracing()` into the FastAPI lifespan in `main.py`
+6. Adds manual trace wrapping for tools and agent entry points (skipped if autolog covers everything)
+7. Verifies traces end-to-end — code review + live testing against the MLflow API
+8. Updates `.env.example` with MLflow environment variables
+9. Updates `README.md` with tracing configuration and install steps
+
+#### Running individual sub-skills
+
+Each step of the pipeline is also available as a standalone skill. This is useful if you want to run just one phase, re-run a step after a fix, or integrate tracing manually with some automation:
+
+```
+/project:check-autolog-support <framework>         # Research MLflow autolog support for a framework
+/project:create-tracing-module <agent_path>         # Create tracing.py only
+/project:wire-into-lifespan <agent_path>            # Wire tracing into main.py only
+/project:add-manual-tracing <agent_path>            # Add manual trace wrapping only
+/project:verify-traces <agent_path>                 # Run code review + live trace testing
+/project:review-tracing-code <agent_path>           # Code review only (no live testing)
+/project:test-tracing <agent_path>                  # Live trace testing only (no code review)
+```
+
+#### How the skill system works
+
+`integrate-tracing` is an orchestrator — it doesn't contain all the logic itself. Instead, it coordinates 7 specialized sub-skills in sequence, passing context between them. The most important piece of context is the **autolog level** (A, B, or C), which is determined in Step 1 by `check-autolog-support` and drives every decision downstream: what code `create-tracing-module` generates, what `wire-into-lifespan` imports, whether `add-manual-tracing` runs at all, and what spans `verify-traces` expects to find.
+
+`verify-traces` is itself a sub-orchestrator — it calls `review-tracing-code` (static analysis) and `test-tracing` (live end-to-end testing) and combines their results into a single report. If verification fails, the report points back to which step to revisit.
+
+All skills live as siblings in `.claude/skills/` (not nested under `integrate-tracing/`) because Claude Code discovers skills by scanning `.claude/skills/*/SKILL.md`. The flat structure also makes each sub-skill independently callable. If you need to maintain or extend a skill, edit the `SKILL.md` file in its directory. Each skill includes a self-update instruction — if Claude deviates from a skill's steps because they were inaccurate, it updates the skill file automatically so the next run benefits.
+
+**Recommended model:** These skills were developed and tested with `claude-opus-4-6`. Use Opus for best results — smaller models may not follow the multi-step orchestration reliably.
+
 ## Questions?
 
 See the main [README](README.md) or open an issue. You can also contact [wrebisz@redhat.com](mailto:wrebisz@redhat.com) or [tguzik@redhat.com](mailto:tguzik@redhat.com).

--- a/tracing.md
+++ b/tracing.md
@@ -143,6 +143,7 @@ This agent has no framework-level orchestration, so autolog only captures raw Op
   ```
 
 **Resulting spans:**
+
 | Span Name | Type | Source |
 |---|---|---|
 | `query` | AGENT | Manual (`wrap_func_with_mlflow_trace`) |
@@ -157,6 +158,7 @@ This agent has no framework-level orchestration, so autolog only captures raw Op
 LangChain's autolog captures the full execution graph including LLM calls, tool calls, and agent orchestration. Works with both `ainvoke` (non-streaming) and `astream_events` (streaming).
 
 **Resulting spans:**
+
 | Span Name | Type | Source |
 |---|---|---|
 | `LangGraph` | CHAIN | `mlflow.langchain.autolog()` |
@@ -174,6 +176,7 @@ No `LLM_PROVIDER` env var needed — `ChatOpenAI` is a LangChain component and i
 LlamaIndex's autolog captures the full workflow including agent runs, LLM chats, and tool calls.
 
 **Resulting spans:**
+
 | Span Name | Type | Source |
 |---|---|---|
 | `FunctionCallingAgent.run` | CHAIN | `mlflow.llama_index.autolog()` |
@@ -217,6 +220,7 @@ The `LLM_PROVIDER` env var controls which autolog is enabled:
 - `openai/my-custom-model` (unrecognized) -> base `LLM` class (LiteLLM fallback)
 
 **Resulting spans:**
+
 | Span Name | Type | Source |
 |---|---|---|
 | `CrewAI` | AGENT | `mlflow.crewai.autolog()` |
@@ -262,6 +266,7 @@ trace.set_tracer_provider(provider)
 The `TracerProvider` must be set **before** any ADK components are used (i.e., `enable_tracing()` is called first in the lifespan, before `get_runner()`).
 
 **Resulting spans:**
+
 | Span Name | Type | Source |
 |---|---|---|
 | `invocation` | — | ADK OTel (top-level request) |

--- a/tracing.md
+++ b/tracing.md
@@ -89,7 +89,7 @@ Polls `{mlflow_tracking_uri}/health` with retry logic. Raises `RuntimeError` if 
 
 ### Startup Flow
 
-```
+```text
 FastAPI lifespan start
   |
   v
@@ -329,7 +329,7 @@ MLFLOW_WORKSPACE="default"
 
 Every agent's traces consist of up to three layers. Which layers are present depends on the framework:
 
-```
+```text
 +--------------------------------------------------+
 |  Layer 3: Agent Orchestration                     |
 |  (Agent loop, Tasks, Crew)                        |

--- a/tracing.md
+++ b/tracing.md
@@ -1,0 +1,475 @@
+# MLflow Tracing Integration
+
+This document covers how MLflow tracing is integrated into the agent templates in this repository: how it works, how it differs per framework, how to configure it, how to test it, and known issues.
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Design Principles](#design-principles)
+- [Architecture](#architecture)
+  - [Tracing Module (`tracing.py`)](#tracing-module-tracingpy)
+  - [Startup Flow](#startup-flow)
+  - [Graceful Degradation](#graceful-degradation)
+- [Framework-Specific Integration](#framework-specific-integration)
+  - [Vanilla Python (OpenAI Responses)](#vanilla-python-openai-responses)
+  - [LangGraph](#langgraph)
+  - [LlamaIndex](#llamaindex)
+  - [CrewAI](#crewai)
+- [Configuration](#configuration)
+  - [Environment Variables](#environment-variables)
+  - [Local Setup](#local-setup)
+  - [OpenShift Cluster Setup](#openshift-cluster-setup)
+- [Tracing Layers](#tracing-layers)
+- [Testing Tracing](#testing-tracing)
+  - [Pre-Test Checklist](#pre-test-checklist)
+  - [Step-by-Step Verification](#step-by-step-verification)
+  - [What to Verify in Traces](#what-to-verify-in-traces)
+- [Google ADK](#google-adk)
+- [Known Issues & Gotchas](#known-issues--gotchas)
+
+---
+
+## Overview
+
+Each agent template optionally integrates with [MLflow](https://mlflow.org/) for tracing LLM calls, tool executions, and agent orchestration. Tracing is **opt-in**: if `MLFLOW_TRACKING_URI` is not set, the agent runs normally without any MLflow dependency.
+
+MLflow is intentionally **not listed** as a dependency in any agent's `pyproject.toml`. Users install it manually:
+
+```bash
+# Local development
+uv pip install "mlflow>=3.10.0"
+
+# OpenShift (RHOAI 3.2/3.3)
+uv pip install "git+https://github.com/red-hat-data-services/mlflow@rhoai-3.3"
+```
+
+This keeps the agent packages lightweight and avoids forcing MLflow on users who don't need tracing.
+
+---
+
+## Design Principles
+
+1. **Opt-in by environment variable** — `MLFLOW_TRACKING_URI` is the single switch. No code changes needed to enable/disable tracing.
+2. **Graceful degradation** — If the MLflow server is unreachable at startup, the agent logs a warning and continues without tracing. The agent never crashes due to tracing.
+3. **Lazy imports** — `import mlflow` only happens inside `enable_tracing()` and `wrap_func_with_mlflow_trace()`, so the agent starts cleanly even if MLflow is not installed.
+4. **Framework-native auto-tracing where possible** — Most frameworks have an MLflow autolog integration (`mlflow.langchain`, `mlflow.llama_index`, `mlflow.crewai`, `mlflow.openai`) that automatically captures spans. Some frameworks (Google ADK) natively emit OpenTelemetry spans instead, which MLflow ingests via OTLP.
+5. **Manual tracing only where auto-tracing falls short** — Manual `wrap_func_with_mlflow_trace()` is used only where autolog doesn't capture what's needed (e.g., Vanilla Python agent orchestration, CrewAI tool spans).
+
+---
+
+## Architecture
+
+### Tracing Module (`tracing.py`)
+
+Every agent has a `tracing.py` module at `src/<package_name>/tracing.py` that exports two main functions:
+
+#### `enable_tracing()`
+
+Called once during FastAPI `lifespan` startup. Responsible for:
+1. Loading `.env` via `load_dotenv()`
+2. Checking if `MLFLOW_TRACKING_URI` is set (if not, tracing is skipped)
+3. Health-checking the MLflow server with retry logic
+4. Configuring MLflow: `set_tracking_uri()`, `set_experiment()`, `enable_async_logging()`
+5. Enabling framework-specific autolog (the **only part that differs** between agents)
+
+#### `wrap_func_with_mlflow_trace(func, span_type, name=None)`
+
+Wraps a callable with `mlflow.trace()` to create a named span. Used for manual tracing where autolog doesn't cover. Returns the original function unchanged if `MLFLOW_TRACKING_URI` is not set.
+
+- `span_type="tool"` creates a `SpanType.TOOL` span
+- `span_type="agent"` creates a `SpanType.AGENT` span
+
+Only present in agents that need manual tracing (Vanilla Python and CrewAI). LangGraph and LlamaIndex rely entirely on autolog.
+
+#### `check_mlflow_health(mlflow_tracking_uri, max_wait_time, retry_interval)`
+
+Polls `{mlflow_tracking_uri}/health` with retry logic. Raises `RuntimeError` if the server is unreachable after `max_wait_time` seconds. The timeout for each individual HTTP request is capped at `min(5, remaining_budget)` to respect the overall time budget.
+
+### Startup Flow
+
+```
+FastAPI lifespan start
+  |
+  v
+enable_tracing()
+  |
+  +-- MLFLOW_TRACKING_URI not set? --> log info, return (tracing disabled)
+  |
+  +-- Health check MLflow server (retry for MLFLOW_HEALTH_CHECK_TIMEOUT seconds)
+  |     |
+  |     +-- Server unreachable? --> log warning, return (tracing disabled, agent continues)
+  |     |
+  |     +-- Server reachable? --> continue
+  |
+  +-- mlflow.set_tracking_uri(...)
+  +-- mlflow.set_experiment(...)
+  +-- mlflow.config.enable_async_logging()
+  +-- mlflow.<framework>.autolog()     <-- framework-specific
+  |
+  v
+Agent initialization (get_agent_closure / get_graph_closure / etc.)
+```
+
+### Graceful Degradation
+
+The tracing system is designed to never prevent the agent from starting:
+
+| Scenario | Behavior |
+|---|---|
+| `MLFLOW_TRACKING_URI` not set | Tracing silently disabled. No MLflow imports. |
+| `MLFLOW_TRACKING_URI` set but server unreachable | Warning logged, tracing disabled, agent starts normally. |
+| `MLFLOW_TRACKING_URI` set and server reachable | Tracing fully enabled. |
+| MLflow package not installed but `MLFLOW_TRACKING_URI` set | `ImportError` will occur. MLflow must be installed if the env var is set. |
+
+---
+
+## Framework-Specific Integration
+
+### Vanilla Python (OpenAI Responses)
+
+**Autolog:** `mlflow.openai.autolog()`
+**Manual tracing:** Yes (`wrap_func_with_mlflow_trace` for agent + tool spans)
+
+This agent has no framework-level orchestration, so autolog only captures raw OpenAI `responses.create()` calls. Manual wrapping adds the orchestration layer:
+
+**Non-streaming (`_handle_chat` in `main.py`):**
+- `_AIAgentAdapter.run()` in `agent.py` wraps `agent.query()` with `span_type="agent"` and each tool function with `span_type="tool"`
+
+**Streaming (`_handle_stream` in `main.py`):**
+- Creates `AIAgent` directly (bypasses `_AIAgentAdapter`) and manually applies the same wrapping:
+  ```python
+  for name, func in adapter._tools:
+      func = wrap_func_with_mlflow_trace(func, span_type="tool")
+      agent.register_tool(name, func)
+  agent.query = wrap_func_with_mlflow_trace(agent.query, span_type="agent")
+  ```
+
+**Resulting spans:**
+| Span Name | Type | Source |
+|---|---|---|
+| `query` | AGENT | Manual (`wrap_func_with_mlflow_trace`) |
+| `Responses` | CHAT_MODEL | `mlflow.openai.autolog()` (one per LLM call in the ReAct loop) |
+| `search_price`, `search_reviews` | TOOL | Manual (`wrap_func_with_mlflow_trace`) |
+
+### LangGraph
+
+**Autolog:** `mlflow.langchain.autolog()`
+**Manual tracing:** None needed
+
+LangChain's autolog captures the full execution graph including LLM calls, tool calls, and agent orchestration. Works with both `ainvoke` (non-streaming) and `astream_events` (streaming).
+
+**Resulting spans:**
+| Span Name | Type | Source |
+|---|---|---|
+| `LangGraph` | CHAIN | `mlflow.langchain.autolog()` |
+| `ChatOpenAI` | CHAT_MODEL | `mlflow.langchain.autolog()` |
+| `tools` | CHAIN | `mlflow.langchain.autolog()` |
+| `dummy_web_search` | TOOL | `mlflow.langchain.autolog()` |
+
+No `LLM_PROVIDER` env var needed — `ChatOpenAI` is a LangChain component and is fully traced by langchain autolog regardless of the underlying `base_url`.
+
+### LlamaIndex
+
+**Autolog:** `mlflow.llama_index.autolog()`
+**Manual tracing:** None needed
+
+LlamaIndex's autolog captures the full workflow including agent runs, LLM chats, and tool calls.
+
+**Resulting spans:**
+| Span Name | Type | Source |
+|---|---|---|
+| `FunctionCallingAgent.run` | CHAIN | `mlflow.llama_index.autolog()` |
+| `OpenAILike.achat` | CHAT_MODEL | `mlflow.llama_index.autolog()` |
+| `FunctionTool` | TOOL | `mlflow.llama_index.autolog()` |
+
+No `LLM_PROVIDER` env var needed — `OpenAILike` is a LlamaIndex component, fully traced.
+
+### CrewAI
+
+**Autolog:** `mlflow.crewai.autolog()` + provider-specific autolog
+**Manual tracing:** Yes (tool `_run` methods in `crew.py`)
+
+CrewAI is the most complex integration because it has two layers that need separate autologs:
+
+#### Layer 1: Orchestration (`mlflow.crewai.autolog()`)
+Captures Crew, Task, and Agent spans. However, in newer CrewAI versions (>=1.10), **tool spans are not captured by autolog**. This is why tools are manually wrapped in `crew.py`:
+
+```python
+# crew.py
+for tool in tools:
+    tool._run = wrap_func_with_mlflow_trace(tool._run, span_type="tool", name=tool.name)
+```
+
+#### Layer 2: LLM calls (provider-specific autolog)
+CrewAI has a factory pattern (`LLM.__new__`) that routes to different provider backends. Native providers (OpenAI, Anthropic, Gemini, Azure, Bedrock) bypass the `crewai.LLM.call` method that `mlflow.crewai.autolog()` patches, so a second provider-specific autolog is needed.
+
+The `LLM_PROVIDER` env var controls which autolog is enabled:
+
+| `LLM_PROVIDER` | Autolog Module | When to Use |
+|---|---|---|
+| `litellm` (default) | `mlflow.litellm` | Non-native models going through LiteLLM fallback |
+| `openai` | `mlflow.openai` | Native OpenAI models (e.g., `gpt-4o-mini`) |
+| `anthropic` | `mlflow.anthropic` | Native Anthropic models |
+| `gemini` | `mlflow.gemini` | Native Google Gemini models |
+| `azure` | `mlflow.openai` | Azure OpenAI models |
+| `bedrock` | `mlflow.bedrock` | AWS Bedrock models |
+
+**How the factory pattern determines the provider path:**
+- `openai/gpt-4o-mini` (recognized model) -> `OpenAICompletion` (native, bypasses `LLM.call`)
+- `openai/my-custom-model` (unrecognized) -> base `LLM` class (LiteLLM fallback)
+
+**Resulting spans:**
+| Span Name | Type | Source |
+|---|---|---|
+| `CrewAI` | AGENT | `mlflow.crewai.autolog()` |
+| `Task` | CHAIN | `mlflow.crewai.autolog()` |
+| `Agent` | AGENT | `mlflow.crewai.autolog()` |
+| `WebSearchTool` | TOOL | Manual (`wrap_func_with_mlflow_trace` in `crew.py`) |
+| `Completions` or `litellm-completion` | CHAT_MODEL / LLM | Provider-specific autolog |
+
+### Google ADK
+
+**Autolog:** None — uses OpenTelemetry-based auto-tracing
+**Manual tracing:** None needed
+
+Google ADK is architecturally unique among the agents in this repo. There is no `mlflow.google_adk.autolog()` module. Instead, ADK natively emits OpenTelemetry spans for agent runs, tool calls, and model requests. We configure an OTLP exporter to forward those spans to the MLflow tracking server.
+
+This makes it **Level A** in terms of coverage (all three layers captured automatically), but the mechanism is different from LangGraph/LlamaIndex which use `mlflow.<framework>.autolog()`.
+
+#### Setup Differences
+
+1. **OpenTelemetry exporter required**: `tracing.py` sets up a `TracerProvider` with an `OTLPSpanExporter` pointing at `{tracking_uri}/v1/traces`, instead of calling an autolog function.
+2. **SQL backend required**: The MLflow server must be started with `--backend-store-uri sqlite:///mlflow.db` (or another SQL store). File-based backend stores do not support OTLP ingestion.
+3. **Extra package**: `opentelemetry-exporter-otlp-proto-http` must be installed alongside MLflow.
+4. **Experiment ID header**: The OTLP exporter sends the experiment ID via the `x-mlflow-experiment-id` HTTP header, which is obtained from `mlflow.set_experiment()`.
+
+#### How It Works
+
+```python
+# In enable_tracing() — instead of mlflow.<framework>.autolog()
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+exporter = OTLPSpanExporter(
+    endpoint=f"{tracking_uri}/v1/traces",
+    headers={"x-mlflow-experiment-id": experiment.experiment_id},
+)
+provider = TracerProvider()
+provider.add_span_processor(SimpleSpanProcessor(exporter))
+trace.set_tracer_provider(provider)
+```
+
+The `TracerProvider` must be set **before** any ADK components are used (i.e., `enable_tracing()` is called first in the lifespan, before `get_runner()`).
+
+**Resulting spans:**
+| Span Name | Type | Source |
+|---|---|---|
+| `invocation` | — | ADK OTel (top-level request) |
+| `invoke_agent adk_agent` | AGENT | ADK OTel |
+| `generate_content openai/<model>` | LLM | ADK OTel |
+| `call_llm` | LLM | ADK OTel |
+| `execute_tool search_price` | TOOL | ADK OTel |
+
+No `LLM_PROVIDER` env var needed — ADK traces LLM calls through its own instrumentation regardless of the underlying model connector (LiteLLM, Gemini, etc.).
+
+---
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `MLFLOW_TRACKING_URI` | *(unset)* | MLflow server URL. Setting this enables tracing. |
+| `MLFLOW_EXPERIMENT_NAME` | `default-agent-experiment` | Experiment name for organizing traces. |
+| `MLFLOW_HEALTH_CHECK_TIMEOUT` | `5` | Seconds to wait for MLflow server at startup. |
+| `MLFLOW_HTTP_REQUEST_TIMEOUT` | `120` (MLflow default) | Timeout for MLflow HTTP requests during operation. |
+| `MLFLOW_HTTP_REQUEST_MAX_RETRIES` | MLflow default | Max retries for MLflow HTTP requests. |
+| `LLM_PROVIDER` | `litellm` | **CrewAI only.** Which provider autolog to enable. |
+| `MLFLOW_TRACKING_TOKEN` | *(unset)* | **OpenShift only.** Auth token for MLflow on OpenShift. |
+| `MLFLOW_TRACKING_INSECURE_TLS` | *(unset)* | **OpenShift only.** Set `"true"` for self-signed certs. |
+| `MLFLOW_WORKSPACE` | *(unset)* | **OpenShift only.** Project/workspace name. |
+| `MLFLOW_TRACKING_AUTH` | *(unset)* | **OpenShift only.** Use K8s service account auth. |
+
+### Local Setup
+
+Add to your agent's `.env` file:
+
+```ini
+MLFLOW_TRACKING_URI="http://localhost:5000"
+MLFLOW_EXPERIMENT_NAME="My Agent Experiment"
+MLFLOW_HEALTH_CHECK_TIMEOUT=5
+MLFLOW_HTTP_REQUEST_TIMEOUT=2
+MLFLOW_HTTP_REQUEST_MAX_RETRIES=0
+```
+
+Start the MLflow server:
+
+```bash
+mlflow server --port 5000
+```
+
+### OpenShift Cluster Setup
+
+```ini
+MLFLOW_TRACKING_URI="https://<openshift-dashboard-url>/mlflow"
+MLFLOW_TRACKING_TOKEN="<your-openshift-token>"
+MLFLOW_EXPERIMENT_NAME="<your-experiment-name>"
+MLFLOW_TRACKING_INSECURE_TLS="true"
+MLFLOW_WORKSPACE="default"
+```
+
+---
+
+## Tracing Layers
+
+Every agent's traces consist of up to three layers. Which layers are present depends on the framework:
+
+```
++--------------------------------------------------+
+|  Layer 3: Agent Orchestration                     |
+|  (Agent loop, Tasks, Crew)                        |
+|  Source: framework autolog or manual wrapping      |
+|                                                    |
+|  +----------------------------------------------+ |
+|  |  Layer 2: Tool Execution                     | |
+|  |  (search_price, dummy_web_search, etc.)      | |
+|  |  Source: framework autolog or manual wrapping | |
+|  |                                               | |
+|  |  +------------------------------------------+| |
+|  |  |  Layer 1: LLM Calls                      || |
+|  |  |  (responses.create, chat.completions)     || |
+|  |  |  Source: provider autolog                 || |
+|  |  +------------------------------------------+| |
+|  +----------------------------------------------+ |
++--------------------------------------------------+
+```
+
+| Framework | Layer 1 (LLM) | Layer 2 (Tools) | Layer 3 (Orchestration) |
+|---|---|---|---|
+| **Vanilla Python** | `mlflow.openai.autolog()` | Manual wrapping | Manual wrapping |
+| **LangGraph** | `mlflow.langchain.autolog()` | Same autolog | Same autolog |
+| **LlamaIndex** | `mlflow.llama_index.autolog()` | Same autolog | Same autolog |
+| **CrewAI** | Provider-specific autolog | Manual wrapping | `mlflow.crewai.autolog()` |
+| **Google ADK** | ADK OTel auto-tracing | ADK OTel auto-tracing | ADK OTel auto-tracing |
+
+### Autolog Coverage Levels
+
+The amount of tracing code required for a new agent depends on how well MLflow's autolog supports the framework. We classify frameworks into three levels:
+
+**Level A — Full auto-tracing.** All three layers are captured automatically with no manual wrapping needed. `tracing.py` only contains `enable_tracing()` and no `wrap_func_with_mlflow_trace()` function. There are two variants:
+- **Autolog variant**: `mlflow.<framework>.autolog()` captures everything. Examples: LangGraph (`mlflow.langchain`), LlamaIndex (`mlflow.llama_index`).
+- **OpenTelemetry variant**: The framework natively emits OTel spans; `tracing.py` sets up an OTLP exporter to forward them to MLflow. Requires a SQL-based MLflow backend and `opentelemetry-exporter-otlp-proto-http`. Example: Google ADK.
+
+**Level B — Partial autolog.** `mlflow.<framework>.autolog()` exists but misses one or more layers (typically tool spans). `tracing.py` includes both `enable_tracing()` (with framework + provider autologs) and `wrap_func_with_mlflow_trace()`. Tool functions are wrapped manually in the agent's code. Example in this repo: CrewAI — `mlflow.crewai.autolog()` captures orchestration but not tool spans, and a separate provider autolog is needed for LLM calls.
+
+**Level C — No framework autolog.** No `mlflow.<framework>` module exists. `tracing.py` includes `enable_tracing()` (with provider autolog only) and `wrap_func_with_mlflow_trace()`. Both tool functions and the agent entry point must be wrapped manually. Example in this repo: Vanilla Python — only `mlflow.openai.autolog()` is available for LLM calls.
+
+| Level | `enable_tracing()` | `wrap_func_with_mlflow_trace()` | Manual wrapping needed for |
+|-------|--------------------|---------------------------------|---------------------------|
+| A | Framework autolog | Not created | Nothing |
+| B | Framework + provider autolog | Created | Tools |
+| C | Provider autolog only | Created | Tools + agent entry point |
+
+To check a new framework's level, search the [MLflow autolog integrations page](https://mlflow.org/docs/latest/genai/tracing/integrations/).
+
+---
+
+## Testing Tracing
+
+### Pre-Test Checklist
+
+1. **Agent tools**: Read `crew.py` / `agent.py` / `tools.py` to understand available tools and their dummy responses. Craft test messages that will trigger tool calls.
+2. **Experiment name**: Check `.env` for `MLFLOW_EXPERIMENT_NAME`.
+3. **App port**: Confirm the port (default 8000).
+4. **MLflow URL**: Confirm MLflow server URL (default `http://localhost:5000`).
+5. **LLM provider** (CrewAI only): Check `LLM_PROVIDER` in `.env`.
+
+### Step-by-Step Verification
+
+**1. Send a request to the agent:**
+
+```bash
+# Non-streaming
+curl -s -X POST http://localhost:8000/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"messages": [{"role": "user", "content": "How much does a Lenovo laptop cost?"}], "stream": false}' | python3 -m json.tool
+
+# Streaming
+curl -s -X POST http://localhost:8000/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"messages": [{"role": "user", "content": "How much does a Lenovo laptop cost?"}], "stream": true}'
+```
+
+**2. Get experiment ID:**
+
+```bash
+curl -s "http://localhost:5000/api/2.0/mlflow/experiments/get-by-name?experiment_name=<NAME>" \
+  | python3 -m json.tool
+```
+
+**3. Get latest trace metadata:**
+
+```bash
+curl -s "http://localhost:5000/api/2.0/mlflow/traces?experiment_ids=<ID>&max_results=1" \
+  | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+t = data['traces'][0]
+meta = {m['key']: m['value'] for m in t['request_metadata']}
+print('Trace:', t['request_id'])
+print('Spans:', json.loads(meta.get('mlflow.trace.sizeStats', '{}')).get('num_spans'))
+print('Tokens:', meta.get('mlflow.trace.tokenUsage'))
+"
+```
+
+**4. Inspect individual spans:**
+
+```python
+import mlflow
+mlflow.set_tracking_uri("http://localhost:5000")
+trace = mlflow.get_trace("<trace-id>")
+for span in trace.search_spans():
+    print(f"  {span.name} (type: {span.span_type})")
+```
+
+### What to Verify in Traces
+
+- **Orchestration spans** exist (agent/crew/graph level)
+- **Tool spans** appear with correct names and inputs/outputs
+- **LLM spans** capture the model calls with content
+- **Token usage** appears in trace metadata (if LLM spans are captured)
+- **Single trace per request** — all spans grouped under one trace, not scattered across multiple
+- **Streaming and non-streaming produce equivalent traces** (same span structure)
+
+---
+
+## Known Issues & Gotchas
+
+### CrewAI: Tool spans not captured by autolog (>=1.10)
+`mlflow.crewai.autolog()` does not capture tool spans in newer CrewAI versions. Tools are manually wrapped in `crew.py` via `wrap_func_with_mlflow_trace(tool._run, span_type="tool", name=tool.name)`. If a future CrewAI/MLflow version fixes this, remove the manual wrapping to avoid duplicate spans.
+
+### CrewAI: Native providers bypass `LLM.call` patch
+CrewAI's `LLM.__new__` factory returns provider-specific subclasses (`OpenAICompletion`, `AnthropicCompletion`, etc.) that inherit from `BaseLLM`, not `LLM`. Since `mlflow.crewai.autolog()` patches `crewai.LLM.call`, these native subclasses bypass the patch entirely. This is why a separate provider-specific autolog (`mlflow.openai.autolog()`, etc.) is required via the `LLM_PROVIDER` env var.
+
+### CrewAI: Hardcoded `openai/` prefix
+`main.py` hardcodes `model=f"openai/{model_id}"`, which means CrewAI's factory decides the provider path based on whether it recognizes the model name — not user intent. `openai/gpt-4o-mini` goes native OpenAI; `openai/my-custom-model` falls back to LiteLLM. Users who want to use non-OpenAI providers need to edit `main.py`.
+
+### Vanilla Python: Streaming required a separate tracing fix
+The streaming path (`_handle_stream`) creates `AIAgent` directly rather than going through `_AIAgentAdapter.run()`. Without explicit wrapping, `mlflow.openai.autolog()` creates separate traces per `responses.create()` call instead of grouping them under a single agent span. The fix manually applies `wrap_func_with_mlflow_trace` in the streaming path. This is specific to the Vanilla Python agent — LangGraph and LlamaIndex handle streaming tracing natively via their autologs.
+
+### LangGraph/LlamaIndex: Empty `content` on tool call messages
+When the LLM makes a function call, the `AIMessage.content` is empty (the call info is in `tool_calls`). This appears in traces as tool-call spans with no content text. This is correct function-calling API behavior, not a tracing issue.
+
+### Google ADK: Requires SQL-based MLflow backend
+Google ADK's tracing uses OpenTelemetry OTLP ingestion, which is only supported with SQL-based backend stores (SQLite, PostgreSQL, MySQL). The default file-based backend (`mlflow server --port 5000`) does not work. Start with `mlflow server --backend-store-uri sqlite:///mlflow.db --port 5000`. This only affects Google ADK — all other agents work with file-based backends.
+
+### Google ADK: Extra package required for tracing
+In addition to MLflow, Google ADK tracing requires `opentelemetry-exporter-otlp-proto-http` to be installed. Without it, `enable_tracing()` will log a warning (`"MLflow or OpenTelemetry packages not installed"`) and continue without tracing.
+
+### MLflow must be installed if `MLFLOW_TRACKING_URI` is set
+The tracing code uses lazy imports (`import mlflow` inside functions), so the agent starts fine without MLflow installed. But if `MLFLOW_TRACKING_URI` is set, `enable_tracing()` will `import mlflow` and fail with `ImportError` if the package isn't installed. The agent will crash at startup in this case.

--- a/tracing.md
+++ b/tracing.md
@@ -35,25 +35,21 @@ This document covers how MLflow tracing is integrated into the agent templates i
 
 Each agent template optionally integrates with [MLflow](https://mlflow.org/) for tracing LLM calls, tool executions, and agent orchestration. Tracing is **opt-in**: if `MLFLOW_TRACKING_URI` is not set, the agent runs normally without any MLflow dependency.
 
-MLflow is intentionally **not listed** as a dependency in any agent's `pyproject.toml`. Users install it manually:
+MLflow is listed as an **optional dependency** in each agent's `pyproject.toml` under a `tracing` extra. When `MLFLOW_TRACKING_URI` is set, `make run` auto-installs it via `uv run --extra tracing`. Users can also start the MLflow server with:
 
 ```bash
-# Local development
-uv pip install "mlflow>=3.10.0"
-
-# OpenShift (RHOAI 3.2/3.3)
-uv pip install "git+https://github.com/red-hat-data-services/mlflow@rhoai-3.3"
+uv run --extra tracing mlflow server --port 5000
 ```
 
-This keeps the agent packages lightweight and avoids forcing MLflow on users who don't need tracing.
+This keeps MLflow out of the core dependencies — agents run without it when tracing is disabled.
 
 ---
 
 ## Design Principles
 
 1. **Opt-in by environment variable** — `MLFLOW_TRACKING_URI` is the single switch. No code changes needed to enable/disable tracing.
-2. **Graceful degradation** — If the MLflow server is unreachable at startup, the agent logs a warning and continues without tracing. The agent never crashes due to tracing.
-3. **Lazy imports** — `import mlflow` only happens inside `enable_tracing()` and `wrap_func_with_mlflow_trace()`, so the agent starts cleanly even if MLflow is not installed.
+2. **Graceful degradation** — If the MLflow server is unreachable at startup, the agent logs a warning and continues without tracing.
+3. **Fail-fast on missing package** — If `MLFLOW_TRACKING_URI` is set but MLflow is not installed, the agent fails at startup with a clear error. MLflow imports are inside `enable_tracing()` (not at module top) so the module can be imported without MLflow — but once tracing is requested, the package must be present.
 4. **Framework-native auto-tracing where possible** — Most frameworks have an MLflow autolog integration (`mlflow.langchain`, `mlflow.llama_index`, `mlflow.crewai`, `mlflow.openai`) that automatically captures spans. Some frameworks (Google ADK) natively emit OpenTelemetry spans instead, which MLflow ingests via OTLP.
 5. **Manual tracing only where auto-tracing falls short** — Manual `wrap_func_with_mlflow_trace()` is used only where autolog doesn't capture what's needed (e.g., Vanilla Python agent orchestration, CrewAI tool spans).
 
@@ -472,4 +468,4 @@ Google ADK's tracing uses OpenTelemetry OTLP ingestion, which is only supported 
 In addition to MLflow, Google ADK tracing requires `opentelemetry-exporter-otlp-proto-http` to be installed. Without it, `enable_tracing()` will log a warning (`"MLflow or OpenTelemetry packages not installed"`) and continue without tracing.
 
 ### MLflow must be installed if `MLFLOW_TRACKING_URI` is set
-The tracing code uses lazy imports (`import mlflow` inside functions), so the agent starts fine without MLflow installed. But if `MLFLOW_TRACKING_URI` is set, `enable_tracing()` will `import mlflow` and fail with `ImportError` if the package isn't installed. The agent will crash at startup in this case.
+MLflow imports are inside `enable_tracing()`, so the agent starts fine without MLflow when `MLFLOW_TRACKING_URI` is not set. But if the URI is set, `enable_tracing()` will fail at startup with a clear `ModuleNotFoundError` telling the user to install MLflow. This is intentional — silently skipping tracing when the user explicitly requested it would hide a misconfiguration.


### PR DESCRIPTION
**Title**: Add integrate-tracing Claude Code skill system and tracing docs

**Summary:**
- Add an orchestrator skill (integrate-tracing) with 7 sub-skills that automate end-to-end MLflow tracing integration for new agent templates
- Add tracing.md documenting the tracing architecture, autolog coverage levels (A/B/C), and framework-specific integration details
- Update CONTRIBUTING.md with tracing requirements for contributors and skill usage instructions

**What this adds
Skills (.claude/skills/)**
| Skill | Role |
|-------|------|
| `integrate-tracing` | Orchestrator — coordinates the full pipeline |
| `check-autolog-support` | Research MLflow autolog support for a framework |
| `create-tracing-module` | Create `tracing.py` with the correct pattern |
| `wire-into-lifespan` | Wire tracing into the FastAPI lifespan |
| `add-manual-tracing` | Add manual trace wrapping (Level B/C only) |
| `verify-traces` | Sub-orchestrator for code review + live testing |
| `review-tracing-code` | Static code review against tracing checklist |
| `test-tracing` | Live end-to-end trace verification |

**Docs**
- **tracing.md** — Full tracing architecture, design principles, framework-specific integration details, autolog coverage levels, configuration, testing guide, and known issues
- **CONTRIBUTING.md** — New section explaining tracing requirements, what files to create/update, and how to use the skill system

### Usage

**Slash command:**
`/project:integrate-tracing <framework> <agent_path>`

**Or prompt Claude Code directly:**
``Integrate tracing into the google adk chat agent using the /project:integrate-tracing skill``


**Testing**
To test this skill, run it on an agent that doesn't have tracing implemented yet, e.g., the Google ADK agent:

``/project:integrate-tracing google_adk agents/google/adk``

**Recommended model**: `claude-opus-4-6`

