### PR TITLE
feat: integrate MLflow tracing into LangGraph human-in-the-loop agent

### DIFF
--- a/agents/langgraph/human_in_the_loop/.env.example
+++ b/agents/langgraph/human_in_the_loop/.env.example
@@ -5,3 +5,14 @@ MODEL_ID=ollama/llama3.1:8b
 
 # Deployment
 #CONTAINER_IMAGE=
+
+# Optional — MLflow Tracing
+# MLFLOW_TRACKING_URI=
+# MLFLOW_EXPERIMENT_NAME=
+# MLFLOW_HEALTH_CHECK_TIMEOUT=5
+# MLFLOW_HTTP_REQUEST_TIMEOUT=2
+# MLFLOW_HTTP_REQUEST_MAX_RETRIES=0
+# MLFLOW_TRACKING_TOKEN=
+# MLFLOW_TRACKING_INSECURE_TLS=
+# MLFLOW_WORKSPACE=default
+# MLFLOW_TRACKING_AUTH= # Use Kubernetes service account for authentication (if running inside the cluster)

--- a/agents/langgraph/human_in_the_loop/Dockerfile
+++ b/agents/langgraph/human_in_the_loop/Dockerfile
@@ -17,7 +17,7 @@ COPY pyproject.toml .
 COPY src/ ./src/
 
 # Install the project and its dependencies using uv
-RUN uv pip install --no-cache "."
+RUN uv pip install --no-cache ".[tracing]"
 
 # Copy the application entrypoint, playground UI, and images
 COPY main.py .

--- a/agents/langgraph/human_in_the_loop/Makefile
+++ b/agents/langgraph/human_in_the_loop/Makefile
@@ -73,17 +73,17 @@ run-app: ## Run agent locally with hot-reload
 	    echo "  Change PORT in .env or run: make run-app-fresh" && \
 	    exit 1; \
 	  fi && \
-	  uv run uvicorn main:app --host 0.0.0.0 --port $${PORT:-8000} --reload --reload-exclude .venv
+	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 0.0.0.0 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-app-fresh: ## Kill existing process on port and run agent with hot-reload
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Killing existing process on port $${PORT:-8000}..." && \
 	  lsof -ti:$${PORT:-8000} | xargs kill -9 2>/dev/null; true && \
-	  uv run uvicorn main:app --host 0.0.0.0 --port $${PORT:-8000} --reload --reload-exclude .venv
+	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 0.0.0.0 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-cli: ## Run interactive CLI chat (no web server)
 	@source .venv/bin/activate && set -a && source .env && set +a && \
-	  cd examples && uv run python execute_ai_service_locally.py
+	  cd examples && uv run $${MLFLOW_TRACKING_URI:+--extra tracing} python execute_ai_service_locally.py
 
 build: ## Build container image locally (podman/docker)
 	@[ -n "$(CONTAINER_CLI)" ] || { echo "ERROR: neither podman nor docker found in PATH"; exit 1; } && \

--- a/agents/langgraph/human_in_the_loop/README.md
+++ b/agents/langgraph/human_in_the_loop/README.md
@@ -39,44 +39,20 @@ User Input → LLM decides tool → Is it sensitive?
 
 ## Local Development
 
-#### Initiating base
+### Initiating base
 
-Here you copy .env.example file into .env
+`make init` creates a `.env` file from `.env.example`. Set your environment variables in the `.env` file.
 
 ```bash
 cd agents/langgraph/human_in_the_loop
 make init
 ```
 
-Edit `.env` with your configuration, then:
-
-```ini
-API_KEY=not-needed
-BASE_URL=http://localhost:8321/v1
-MODEL_ID=ollama/llama3.2:3b
-```
-
-See [Local Development](../../../docs/local-development.md) for Ollama + Llama Stack setup for local model serving.
-
-#### Pointing to a remotely hosted model
-
-```ini
-API_KEY=your-api-key-here
-BASE_URL=https://your-model-endpoint.com/v1
-MODEL_ID=llama-3.1-8b-instruct
-```
-
-**Notes:**
-
-- `API_KEY` - your API key or contact your cluster administrator
-- `BASE_URL` - should end with `/v1`
-- `MODEL_ID` - model identifier available on your endpoint
-
 ### Tracing (optional)
 
-#### Tracing with a local MLflow server
+Tracing is optional. If MLflow tracing is required, enable it by uncommenting and setting the following environment variables in the `.env` file.
 
-To enable MLflow tracing, add the following to your `.env`:
+#### Tracing with a local MLflow server
 
 ```ini
 MLFLOW_TRACKING_URI="http://localhost:5000"
@@ -92,6 +68,8 @@ Then start the MLflow server in a separate terminal:
 uv run --extra tracing mlflow server --port 5000
 ```
 
+When `MLFLOW_TRACKING_URI` is set, `make run-app` and `make run-cli` will automatically install the tracing dependency.
+
 #### Tracing with an OpenShift MLflow server
 
 To enable tracing and logging with MLflow on your OpenShift cluster, add the following environment variables to your `.env` file:
@@ -105,11 +83,11 @@ MLFLOW_WORKSPACE="default"
 ```
 
 **Notes:**
-- `MLFLOW_TRACKING_URI` - Replace `<openshift-dashboard-url>` with your OpenShift cluster's data science gateway URL
-- `MLFLOW_TRACKING_TOKEN` - Your openshift authentication token. It can be obtained from the openshift console.
+- `MLFLOW_TRACKING_URI` - URL of your MLflow server. For local development, use `http://localhost:5000`. If using MLflow on an OpenShift cluster, replace `<openshift-dashboard-url>` with your cluster's data science gateway URL.
+- `MLFLOW_TRACKING_TOKEN` - Required for OpenShift only. Your OpenShift authentication token, obtained from the OpenShift console.
 - `MLFLOW_EXPERIMENT_NAME` - A descriptive name for your experiment (e.g., "LangGraph HITL Demo")
-- `MLFLOW_TRACKING_INSECURE_TLS` - Set to `"true"` if your OpenShift cluster does not use trusted certificates
-- `MLFLOW_WORKSPACE` - Project name
+- `MLFLOW_TRACKING_INSECURE_TLS` - Required for OpenShift only. Set to `"true"` if your cluster does not use trusted certificates.
+- `MLFLOW_WORKSPACE` - Required for OpenShift only. Project name.
 
 - Tracing is optional; if you do not set `MLFLOW_TRACKING_URI`, the application will run without MLflow logging.
 
@@ -117,7 +95,7 @@ MLFLOW_WORKSPACE="default"
 
 - You can control how long the application waits for the MLflow server by setting `MLFLOW_HEALTH_CHECK_TIMEOUT` (in seconds, default: `5`).
 
-#### Creating environment
+### Creating environment
 
 Now you will remove old .venv and create new. Next dependencies will be installed.
 
@@ -125,7 +103,7 @@ Now you will remove old .venv and create new. Next dependencies will be installe
 make env
 ```
 
-#### Setup Ollama
+### Setup Ollama
 
 This will install ollama if it is not installed already. Then pull needed models for local work.
 The default model is `llama3.1:8b`. To use a different model, pass `MODEL=`:
@@ -135,7 +113,7 @@ The default model is `llama3.1:8b`. To use a different model, pass `MODEL=`:
 make ollama
 ```
 
-#### Run llama server
+### Run llama server
 
 > **Keep this terminal open** – the server needs to keep running.
 > You should see output indicating the server started on `http://localhost:8321`.
@@ -144,7 +122,7 @@ make ollama
 make llama-server
 ```
 
-#### Run the interactive web application
+### Run the interactive web application
 
 > **Keep this terminal open** – the app needs to keep running.
 > You should see output indicating the app started on `http://localhost:8000`.
@@ -159,7 +137,7 @@ connected and ready.
 
 When the agent pauses for approval, an **Approve / Reject** banner appears directly in the chat.
 
-#### Interactive CLI
+### Interactive CLI
 
 For terminal-based testing without a browser:
 

--- a/agents/langgraph/human_in_the_loop/README.md
+++ b/agents/langgraph/human_in_the_loop/README.md
@@ -50,6 +50,73 @@ make init
 
 Edit `.env` with your configuration, then:
 
+```ini
+API_KEY=not-needed
+BASE_URL=http://localhost:8321/v1
+MODEL_ID=ollama/llama3.2:3b
+```
+
+See [Local Development](../../../docs/local-development.md) for Ollama + Llama Stack setup for local model serving.
+
+#### Pointing to a remotely hosted model
+
+```ini
+API_KEY=your-api-key-here
+BASE_URL=https://your-model-endpoint.com/v1
+MODEL_ID=llama-3.1-8b-instruct
+```
+
+**Notes:**
+
+- `API_KEY` - your API key or contact your cluster administrator
+- `BASE_URL` - should end with `/v1`
+- `MODEL_ID` - model identifier available on your endpoint
+
+### Tracing (optional)
+
+#### Tracing with a local MLflow server
+
+To enable MLflow tracing, add the following to your `.env`:
+
+```ini
+MLFLOW_TRACKING_URI="http://localhost:5000"
+MLFLOW_EXPERIMENT_NAME="langgraph-hitl-agent"
+MLFLOW_HTTP_REQUEST_TIMEOUT=2
+MLFLOW_HTTP_REQUEST_MAX_RETRIES=0
+```
+
+Then start the MLflow server in a separate terminal:
+
+```bash
+# Start the MLflow server
+uv run --extra tracing mlflow server --port 5000
+```
+
+#### Tracing with an OpenShift MLflow server
+
+To enable tracing and logging with MLflow on your OpenShift cluster, add the following environment variables to your `.env` file:
+
+```ini
+MLFLOW_TRACKING_URI="https://<openshift-dashboard-url>/mlflow"
+MLFLOW_TRACKING_TOKEN="<your-openshift-token>"
+MLFLOW_EXPERIMENT_NAME="langgraph-hitl-agent"
+MLFLOW_TRACKING_INSECURE_TLS="true"
+MLFLOW_WORKSPACE="default"
+```
+
+**Notes:**
+- `MLFLOW_TRACKING_URI` - Replace `<openshift-dashboard-url>` with your OpenShift cluster's data science gateway URL
+- `MLFLOW_TRACKING_TOKEN` - Your openshift authentication token. It can be obtained from the openshift console.
+- `MLFLOW_EXPERIMENT_NAME` - A descriptive name for your experiment (e.g., "LangGraph HITL Demo")
+- `MLFLOW_TRACKING_INSECURE_TLS` - Set to `"true"` if your OpenShift cluster does not use trusted certificates
+- `MLFLOW_WORKSPACE` - Project name
+
+- Tracing is optional; if you do not set `MLFLOW_TRACKING_URI`, the application will run without MLflow logging.
+
+- If `MLFLOW_TRACKING_URI` is set, the application will attempt to connect to the MLflow server at startup. If the server is unreachable, the application will log a warning and continue running without tracing.
+
+- You can control how long the application waits for the MLflow server by setting `MLFLOW_HEALTH_CHECK_TIMEOUT` (in seconds, default: `5`).
+
 #### Creating environment
 
 Now you will remove old .venv and create new. Next dependencies will be installed.

--- a/agents/langgraph/human_in_the_loop/main.py
+++ b/agents/langgraph/human_in_the_loop/main.py
@@ -14,6 +14,7 @@ from langgraph.types import Command
 from pydantic import BaseModel, Field
 
 from human_in_the_loop.agent import get_graph_closure
+from human_in_the_loop.tracing import enable_tracing
 
 logger = logging.getLogger(__name__)
 
@@ -130,6 +131,8 @@ checkpointer = None
 async def lifespan(app: FastAPI):
     """Initialize the HITL agent graph on startup and clear it on shutdown."""
     global agent_graph_closure, checkpointer
+
+    enable_tracing()
 
     base_url = getenv("BASE_URL")
     model_id = getenv("MODEL_ID")

--- a/agents/langgraph/human_in_the_loop/pyproject.toml
+++ b/agents/langgraph/human_in_the_loop/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+tracing = [
+    "mlflow>=3.10.0",
+]
 dev = [
     "pytest>=9.0.2",
 ]

--- a/agents/langgraph/human_in_the_loop/src/human_in_the_loop/tracing.py
+++ b/agents/langgraph/human_in_the_loop/src/human_in_the_loop/tracing.py
@@ -1,0 +1,110 @@
+from os import getenv
+import time
+from dotenv import load_dotenv
+from typing import Optional
+
+import logging
+
+logger = logging.getLogger("tracing")
+logger.setLevel(logging.INFO)
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter(
+    "[%(asctime)s] [%(levelname)s] %(message)s"
+)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+def check_mlflow_health(mlflow_tracking_uri: str, max_wait_time: int = 5, retry_interval: int = 1) -> None:
+    """
+    Check MLflow health by trying the /health endpoint. If it fails, retry for a certain duration before giving up.
+    args:
+        mlflow_tracking_uri: base URI of the MLflow server
+        max_wait_time: total time to keep retrying before giving up (in seconds)
+        retry_interval: time to wait between retries (in seconds)
+    """
+    import requests
+    mlflow_health_endpoint = "/health"
+    mlflow_url = f"{mlflow_tracking_uri.rstrip('/')}{mlflow_health_endpoint}"
+    start_time = time.time()
+
+    while True:
+        remaining = max_wait_time - (time.time() - start_time)
+        if remaining <= 0:
+            logger.error(f"MLflow server is unavailable after {max_wait_time} seconds of checking.")
+            raise RuntimeError("MLflow server is unavailable. Please start the server or check the URI.")
+
+        try:
+            response = requests.get(mlflow_url, timeout=min(5, remaining))
+            if response.status_code == 200:
+                logger.info(f"MLflow health check passed at {mlflow_url} with status code {response.status_code}.")
+                return  # Success, exit the function without error
+            else:
+                logger.warning(
+                    f"MLflow returned status code {response.status_code} at {mlflow_url}\n"
+                    f"  Status Code: {response.status_code}\n"
+                    f"  Reason: {response.reason}\n"
+                    f"  Response Body: {response.text[:500]}"
+                )
+        except requests.exceptions.RequestException as e:
+            logger.warning(f"Failed to connect to MLflow at {mlflow_url}: {e}")
+
+        logger.warning(f"Retrying in {retry_interval} seconds...")
+        time.sleep(retry_interval)
+
+def enable_tracing() -> None:
+    """
+    Enable MLflow tracing if MLFLOW_TRACKING_URI is set.
+
+    Behavior:
+    1. If MLFLOW_TRACKING_URI is not set: tracing is skipped.
+    2. If MLFLOW_TRACKING_URI is set:
+       - Try to connect to the server.
+       - If the server is reachable: tracing is enabled.
+       - If the server is unreachable: log a warning and continue without tracing.
+    """
+    load_dotenv()
+    tracking_uri: Optional[str] = getenv("MLFLOW_TRACKING_URI")
+    if not tracking_uri:
+        logger.info("[Tracing] MLFLOW_TRACKING_URI not set. Tracing is disabled.")
+        return
+
+    try:
+        import mlflow
+        import mlflow.langchain
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "MLFLOW_TRACKING_URI is set but mlflow is not installed. "
+            "Install it with: uv pip install 'mlflow>=3.10.0'"
+        ) from e
+
+    # Check if server is reachable
+    try:
+        try:
+            health_check_timeout = int(getenv("MLFLOW_HEALTH_CHECK_TIMEOUT", "5"))
+        except ValueError:
+            health_check_timeout = 5
+        check_mlflow_health(mlflow_tracking_uri=tracking_uri, max_wait_time=health_check_timeout)
+        logger.info(f"[Tracing] MLflow server is reachable at {tracking_uri}")
+    except RuntimeError as e:
+        logger.warning(
+            f"[Tracing] MLflow server is unreachable at {tracking_uri}. "
+            f"Tried connecting for {health_check_timeout}s. Continuing without tracing. Error: {e}"
+        )
+        return
+
+    # Server is reachable → enable tracing
+    try:
+        mlflow.set_tracking_uri(tracking_uri)
+        experiment_name: str = getenv("MLFLOW_EXPERIMENT_NAME", "default-agent-experiment")
+        mlflow.set_experiment(experiment_name)
+        mlflow.config.enable_async_logging()
+
+        mlflow.langchain.autolog()
+
+        logger.info(f"[Tracing Enabled] MLflow -> {tracking_uri}, Experiment: {experiment_name}")
+    except Exception as e:
+        logger.warning(
+            f"[Tracing] Failed to configure MLflow tracing at {tracking_uri}. "
+            f"Continuing without tracing. Error: {e}"
+        )

--- a/agents/langgraph/human_in_the_loop/src/human_in_the_loop/tracing.py
+++ b/agents/langgraph/human_in_the_loop/src/human_in_the_loop/tracing.py
@@ -75,7 +75,7 @@ def enable_tracing() -> None:
     except ModuleNotFoundError as e:
         raise ModuleNotFoundError(
             "MLFLOW_TRACKING_URI is set but mlflow is not installed. "
-            "Install it with: uv pip install 'mlflow>=3.10.0'"
+            "Install it with: uv sync --extra tracing'"
         ) from e
 
     # Check if server is reachable


### PR DESCRIPTION
## Summary
- Add `tracing.py` with MLflow health check and graceful degradation (warn + continue if server is unreachable)
- Wire `enable_tracing()` into the FastAPI lifespan in `main.py`
- Add `mlflow>=3.10.0` as an optional `tracing` dependency in `pyproject.toml`
- Update `Makefile` to conditionally include `--extra tracing` in `run-app`, `run-app-fresh`, and `run-cli` targets
- Add MLflow env vars to `.env.example`
- Document local and OpenShift tracing setup in the README

## Test plan
- [ ] Run agent without `MLFLOW_TRACKING_URI` set — verify it starts normally with no tracing
- [ ] Run agent with `MLFLOW_TRACKING_URI` pointing to a local MLflow server — verify traces appear
- [ ] Run agent with `MLFLOW_TRACKING_URI` pointing to an unreachable server — verify it warns and continues without crashing