### PR TITLE
fix: update root README, and harden Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,14 @@ Agents are organized by framework. Pick one and follow its README:
 | **LangGraph** | [ReAct Agent](./agents/langgraph/react_agent/) | General-purpose agent using a ReAct loop: it reasons and calls tools (e.g. search, math) step by step. Built with LangGraph and LangChain. |
 | **LangGraph** | [Agentic RAG](./agents/langgraph/agentic_rag/) | RAG agent that indexes documents in a vector store (Milvus) and retrieves relevant chunks to augment the LLM's answers with your own data. |
 | **LangGraph** | [ReAct + DB Memory](./agents/langgraph/react_with_database_memory/) | ReAct agent with PostgreSQL-backed conversation memory. Full chat history is persisted in the database while a FIFO sliding window keeps only the last N messages in the LLM context. |
+| **LangGraph** | [Human-in-the-Loop](./agents/langgraph/human_in_the_loop/) | ReAct agent with a human approval step. The agent pauses before executing tool calls and waits for user confirmation, enabling oversight of critical actions. |
 | **LlamaIndex** | [WebSearch Agent](./agents/llamaindex/websearch_agent/) | Agent built on LlamaIndex that uses a web search tool to query the internet and use the results in its answers. |
 | **CrewAI** | [WebSearch Agent](./agents/crewai/websearch_agent/) | CrewAI-based agent with a web search tool to query the internet and answer user questions. |
 | **Vanilla Python** | [OpenAI Responses Agent](./agents/vanilla_python/openai_responses_agent/) | Minimal agent with no framework: only the OpenAI Python client and an Action/Observation loop with tools. Use with OpenAI or any compatible API. |
 | **AutoGen** | [MCP Agent](./agents/autogen/mcp_agent/) | AutoGen AssistantAgent with MCP tools over SSE (e.g. churn prediction, math tools), FastAPI `/chat/completions`. |
+| **Google ADK** | [ADK Agent](./agents/google/adk/) | General-purpose agent using Google ADK 2.0 with LiteLLM to route inference through a LlamaStack-compatible endpoint. |
 | **Langflow** | [Simple Tool Calling Agent](./agents/langflow/simple_tool_calling_agent/) | Tool-calling agent built with Langflow's visual flow builder. Calls external APIs as tools and reasons over results. Includes Langfuse v3 tracing. Runs locally via `podman-compose`. |
+| **A2A** | [LangGraph + CrewAI Agent](./agents/a2a/langgraph_crewai_agent/) | Multi-agent system using the Agent-to-Agent (A2A) protocol. A LangGraph orchestrator delegates tasks to a CrewAI worker agent. Uses a dedicated Helm chart. |
 
 ## Deployment Options
 
@@ -51,7 +54,8 @@ agentic-starter-kits/
 │   ├── langgraph/
 │   │   ├── react_agent/              # LangGraph ReAct agent
 │   │   ├── agentic_rag/             # LangGraph RAG agent with Milvus
-│   │   └── react_with_database_memory/ # LangGraph ReAct + PostgreSQL memory
+│   │   ├── react_with_database_memory/ # LangGraph ReAct + PostgreSQL memory
+│   │   └── human_in_the_loop/       # LangGraph Human-in-the-Loop agent
 │   ├── crewai/
 │   │   └── websearch_agent/         # CrewAI web search agent
 │   ├── llamaindex/
@@ -60,10 +64,15 @@ agentic-starter-kits/
 │   │   └── openai_responses_agent/  # OpenAI Responses API (no framework)
 │   ├── autogen/
 │   │   └── mcp_agent/               # AutoGen + MCP (SSE)
-│   └── langflow/
-│       └── simple_tool_calling_agent/ # Langflow tool-calling agent
+│   ├── google/
+│   │   └── adk/                     # Google ADK 2.0 agent
+│   ├── langflow/
+│   │   └── simple_tool_calling_agent/ # Langflow tool-calling agent
+│   └── a2a/
+│       └── langgraph_crewai_agent/  # A2A multi-agent (LangGraph + CrewAI)
 ├── charts/
-│   └── agent/                       # Shared Helm chart for all agents
+│   ├── agent/                       # Shared Helm chart for all standard agents
+│   └── a2a-langgraph-crewai/        # Dedicated Helm chart for A2A agent
 ├── docs/                            # Guides: local dev, deployment, contributing
 └── README.md
 ```

--- a/agents/google/adk/Makefile
+++ b/agents/google/adk/Makefile
@@ -5,7 +5,7 @@ VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 MODEL          ?= llama3.1:8b
 
-.PHONY: init re-init env ollama llama run-app run-app-fresh run-cli build push build-openshift deploy undeploy test dry-run help
+.PHONY: init re-init env ollama llama-server run-app run-app-fresh run-cli build push build-openshift deploy undeploy test dry-run help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-12s %s\n", $$1, $$2}'

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
       {{- include "agent.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "agent.selectorLabels" . | nindent 8 }}
     spec:
@@ -18,7 +20,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: {{ include "agent.name" . }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ required "image.repository is required — set CONTAINER_IMAGE in .env" .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
### Summary

- Add 3 missing agents (Human-in-the-Loop, Google ADK, A2A) to root README agents table and directory tree
- Fix ADK Makefile .PHONY typo (llama → llama-server)
- Add {{ required }} validation on image.repository in shared Helm chart
- Add checksum/secret annotation to deployment pod template so pods auto-restart when secret values change (e.g. API key rotation via make deploy)

### Test plan

- [x]  cd agents/google/adk && make help — verify llama-server appears in output (not llama)
- [x]  cd agents/langgraph/agentic_rag && make help — verify column alignment matches other agents (%-12s)
- [x]  Verify root README table has 11 agent rows (was 8) — Human-in-the-Loop, Google ADK, A2A added
- [x]  Verify root README directory tree includes google/adk/, a2a/langgraph_crewai_agent/, human_in_the_loop/, and charts/a2a-langgraph-crewai/