### PR TITLE
fix: health check 503, bind to 127.0.0.1, standardize dependencies

### DIFF
--- a/agents/autogen/mcp_agent/mcp_automl_template/pyproject.toml
+++ b/agents/autogen/mcp_agent/mcp_automl_template/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "langchain-llama-stack>=0.1.0,<1.0.0",
     "pandas>=2.0.0,<3.0.0",
     "pydantic>=2.0.0,<3.0.0",
-    "uvicorn[standard]>=0.30.0,<1.0.0",
+    "uvicorn[standard]>=0.41.0,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/agents/autogen/mcp_agent/pyproject.toml
+++ b/agents/autogen/mcp_agent/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "autogen-agentchat",
     "autogen-ext[openai,mcp]",
     "openai",
-    "fastapi>=0.129.0",
+    "fastapi>=0.135.1",
     "uvicorn[standard]>=0.41.0",
     "pydantic>=2.0.0",
     "python-dotenv>=1.2.0",

--- a/agents/crewai/websearch_agent/Makefile
+++ b/agents/crewai/websearch_agent/Makefile
@@ -71,13 +71,13 @@ run-app: ## Run agent locally with hot-reload
 	    echo "  Change PORT in .env or run: make run-app-fresh" && \
 	    exit 1; \
 	  fi && \
-	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 0.0.0.0 --port $${PORT:-8000} --reload --reload-exclude .venv
+	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-app-fresh: ## Kill existing process on port and run agent with hot-reload
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Killing existing process on port $${PORT:-8000}..." && \
 	  lsof -ti:$${PORT:-8000} | xargs kill -9 2>/dev/null; true && \
-	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 0.0.0.0 --port $${PORT:-8000} --reload --reload-exclude .venv
+	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-cli: ## Run interactive CLI chat (no web server)
 	@source .venv/bin/activate && set -a && source .env && set +a && \

--- a/agents/crewai/websearch_agent/main.py
+++ b/agents/crewai/websearch_agent/main.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from crewai import LLM
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
 from crewai_web_search.crew import AssistanceAgents
@@ -364,7 +364,11 @@ async def _handle_stream(user_message: str, model_id: str):
     "/health", response_model=HealthResponse, summary="Health check", tags=["Health"]
 )
 async def health():
-    return {"status": "healthy", "agent_initialized": llm is not None}
+    initialized = llm is not None
+    body = {"status": "healthy" if initialized else "not_ready", "agent_initialized": initialized}
+    if not initialized:
+        return JSONResponse(status_code=503, content=body)
+    return body
 
 
 # ── Playground API aliases (so the same index.html works in both modes) ───────

--- a/agents/google/adk/Makefile
+++ b/agents/google/adk/Makefile
@@ -73,13 +73,13 @@ run-app: ## Run agent locally with hot-reload
 	    echo "  Change PORT in .env or run: make run-app-fresh" && \
 	    exit 1; \
 	  fi && \
-	  uv run uvicorn main:app --host 0.0.0.0 --port $${PORT:-8000} --reload --reload-exclude .venv
+	  uv run uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-app-fresh: ## Kill existing process on port and run agent with hot-reload
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Killing existing process on port $${PORT:-8000}..." && \
 	  lsof -ti:$${PORT:-8000} | xargs kill -9 2>/dev/null; true && \
-	  uv run uvicorn main:app --host 0.0.0.0 --port $${PORT:-8000} --reload --reload-exclude .venv
+	  uv run uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-cli: ## Run interactive CLI chat (no web server)
 	@source .venv/bin/activate && set -a && source .env && set +a && \

--- a/agents/google/adk/main.py
+++ b/agents/google/adk/main.py
@@ -7,7 +7,7 @@ from os import getenv
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, StreamingResponse
 from google.genai import types
 from pydantic import BaseModel, Field
 
@@ -411,7 +411,11 @@ async def _handle_stream(user_content: str, model_id: str):
     "/health", response_model=HealthResponse, summary="Health check", tags=["Health"]
 )
 async def health():
-    return {"status": "healthy", "agent_initialized": runner is not None}
+    initialized = runner is not None
+    body = {"status": "healthy" if initialized else "not_ready", "agent_initialized": initialized}
+    if not initialized:
+        return JSONResponse(status_code=503, content=body)
+    return body
 
 
 # ── Playground UI ────────────────────────────────────────────────────────────

--- a/agents/google/adk/pyproject.toml
+++ b/agents/google/adk/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "Your Name", email = "you@example.com" }]
 license = { text = "MIT" }
 requires-python = ">=3.12,<=3.14"
 dependencies = [
-    "fastapi>=0.129.0",
+    "fastapi>=0.135.1",
     "uvicorn[standard]>=0.41.0",
     "google-adk>=2.0.0a1",
     "litellm>=1.50.0,!=1.82.7,!=1.82.8", # Those versions were compromised so we skip them

--- a/agents/langgraph/agentic_rag/Makefile
+++ b/agents/langgraph/agentic_rag/Makefile
@@ -76,13 +76,13 @@ run-app: ## Run agent locally with hot-reload
 	    echo "  Change PORT in .env or run: make run-app-fresh" && \
 	    exit 1; \
 	  fi && \
-	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 0.0.0.0 --port $${PORT:-8000} --reload --reload-exclude .venv
+	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-app-fresh: ## Kill existing process on port and run agent with hot-reload
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Killing existing process on port $${PORT:-8000}..." && \
 	  lsof -ti:$${PORT:-8000} | xargs kill -9 2>/dev/null; true && \
-	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 0.0.0.0 --port $${PORT:-8000} --reload --reload-exclude .venv
+	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-cli: ## Run interactive CLI chat (no web server)
 	@source .venv/bin/activate && set -a && source .env && set +a && \

--- a/agents/langgraph/agentic_rag/main.py
+++ b/agents/langgraph/agentic_rag/main.py
@@ -7,7 +7,7 @@ from os import getenv
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, StreamingResponse
 from langchain_core.messages import HumanMessage, AIMessage, ToolMessage
 from pydantic import BaseModel, Field
 from agentic_rag.agent import get_graph_closure
@@ -387,7 +387,11 @@ async def _handle_stream(messages: list[HumanMessage], model_id: str):
     "/health", response_model=HealthResponse, summary="Health check", tags=["Health"]
 )
 async def health():
-    return {"status": "healthy", "agent_initialized": agent_graph is not None}
+    initialized = agent_graph is not None
+    body = {"status": "healthy" if initialized else "not_ready", "agent_initialized": initialized}
+    if not initialized:
+        return JSONResponse(status_code=503, content=body)
+    return body
 
 
 # ── Playground UI ────────────────────────────────────────────────────────────

--- a/agents/langgraph/agentic_rag/pyproject.toml
+++ b/agents/langgraph/agentic_rag/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "Your Name", email = "you@example.com" }]
 license = { text = "MIT" }
 requires-python = ">=3.12, <3.14"
 dependencies = [
-    "fastapi>=0.132.0",
+    "fastapi>=0.135.1",
     "uvicorn[standard]>=0.41.0",
     "langchain>=1.2.10",
     "langchain-openai>=1.1.10",

--- a/agents/langgraph/human_in_the_loop/Makefile
+++ b/agents/langgraph/human_in_the_loop/Makefile
@@ -73,13 +73,13 @@ run-app: ## Run agent locally with hot-reload
 	    echo "  Change PORT in .env or run: make run-app-fresh" && \
 	    exit 1; \
 	  fi && \
-	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 0.0.0.0 --port $${PORT:-8000} --reload --reload-exclude .venv
+	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-app-fresh: ## Kill existing process on port and run agent with hot-reload
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Killing existing process on port $${PORT:-8000}..." && \
 	  lsof -ti:$${PORT:-8000} | xargs kill -9 2>/dev/null; true && \
-	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 0.0.0.0 --port $${PORT:-8000} --reload --reload-exclude .venv
+	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-cli: ## Run interactive CLI chat (no web server)
 	@source .venv/bin/activate && set -a && source .env && set +a && \

--- a/agents/langgraph/human_in_the_loop/main.py
+++ b/agents/langgraph/human_in_the_loop/main.py
@@ -7,7 +7,7 @@ from os import getenv
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, StreamingResponse
 from langchain_core.messages import HumanMessage, AIMessage, ToolMessage
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.types import Command
@@ -538,7 +538,11 @@ async def _handle_stream(
     "/health", response_model=HealthResponse, summary="Health check", tags=["Health"]
 )
 async def health():
-    return {"status": "healthy", "agent_initialized": agent_graph_closure is not None}
+    initialized = agent_graph_closure is not None
+    body = {"status": "healthy" if initialized else "not_ready", "agent_initialized": initialized}
+    if not initialized:
+        return JSONResponse(status_code=503, content=body)
+    return body
 
 
 # ── Playground UI ────────────────────────────────────────────────────────────

--- a/agents/langgraph/react_agent/Makefile
+++ b/agents/langgraph/react_agent/Makefile
@@ -73,13 +73,13 @@ run-app: ## Run agent locally with hot-reload
 	    echo "  Change PORT in .env or run: make run-app-fresh" && \
 	    exit 1; \
 	  fi && \
-	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 0.0.0.0 --port $${PORT:-8000} --reload --reload-exclude .venv
+	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-app-fresh: ## Kill existing process on port and run agent with hot-reload
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Killing existing process on port $${PORT:-8000}..." && \
 	  lsof -ti:$${PORT:-8000} | xargs kill -9 2>/dev/null; true && \
-	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 0.0.0.0 --port $${PORT:-8000} --reload --reload-exclude .venv
+	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-cli: ## Run interactive CLI chat (no web server)
 	@source .venv/bin/activate && set -a && source .env && set +a && \

--- a/agents/langgraph/react_agent/main.py
+++ b/agents/langgraph/react_agent/main.py
@@ -7,7 +7,7 @@ from os import getenv
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, StreamingResponse
 from langchain_core.messages import HumanMessage, AIMessage, ToolMessage
 from pydantic import BaseModel, Field
 from react_agent.agent import get_graph_closure
@@ -384,7 +384,11 @@ async def _handle_stream(messages: list[HumanMessage], model_id: str):
     "/health", response_model=HealthResponse, summary="Health check", tags=["Health"]
 )
 async def health():
-    return {"status": "healthy", "agent_initialized": agent_graph is not None}
+    initialized = agent_graph is not None
+    body = {"status": "healthy" if initialized else "not_ready", "agent_initialized": initialized}
+    if not initialized:
+        return JSONResponse(status_code=503, content=body)
+    return body
 
 
 # ── Playground UI ────────────────────────────────────────────────────────────

--- a/agents/langgraph/react_agent/pyproject.toml
+++ b/agents/langgraph/react_agent/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "Your Name", email = "you@example.com" }]
 license = { text = "MIT" }
 requires-python = ">=3.12,<=3.14"
 dependencies = [
-    "fastapi>=0.132.0",
+    "fastapi>=0.135.1",
     "uvicorn[standard]>=0.41.0",
     "langchain>=1.2.10",
     "langchain-openai>=1.1.10",

--- a/agents/langgraph/react_with_database_memory/Makefile
+++ b/agents/langgraph/react_with_database_memory/Makefile
@@ -17,7 +17,7 @@ re-init: ## Activate venv and reload .env variables
 init: ## Copy .env.example to .env for configuration
 	@if [ ! -f .env ]; then cp .env.example .env && echo "Created .env from .env.example — edit it with your configuration"; else echo ".env already exists — skipping"; fi
 
-env: init ## Create venv, load .env, and install dependencies
+env: ## Create venv, load .env, and install dependencies
 	@echo "==> Creating virtual environment and installing dependencies..." && \
 	  rm -rf .venv && \
 	  uv sync --python 3.12 && \
@@ -73,13 +73,13 @@ run-app: ## Run agent locally with hot-reload
 	    echo "  Change PORT in .env or run: make run-app-fresh" && \
 	    exit 1; \
 	  fi && \
-	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 0.0.0.0 --port $${PORT:-8000} --reload --reload-exclude .venv
+	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-app-fresh: ## Kill existing process on port and run agent with hot-reload
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Killing existing process on port $${PORT:-8000}..." && \
 	  lsof -ti:$${PORT:-8000} | xargs kill -9 2>/dev/null; true && \
-	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 0.0.0.0 --port $${PORT:-8000} --reload --reload-exclude .venv
+	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-cli: ## Run interactive CLI chat (no web server)
 	@source .venv/bin/activate && set -a && source .env && set +a && \

--- a/agents/langgraph/react_with_database_memory/main.py
+++ b/agents/langgraph/react_with_database_memory/main.py
@@ -7,7 +7,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, StreamingResponse
 from langchain_core.messages import HumanMessage, AIMessage, ToolMessage, SystemMessage
 from langgraph.checkpoint.postgres import PostgresSaver
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
@@ -462,11 +462,15 @@ async def _handle_stream(
     "/health", response_model=HealthResponse, summary="Health check", tags=["Health"]
 )
 async def health():
-    return {
-        "status": "healthy",
-        "agent_initialized": agent_graph_closure is not None,
+    initialized = agent_graph_closure is not None
+    body = {
+        "status": "healthy" if initialized else "not_ready",
+        "agent_initialized": initialized,
         "database_connected": DB_URI is not None,
     }
+    if not initialized:
+        return JSONResponse(status_code=503, content=body)
+    return body
 
 
 # ── Playground UI ────────────────────────────────────────────────────────────

--- a/agents/langgraph/react_with_database_memory/pyproject.toml
+++ b/agents/langgraph/react_with_database_memory/pyproject.toml
@@ -7,7 +7,7 @@ license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.12,<3.14"
 dependencies = [
-    "fastapi>=0.132.0",
+    "fastapi>=0.135.1",
     "uvicorn[standard]>=0.41.0",
     "pydantic>=2.12.5",
     "langchain>=1.2.10",

--- a/agents/llamaindex/websearch_agent/Makefile
+++ b/agents/llamaindex/websearch_agent/Makefile
@@ -73,13 +73,13 @@ run-app: ## Run agent locally with hot-reload
 	    echo "  Change PORT in .env or run: make run-app-fresh" && \
 	    exit 1; \
 	  fi && \
-	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 0.0.0.0 --port $${PORT:-8000} --reload --reload-exclude .venv
+	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-app-fresh: ## Kill existing process on port and run agent with hot-reload
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Killing existing process on port $${PORT:-8000}..." && \
 	  lsof -ti:$${PORT:-8000} | xargs kill -9 2>/dev/null; true && \
-	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 0.0.0.0 --port $${PORT:-8000} --reload --reload-exclude .venv
+	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-cli: ## Run interactive CLI chat (no web server)
 	@source .venv/bin/activate && set -a && source .env && set +a && \

--- a/agents/llamaindex/websearch_agent/main.py
+++ b/agents/llamaindex/websearch_agent/main.py
@@ -7,7 +7,7 @@ from os import getenv
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, StreamingResponse
 from websearch_agent.agent import get_workflow_closure
 from websearch_agent.tracing import enable_tracing
 from websearch_agent.workflow import ToolCallEvent, InputEvent
@@ -451,7 +451,11 @@ async def _handle_stream(user_message: str, model_id: str):
     "/health", response_model=HealthResponse, summary="Health check", tags=["Health"]
 )
 async def health():
-    return {"status": "healthy", "agent_initialized": get_agent is not None}
+    initialized = get_agent is not None
+    body = {"status": "healthy" if initialized else "not_ready", "agent_initialized": initialized}
+    if not initialized:
+        return JSONResponse(status_code=503, content=body)
+    return body
 
 
 # ── Playground API aliases (so the same index.html works in both modes) ───────

--- a/agents/vanilla_python/openai_responses_agent/Makefile
+++ b/agents/vanilla_python/openai_responses_agent/Makefile
@@ -33,13 +33,13 @@ run-app: ## Run agent locally with hot-reload
 	    echo "  Change PORT in .env or run: make run-app-fresh" && \
 	    exit 1; \
 	  fi && \
-	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 0.0.0.0 --port $${PORT:-8000} --reload --reload-exclude .venv
+	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-app-fresh: ## Kill existing process on port and run agent with hot-reload
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Killing existing process on port $${PORT:-8000}..." && \
 	  lsof -ti:$${PORT:-8000} | xargs kill -9 2>/dev/null; true && \
-	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 0.0.0.0 --port $${PORT:-8000} --reload --reload-exclude .venv
+	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-cli: ## Run interactive CLI chat (no web server)
 	@source .venv/bin/activate && set -a && source .env && set +a && \

--- a/agents/vanilla_python/openai_responses_agent/main.py
+++ b/agents/vanilla_python/openai_responses_agent/main.py
@@ -8,7 +8,7 @@ from os import getenv
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, StreamingResponse
 from openai_responses_agent.agent import get_agent_closure, AIAgent
 from openai_responses_agent.tracing import enable_tracing, wrap_func_with_mlflow_trace
 from pydantic import BaseModel, Field
@@ -388,7 +388,11 @@ def _map_event_to_chunk(
     "/health", response_model=HealthResponse, summary="Health check", tags=["Health"]
 )
 async def health():
-    return {"status": "healthy", "agent_initialized": get_agent is not None}
+    initialized = get_agent is not None
+    body = {"status": "healthy" if initialized else "not_ready", "agent_initialized": initialized}
+    if not initialized:
+        return JSONResponse(status_code=503, content=body)
+    return body
 
 
 # ── Playground API aliases (so the same index.html works in both modes) ───────

--- a/agents/vanilla_python/openai_responses_agent/pyproject.toml
+++ b/agents/vanilla_python/openai_responses_agent/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "openai>=2.24.0",
     "setuptools>=80.9.0,<82.0.0",
     "flask>=3.1.0",
-    "fastapi>=0.129.0",
+    "fastapi>=0.135.1",
     "uvicorn[standard]>=0.41.0",
 ]
 


### PR DESCRIPTION
## Summary

- **Health check returns 503 when uninitialized** — All 8 standard agents now return HTTP 503 (not 200) when the agent isn't ready, so K8s readiness probes correctly gate traffic. Matches the AutoGen pattern.
- **Bind local dev to 127.0.0.1** — Makefiles now use `--host 127.0.0.1` in `run-app`/`run-app-fresh` targets. Container Dockerfiles remain at `0.0.0.0` for K8s networking.
- **Standardize FastAPI to `>=0.135.1`** — 6 agents bumped from `>=0.129.0` or `>=0.132.0`.
- **Bump uvicorn in mcp_automl_template to `>=0.41.0`** — from `>=0.30.0`.
- **Remove `env: init` dependency** in `react_with_database_memory/Makefile` — aligns with all other agents where `env` is standalone.

## Files changed (23 + 1 doc)

| Category | Files | Change |
|----------|-------|--------|
| Health check 503 | 8 `main.py` | Add `JSONResponse` import, return 503 when not initialized |
| 127.0.0.1 binding | 8 `Makefile` | `--host 0.0.0.0` → `--host 127.0.0.1` (run-app + run-app-fresh) |
| FastAPI version | 6 `pyproject.toml` | `>=0.129.0`/`>=0.132.0` → `>=0.135.1` |
| Uvicorn version | 1 `pyproject.toml` | `>=0.30.0` → `>=0.41.0` (mcp_automl_template) |
| Makefile dep fix | 1 `Makefile` | `env: init` → `env:` (react_with_database_memory) |
| Audit doc | 1 `md` | Updated resolved/accepted counts |

## Test plan

- [ ] `curl localhost:8000/health` before agent init returns HTTP 503 with `{"status": "not_ready", ...}`
- [ ] `curl localhost:8000/health` after agent init returns HTTP 200 with `{"status": "healthy", ...}`
- [ ] `make run-app` binds to `127.0.0.1` (not reachable from other hosts)