### PR TITLE
chore: add PR template to guide contributors

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+## Description
+
+<!-- Summarize your changes and the motivation behind them -->
+
+## Type of Change
+
+- [ ] Bug Fix
+- [ ] Feature
+- [ ] Breaking Change
+- [ ] Documentation
+- [ ] Refactor/Chore
+
+## Testing
+
+- [ ] `make test` passes for affected agent(s)
+- [ ] Manual testing performed (describe steps below)
+- [ ] No testing required (documentation/config change only)
+
+<!-- Describe any additional verification steps -->
+
+## Checklist
+
+- [ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
+- [ ] No `.env` or secret files are included in this PR
+- [ ] All changes are within scope of the linked Jira ticket (if not, explain in Description)
+
+## Review Guidance
+
+<!-- Optional: highlight areas that need careful review, key design decisions, or files that can be safely skipped -->
+
+## Related PRs
+
+<!-- Link any related pull requests, e.g. #42, #56 -->
+
+## Jira Ticket
+
+<!-- e.g. RHAIENG-123 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 ## Testing
 
-- [ ] `make test` passes for affected agent(s)
+- [ ] `make test` passes (run from the affected agent directory)
 - [ ] Manual testing performed (describe steps below)
 - [ ] No testing required (documentation/config change only)
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,13 +2,9 @@
 
 <!-- Summarize your changes and the motivation behind them -->
 
-## Type of Change
+## Jira Ticket
 
-- [ ] Bug Fix
-- [ ] Feature
-- [ ] Breaking Change
-- [ ] Documentation
-- [ ] Refactor/Chore
+<!-- e.g. RHAIENG-123 -->
 
 ## Testing
 
@@ -31,7 +27,3 @@
 ## Related PRs
 
 <!-- Link any related pull requests, e.g. #42, #56 -->
-
-## Jira Ticket
-
-<!-- e.g. RHAIENG-123 -->


### PR DESCRIPTION
## Summary

- Adds `.github/PULL_REQUEST_TEMPLATE.md` with sections for Description, Type of Change, Testing, Checklist, Review Guidance, Related PRs, and Jira Ticket
- Auto-populates into every new PR to ensure reviewers get consistent context
- Addresses RHAIENG-4060

## Test plan

- [ ] *(Post-merge)* Open a new PR and verify the template auto-populates
- [x] Confirm all sections render correctly (checkboxes, comments, links)

> **Note:** GitHub only loads PR templates from the default branch. Auto-populate can only be verified after this PR is merged into `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)