### PR TITLE
fix: align autogen mcp_agent Makefile and README with standard pattern

### DIFF
--- a/agents/autogen/mcp_agent/.env.example
+++ b/agents/autogen/mcp_agent/.env.example
@@ -6,7 +6,7 @@ MODEL_ID=
 # Deployment — Agent
 CONTAINER_IMAGE=
 
-# MCP Server URL (defaults: localhost:8080 for `make run`, in-cluster DNS for `make deploy`)
+# MCP Server URL (defaults: localhost:8080 for `make run-app`, in-cluster DNS for `make deploy`)
 # MCP_SERVER_URL=http://127.0.0.1:8080/sse
 # MCP Server — DNS rebinding protection (enabled by default in MCP SDK ≥1.x)
 # DISABLE_DNS_REBINDING_PROTECTION=true

--- a/agents/autogen/mcp_agent/Makefile
+++ b/agents/autogen/mcp_agent/Makefile
@@ -3,17 +3,75 @@ AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)
 CHART_DIR      := ../../../charts/agent
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
+MODEL          ?= llama3.1:8b
 
-.PHONY: init run run-mcp interact-mcp build push build-openshift deploy deploy-mcp undeploy undeploy-mcp test dry-run dry-run-mcp help
+.PHONY: init env ollama llama-server run-app run-app-fresh run-mcp interact-mcp build push build-openshift deploy deploy-mcp undeploy undeploy-mcp test dry-run dry-run-mcp help
 
 help: ## Show this help
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-14s %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-12s %s\n", $$1, $$2}'
 
 init: ## Copy .env.example to .env for configuration
 	@if [ ! -f .env ]; then cp .env.example .env && echo "Created .env from .env.example — edit it with your configuration"; else echo ".env already exists — skipping"; fi
 
-run: ## Run agent locally with hot-reload (port 8000)
-	@set -a && source .env && set +a && \
+env: ## Create venv and install dependencies
+	@echo "==> Creating virtual environment and installing dependencies..." && \
+	  rm -rf .venv && \
+	  uv sync --python 3.12 && \
+	  echo "" && \
+	  echo "Done. Next steps:" && \
+	  echo "  make ollama       # install Ollama and pull models" && \
+	  echo "  make llama-server # start Llama Stack server"
+
+ollama: ## Install Ollama, start it, and pull models
+	@if command -v ollama >/dev/null 2>&1; then \
+	  echo "==> Ollama already installed, skipping..."; \
+	else \
+	  echo "==> Installing Ollama..." && \
+	  curl -fsSL https://ollama.com/install.sh | sh; \
+	fi && \
+	  echo "==> Starting Ollama service..." && \
+	  ollama serve &>/dev/null & \
+	  OLLAMA_PID=$$! && \
+	  echo "Waiting for Ollama to be ready (max 30s)..." && \
+	  OLLAMA_WAIT=0 && \
+	  until ollama list >/dev/null 2>&1; do \
+	    OLLAMA_WAIT=$$((OLLAMA_WAIT + 1)); \
+	    if [ $$OLLAMA_WAIT -ge 30 ]; then \
+	      echo "ERROR: Ollama failed to start within 30 seconds." && \
+	      kill $$OLLAMA_PID 2>/dev/null; \
+	      exit 1; \
+	    fi; \
+	    sleep 1; \
+	  done && \
+	  echo "==> Pulling $(MODEL)..." && \
+	  ollama pull $(MODEL) && \
+	  echo "" && \
+	  echo "Done. Run 'make llama-server' to start the Llama Stack server."
+
+llama-server: ## Install llama-stack and start Llama Stack server
+	@source .venv/bin/activate && set -a && source .env && set +a && \
+	  echo "==> Installing llama-stack dependencies..." && \
+	  uv sync --extra llama && \
+	  mkdir -p ../../../milvus_data && \
+	  echo "==> Killing any existing process on port 8321..." && \
+	  lsof -ti:8321 | xargs kill -9 2>/dev/null; true && \
+	  echo "==> Starting Llama Stack server on port 8321..." && \
+	  llama stack run ../../../run_llama_server.yaml
+
+run-app: ## Run agent locally with hot-reload
+	@source .venv/bin/activate && set -a && source .env && set +a && \
+	  if lsof -ti:$${PORT:-8000} >/dev/null 2>&1; then \
+	    echo "ERROR: Port $${PORT:-8000} is already in use." && \
+	    echo "  Change PORT in .env or run: make run-app-fresh" && \
+	    exit 1; \
+	  fi && \
+	  MCP_SERVER_URL="$${MCP_SERVER_URL:-http://127.0.0.1:8080/sse}" \
+	  uv run uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
+
+run-app-fresh: ## Kill existing process on port and run agent with hot-reload
+	@source .venv/bin/activate && set -a && source .env && set +a && \
+	  echo "==> Killing existing process on port $${PORT:-8000}..." && \
+	  lsof -ti:$${PORT:-8000} | xargs kill -9 2>/dev/null; true && \
 	  MCP_SERVER_URL="$${MCP_SERVER_URL:-http://127.0.0.1:8080/sse}" \
 	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
 

--- a/agents/autogen/mcp_agent/Makefile
+++ b/agents/autogen/mcp_agent/Makefile
@@ -49,11 +49,12 @@ ollama: ## Install Ollama, start it, and pull models
 	  echo "Done. Run 'make llama-server' to start the Llama Stack server."
 
 llama-server: ## Install llama-stack and start Llama Stack server
-	@[ -d .venv ] || { echo "ERROR: .venv not found — run 'make env' first"; exit 1; }
 	@[ -f .env ] || { echo "ERROR: .env not found — run 'make init' first"; exit 1; }
-	@source .venv/bin/activate && set -a && source .env && set +a && \
+	@[ -d .venv ] || { echo "ERROR: .venv not found — run 'make env' first"; exit 1; }
+	@source .venv/bin/activate && \
 	  echo "==> Installing llama-stack dependencies..." && \
 	  uv sync --extra llama && \
+	  set -a && source .env && set +a && \
 	  mkdir -p ../../../milvus_data && \
 	  echo "==> Killing any existing process on port 8321..." && \
 	  lsof -ti:8321 | xargs kill -9 2>/dev/null; true && \
@@ -61,8 +62,8 @@ llama-server: ## Install llama-stack and start Llama Stack server
 	  llama stack run ../../../run_llama_server.yaml
 
 run-app: ## Run agent locally with hot-reload
-	@[ -d .venv ] || { echo "ERROR: .venv not found — run 'make env' first"; exit 1; }
 	@[ -f .env ] || { echo "ERROR: .env not found — run 'make init' first"; exit 1; }
+	@[ -d .venv ] || { echo "ERROR: .venv not found — run 'make env' first"; exit 1; }
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  if lsof -ti:$${PORT:-8000} >/dev/null 2>&1; then \
 	    echo "ERROR: Port $${PORT:-8000} is already in use." && \
@@ -73,8 +74,8 @@ run-app: ## Run agent locally with hot-reload
 	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-app-fresh: ## Kill existing process on port and run agent with hot-reload
-	@[ -d .venv ] || { echo "ERROR: .venv not found — run 'make env' first"; exit 1; }
 	@[ -f .env ] || { echo "ERROR: .env not found — run 'make init' first"; exit 1; }
+	@[ -d .venv ] || { echo "ERROR: .venv not found — run 'make env' first"; exit 1; }
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Killing existing process on port $${PORT:-8000}..." && \
 	  lsof -ti:$${PORT:-8000} | xargs kill -9 2>/dev/null; true && \

--- a/agents/autogen/mcp_agent/Makefile
+++ b/agents/autogen/mcp_agent/Makefile
@@ -50,6 +50,7 @@ ollama: ## Install Ollama, start it, and pull models
 
 llama-server: ## Install llama-stack and start Llama Stack server
 	@[ -d .venv ] || { echo "ERROR: .venv not found — run 'make env' first"; exit 1; }
+	@[ -f .env ] || { echo "ERROR: .env not found — run 'make init' first"; exit 1; }
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Installing llama-stack dependencies..." && \
 	  uv sync --extra llama && \
@@ -61,6 +62,7 @@ llama-server: ## Install llama-stack and start Llama Stack server
 
 run-app: ## Run agent locally with hot-reload
 	@[ -d .venv ] || { echo "ERROR: .venv not found — run 'make env' first"; exit 1; }
+	@[ -f .env ] || { echo "ERROR: .env not found — run 'make init' first"; exit 1; }
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  if lsof -ti:$${PORT:-8000} >/dev/null 2>&1; then \
 	    echo "ERROR: Port $${PORT:-8000} is already in use." && \
@@ -68,10 +70,11 @@ run-app: ## Run agent locally with hot-reload
 	    exit 1; \
 	  fi && \
 	  MCP_SERVER_URL="$${MCP_SERVER_URL:-http://127.0.0.1:8080/sse}" \
-	  uv run uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
+	  uv run $${MLFLOW_TRACKING_URI:+--extra tracing} uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-app-fresh: ## Kill existing process on port and run agent with hot-reload
 	@[ -d .venv ] || { echo "ERROR: .venv not found — run 'make env' first"; exit 1; }
+	@[ -f .env ] || { echo "ERROR: .env not found — run 'make init' first"; exit 1; }
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Killing existing process on port $${PORT:-8000}..." && \
 	  lsof -ti:$${PORT:-8000} | xargs kill -9 2>/dev/null; true && \

--- a/agents/autogen/mcp_agent/Makefile
+++ b/agents/autogen/mcp_agent/Makefile
@@ -49,6 +49,7 @@ ollama: ## Install Ollama, start it, and pull models
 	  echo "Done. Run 'make llama-server' to start the Llama Stack server."
 
 llama-server: ## Install llama-stack and start Llama Stack server
+	@[ -d .venv ] || { echo "ERROR: .venv not found — run 'make env' first"; exit 1; }
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Installing llama-stack dependencies..." && \
 	  uv sync --extra llama && \
@@ -59,6 +60,7 @@ llama-server: ## Install llama-stack and start Llama Stack server
 	  llama stack run ../../../run_llama_server.yaml
 
 run-app: ## Run agent locally with hot-reload
+	@[ -d .venv ] || { echo "ERROR: .venv not found — run 'make env' first"; exit 1; }
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  if lsof -ti:$${PORT:-8000} >/dev/null 2>&1; then \
 	    echo "ERROR: Port $${PORT:-8000} is already in use." && \
@@ -69,6 +71,7 @@ run-app: ## Run agent locally with hot-reload
 	  uv run uvicorn main:app --host 127.0.0.1 --port $${PORT:-8000} --reload --reload-exclude .venv
 
 run-app-fresh: ## Kill existing process on port and run agent with hot-reload
+	@[ -d .venv ] || { echo "ERROR: .venv not found — run 'make env' first"; exit 1; }
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Killing existing process on port $${PORT:-8000}..." && \
 	  lsof -ti:$${PORT:-8000} | xargs kill -9 2>/dev/null; true && \

--- a/agents/autogen/mcp_agent/README.md
+++ b/agents/autogen/mcp_agent/README.md
@@ -151,7 +151,7 @@ Then start the MLflow server in a separate terminal:
 uv run --extra tracing mlflow server --port 5000
 ```
 
-When `MLFLOW_TRACKING_URI` is set, `make run` will automatically install the tracing dependency.
+When `MLFLOW_TRACKING_URI` is set, `make run-app` will automatically install the tracing dependency.
 
 #### Tracing with an OpenShift MLflow server
 

--- a/agents/autogen/mcp_agent/README.md
+++ b/agents/autogen/mcp_agent/README.md
@@ -42,9 +42,19 @@ cd agents/autogen/mcp_agent
 make init        # creates .env from .env.example
 ```
 
-### Configuration
+### Install dependencies
 
-#### Pointing to a locally hosted model
+```bash
+make env
+```
+
+### Configure your model
+
+Edit `.env` to point the agent at an LLM. Choose **one** of the two options below.
+
+#### Option A: Local model (Ollama + Llama Stack)
+
+Set the following in `.env`:
 
 ```ini
 API_KEY=not-needed
@@ -52,9 +62,24 @@ BASE_URL=http://localhost:11434/v1
 MODEL_ID=llama3.1:8b
 ```
 
-See [Local Development](../../../docs/local-development.md) for Ollama + Llama Stack setup for local model serving.
+Then install Ollama and pull the model:
 
-#### Pointing to a remotely hosted model
+```bash
+make ollama                    # default model: llama3.1:8b
+make ollama MODEL=llama3.2:3b  # or specify a different model
+```
+
+Start the Llama Stack server (keep this terminal open):
+
+```bash
+make llama-server
+```
+
+> You should see output indicating the server started on `http://localhost:8321`.
+
+#### Option B: Remote model
+
+Set the following in `.env`:
 
 ```ini
 API_KEY=your-api-key-here
@@ -62,19 +87,17 @@ BASE_URL=https://your-model-endpoint.com/v1
 MODEL_ID=llama-3.1-8b-instruct
 ```
 
-**Notes:**
-
 - `API_KEY` - your API key or contact your cluster administrator
 - `BASE_URL` - should end with `/v1`
 - `MODEL_ID` - model identifier available on your endpoint
 
-#### MCP Configuration
+### MCP Configuration
 
 The agent can connect to any MCP server that supports SSE transport. By default it points to the bundled `mcp_automl_template` server(no configuration needed):
 
 | Environment | Default `MCP_SERVER_URL` | How it's set |
 |-------------|--------------------------|--------------|
-| Local (`make run`) | `http://127.0.0.1:8080/sse` | Makefile fallback |
+| Local (`make run-app`) | `http://127.0.0.1:8080/sse` | Makefile fallback |
 | OpenShift (`make deploy`) | `http://mcp-automl:8080/sse` | `values.yaml` (in-cluster service DNS) |
 
 To connect to an external MCP server, set `MCP_SERVER_URL` in your `.env`:
@@ -188,7 +211,8 @@ This starts the MCP AutoML server on port 8080.
 #### Terminal 2 — Start agent
 
 ```bash
-make run
+make run-app           # fails if port is already in use
+make run-app-fresh     # kills existing process on port, then starts
 ```
 
 The agent starts on port 8000. Open [http://localhost:8000](http://localhost:8000) in your browser. A green dot in

--- a/agents/autogen/mcp_agent/pyproject.toml
+++ b/agents/autogen/mcp_agent/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 llama = [
     "llama-stack>=0.7.1",
     "llama-stack-api>=0.7.1",
-    "ollama",
+    "ollama>=0.4.0",
     "milvus-lite>=2.5.1",
     "pymilvus>=2.6.9",
     "chardet>=7.1.0",

--- a/agents/autogen/mcp_agent/pyproject.toml
+++ b/agents/autogen/mcp_agent/pyproject.toml
@@ -24,6 +24,15 @@ tracing = [
 dev = [
     "pytest>=9.0.2",
 ]
+llama = [
+    "llama-stack>=0.7.1",
+    "llama-stack-api>=0.7.1",
+    "ollama",
+    "milvus-lite>=2.5.1",
+    "pymilvus>=2.6.9",
+    "chardet>=7.1.0",
+    "pypdf>=6.9.0",
+]
 [tool.setuptools.packages.find]
 where = ["src"]
 


### PR DESCRIPTION
### Summary

- Add missing `make env`, `make ollama`, `make llama-server`, `make run-app`, and `make run-app-fresh` targets to the autogen mcp_agent Makefile, aligning it with the standard agent Makefile pattern used across the repo
- Update README with step-by-step local setup instructions (Option A: local model via Ollama + Llama Stack, Option B: remote model)
- Add [llama] optional dependency group in pyproject.toml for Llama Stack server dependencies (llama-stack, ollama, milvus-lite, pymilvus, etc.)
- Rename make run to make run-app for consistency with other agents; fix stale make run references in .env.example and README

### Test plan

- [x]  make init creates .env from .env.example
- [x]  make env creates virtualenv and installs dependencies via uv sync
- [x]  make run-app starts the agent on port 8000 with hot-reload
- [x]  make run-app-fresh kills any existing process on the port before starting
- [x]  make help displays all new targets with correct formatting
- [x]  Verify make ollama and make llama-server targets work for local model setup