### PR TITLE
chore: add PR template rule to CLAUDE.md instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,11 @@ make dry-run    # preview Helm manifests
 - Source code in `src/<agent_name>/` within each agent directory
 - Keep agents self-contained -- never import from another agent's `src/`
 
+## Pull requests
+
+- When creating a PR, always read `.github/PULL_REQUEST_TEMPLATE.md` and use its contents as the PR body structure. Fill in each section appropriately. This applies whether using `gh pr create`, the GitHub web UI, or any other method.
+- Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for PR titles (e.g., `feat:`, `fix:`, `chore:`)
+
 ## Workflow
 
 - `cd` into the agent directory first -- Makefiles use relative paths and read `agent.yaml` at runtime

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,12 +30,6 @@ make dry-run    # preview Helm manifests
 - All agents must expose `POST /chat/completions` (JSON + SSE) and `GET /health`
 - Source code in `src/<agent_name>/` within each agent directory
 - Keep agents self-contained -- never import from another agent's `src/`
-
-## Pull requests
-
-- When creating a PR, always read `.github/PULL_REQUEST_TEMPLATE.md` and use its contents as the PR body structure. Fill in each section appropriately. This applies whether using `gh pr create`, the GitHub web UI, or any other method.
-- Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for PR titles (e.g., `feat:`, `fix:`, `chore:`)
-
 ## Workflow
 
 - `cd` into the agent directory first -- Makefiles use relative paths and read `agent.yaml` at runtime

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing. This document gives a short overvie
 
 - **Report bugs or suggest features** – Open an [issue](https://github.com/red-hat-data-services/agentic-starter-kits/issues) and describe the problem or idea. Check existing issues first to avoid duplicates.
 
-- **Submit code changes** – Create a branch (in your fork or directly in this repo if you have access), make your changes, and open a pull request (PR). You don’t need to fork if you can push branches here. Keep PRs focused; one feature or fix per PR is easier to review.
+- **Submit code changes** – Create a branch (in your fork or directly in this repo if you have access), make your changes, and open a pull request (PR). You don’t need to fork if you can push branches here. Keep PRs focused; one feature or fix per PR is easier to review. When creating a PR, use the [PR template](.github/PULL_REQUEST_TEMPLATE.md) and fill in each section.
 
 - **Improve documentation** – Fixes and clarifications in the README, agent docs, or code comments are always welcome. Use the `docs:` prefix in your commit (see below).
 


### PR DESCRIPTION
## Description

Adds a "Pull requests" section to AGENTS.md instructing Claude Code to read and use `.github/PULL_REQUEST_TEMPLATE.md` when creating PRs via CLI. Also documents the conventional commits requirement for PR titles.

## Jira Ticket

N/A

## Testing

- [ ] `make test` passes (run from the affected agent directory)
- [ ] Manual testing performed (describe steps below)
- [x] No testing required (documentation/config change only)

PR #72 was created by Claude Code using this rule — confirmed all template sections were populated.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)

## Review Guidance

Documentation-only change to AGENTS.md — adds 4 lines under a new "Pull requests" section before "Workflow".

## Related PRs

- #66 (PR template)
- #72 (test PR verifying this rule works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)