### PR TITLE
fix: remove response body logging and align tracing structure across agents

### DIFF
--- a/agents/autogen/mcp_agent/src/autogen_agent_base/tracing.py
+++ b/agents/autogen/mcp_agent/src/autogen_agent_base/tracing.py
@@ -74,7 +74,7 @@ def enable_tracing() -> None:
     except ModuleNotFoundError as e:
         raise ModuleNotFoundError(
             "MLFLOW_TRACKING_URI is set but mlflow is not installed. "
-            "Install it with: uv sync --extra tracing'"
+            "Install it with: uv sync --extra tracing"
         ) from e
 
     # Check if server is reachable

--- a/agents/autogen/mcp_agent/src/autogen_agent_base/tracing.py
+++ b/agents/autogen/mcp_agent/src/autogen_agent_base/tracing.py
@@ -43,8 +43,7 @@ def check_mlflow_health(mlflow_tracking_uri: str, max_wait_time: int = 5, retry_
                 logger.warning(
                     f"MLflow returned status code {response.status_code} at {mlflow_url}\n"
                     f"  Status Code: {response.status_code}\n"
-                    f"  Reason: {response.reason}\n"
-                    f"  Response Body: {response.text[:500]}"
+                    f"  Reason: {response.reason}"
                 )
         except requests.exceptions.RequestException as e:
             logger.warning(f"Failed to connect to MLflow at {mlflow_url}: {e}")

--- a/agents/crewai/websearch_agent/src/crewai_web_search/tracing.py
+++ b/agents/crewai/websearch_agent/src/crewai_web_search/tracing.py
@@ -45,8 +45,7 @@ def check_mlflow_health(mlflow_tracking_uri: str, max_wait_time: int = 5, retry_
                 logger.warning(
                     f"MLflow returned status code {response.status_code} at {mlflow_url}\n"
                     f"  Status Code: {response.status_code}\n"
-                    f"  Reason: {response.reason}\n"
-                    f"  Response Body: {response.text[:500]}"
+                    f"  Reason: {response.reason}"
                 )
         except requests.exceptions.RequestException as e:
             logger.warning(f"Failed to connect to MLflow at {mlflow_url}: {e}")
@@ -92,6 +91,15 @@ def enable_tracing() -> None:
         logger.info("[Tracing] MLFLOW_TRACKING_URI not set. Tracing is disabled.")
         return
 
+    try:
+        import mlflow
+        import mlflow.crewai
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "MLFLOW_TRACKING_URI is set but mlflow is not installed. "
+            "Install it with: uv sync --extra tracing'"
+        ) from e
+
     # Check if server is reachable
     try:
         try:
@@ -100,7 +108,7 @@ def enable_tracing() -> None:
             health_check_timeout = 5
         check_mlflow_health(mlflow_tracking_uri=tracking_uri, max_wait_time=health_check_timeout)
         logger.info(f"[Tracing] MLflow server is reachable at {tracking_uri}")
-    except (RuntimeError, ModuleNotFoundError) as e:
+    except RuntimeError as e:
         logger.warning(
             f"[Tracing] MLflow server is unreachable at {tracking_uri}. "
             f"Tried connecting for {health_check_timeout}s. Continuing without tracing. Error: {e}"
@@ -110,8 +118,6 @@ def enable_tracing() -> None:
     # Server is reachable → enable tracing
     try:
         import importlib
-        import mlflow
-        import mlflow.crewai
 
         mlflow.set_tracking_uri(tracking_uri)
         experiment_name: str = getenv("MLFLOW_EXPERIMENT_NAME", "default-agent-experiment")
@@ -155,10 +161,6 @@ def enable_tracing() -> None:
         logger.info(
             f"[Tracing Enabled] MLflow -> {tracking_uri}, Experiment: {experiment_name}, "
             f"LLM Provider: {llm_provider} ({module_name}.autolog())"
-        )
-    except ModuleNotFoundError:
-        logger.warning(
-            "[Tracing] MLflow not installed. Skipping tracing."
         )
     except Exception as e:
         logger.warning(

--- a/agents/crewai/websearch_agent/src/crewai_web_search/tracing.py
+++ b/agents/crewai/websearch_agent/src/crewai_web_search/tracing.py
@@ -97,7 +97,7 @@ def enable_tracing() -> None:
     except ModuleNotFoundError as e:
         raise ModuleNotFoundError(
             "MLFLOW_TRACKING_URI is set but mlflow is not installed. "
-            "Install it with: uv sync --extra tracing'"
+            "Install it with: uv sync --extra tracing"
         ) from e
 
     # Check if server is reachable

--- a/agents/langgraph/agentic_rag/src/agentic_rag/tracing.py
+++ b/agents/langgraph/agentic_rag/src/agentic_rag/tracing.py
@@ -74,7 +74,7 @@ def enable_tracing() -> None:
     except ModuleNotFoundError as e:
         raise ModuleNotFoundError(
             "MLFLOW_TRACKING_URI is set but mlflow is not installed. "
-            "Install it with: uv sync --extra tracing'"
+            "Install it with: uv sync --extra tracing"
         ) from e
 
     # Check if server is reachable

--- a/agents/langgraph/agentic_rag/src/agentic_rag/tracing.py
+++ b/agents/langgraph/agentic_rag/src/agentic_rag/tracing.py
@@ -43,8 +43,7 @@ def check_mlflow_health(mlflow_tracking_uri: str, max_wait_time: int = 5, retry_
                 logger.warning(
                     f"MLflow returned status code {response.status_code} at {mlflow_url}\n"
                     f"  Status Code: {response.status_code}\n"
-                    f"  Reason: {response.reason}\n"
-                    f"  Response Body: {response.text[:500]}"
+                    f"  Reason: {response.reason}"
                 )
         except requests.exceptions.RequestException as e:
             logger.warning(f"Failed to connect to MLflow at {mlflow_url}: {e}")
@@ -69,6 +68,15 @@ def enable_tracing() -> None:
         logger.info("[Tracing] MLFLOW_TRACKING_URI not set. Tracing is disabled.")
         return
 
+    try:
+        import mlflow
+        import mlflow.langchain
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "MLFLOW_TRACKING_URI is set but mlflow is not installed. "
+            "Install it with: uv sync --extra tracing'"
+        ) from e
+
     # Check if server is reachable
     try:
         try:
@@ -77,7 +85,7 @@ def enable_tracing() -> None:
             health_check_timeout = 5
         check_mlflow_health(mlflow_tracking_uri=tracking_uri, max_wait_time=health_check_timeout)
         logger.info(f"[Tracing] MLflow server is reachable at {tracking_uri}")
-    except (RuntimeError, ModuleNotFoundError) as e:
+    except RuntimeError as e:
         logger.warning(
             f"[Tracing] MLflow server is unreachable at {tracking_uri}. "
             f"Tried connecting for {health_check_timeout}s. Continuing without tracing. Error: {e}"
@@ -86,9 +94,6 @@ def enable_tracing() -> None:
 
     # Server is reachable → enable tracing
     try:
-        import mlflow
-        import mlflow.langchain
-
         mlflow.set_tracking_uri(tracking_uri)
         experiment_name: str = getenv("MLFLOW_EXPERIMENT_NAME", "default-agent-experiment")
         mlflow.set_experiment(experiment_name)
@@ -97,10 +102,6 @@ def enable_tracing() -> None:
         mlflow.langchain.autolog()
 
         logger.info(f"[Tracing Enabled] MLflow -> {tracking_uri}, Experiment: {experiment_name}")
-    except ModuleNotFoundError:
-        logger.warning(
-            "[Tracing] MLflow not installed. Skipping tracing."
-        )
     except Exception as e:
         logger.warning(
             f"[Tracing] Failed to configure MLflow tracing at {tracking_uri}. "

--- a/agents/langgraph/human_in_the_loop/src/human_in_the_loop/tracing.py
+++ b/agents/langgraph/human_in_the_loop/src/human_in_the_loop/tracing.py
@@ -74,7 +74,7 @@ def enable_tracing() -> None:
     except ModuleNotFoundError as e:
         raise ModuleNotFoundError(
             "MLFLOW_TRACKING_URI is set but mlflow is not installed. "
-            "Install it with: uv sync --extra tracing'"
+            "Install it with: uv sync --extra tracing"
         ) from e
 
     # Check if server is reachable

--- a/agents/langgraph/human_in_the_loop/src/human_in_the_loop/tracing.py
+++ b/agents/langgraph/human_in_the_loop/src/human_in_the_loop/tracing.py
@@ -43,8 +43,7 @@ def check_mlflow_health(mlflow_tracking_uri: str, max_wait_time: int = 5, retry_
                 logger.warning(
                     f"MLflow returned status code {response.status_code} at {mlflow_url}\n"
                     f"  Status Code: {response.status_code}\n"
-                    f"  Reason: {response.reason}\n"
-                    f"  Response Body: {response.text[:500]}"
+                    f"  Reason: {response.reason}"
                 )
         except requests.exceptions.RequestException as e:
             logger.warning(f"Failed to connect to MLflow at {mlflow_url}: {e}")

--- a/agents/langgraph/react_agent/src/react_agent/tracing.py
+++ b/agents/langgraph/react_agent/src/react_agent/tracing.py
@@ -74,7 +74,7 @@ def enable_tracing() -> None:
     except ModuleNotFoundError as e:
         raise ModuleNotFoundError(
             "MLFLOW_TRACKING_URI is set but mlflow is not installed. "
-            "Install it with: uv sync --extra tracing'"
+            "Install it with: uv sync --extra tracing"
         ) from e
 
     # Check if server is reachable

--- a/agents/langgraph/react_agent/src/react_agent/tracing.py
+++ b/agents/langgraph/react_agent/src/react_agent/tracing.py
@@ -43,8 +43,7 @@ def check_mlflow_health(mlflow_tracking_uri: str, max_wait_time: int = 5, retry_
                 logger.warning(
                     f"MLflow returned status code {response.status_code} at {mlflow_url}\n"
                     f"  Status Code: {response.status_code}\n"
-                    f"  Reason: {response.reason}\n"
-                    f"  Response Body: {response.text[:500]}"
+                    f"  Reason: {response.reason}"
                 )
         except requests.exceptions.RequestException as e:
             logger.warning(f"Failed to connect to MLflow at {mlflow_url}: {e}")
@@ -69,6 +68,15 @@ def enable_tracing() -> None:
         logger.info("[Tracing] MLFLOW_TRACKING_URI not set. Tracing is disabled.")
         return
 
+    try:
+        import mlflow
+        import mlflow.langchain
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "MLFLOW_TRACKING_URI is set but mlflow is not installed. "
+            "Install it with: uv sync --extra tracing'"
+        ) from e
+
     # Check if server is reachable
     try:
         try:
@@ -77,7 +85,7 @@ def enable_tracing() -> None:
             health_check_timeout = 5
         check_mlflow_health(mlflow_tracking_uri=tracking_uri, max_wait_time=health_check_timeout)
         logger.info(f"[Tracing] MLflow server is reachable at {tracking_uri}")
-    except (RuntimeError, ModuleNotFoundError) as e:
+    except RuntimeError as e:
         logger.warning(
             f"[Tracing] MLflow server is unreachable at {tracking_uri}. "
             f"Tried connecting for {health_check_timeout}s. Continuing without tracing. Error: {e}"
@@ -86,9 +94,6 @@ def enable_tracing() -> None:
 
     # Server is reachable → enable tracing
     try:
-        import mlflow
-        import mlflow.langchain
-
         mlflow.set_tracking_uri(tracking_uri)
         experiment_name: str = getenv("MLFLOW_EXPERIMENT_NAME", "default-agent-experiment")
         mlflow.set_experiment(experiment_name)
@@ -97,10 +102,6 @@ def enable_tracing() -> None:
         mlflow.langchain.autolog()
 
         logger.info(f"[Tracing Enabled] MLflow -> {tracking_uri}, Experiment: {experiment_name}")
-    except ModuleNotFoundError:
-        logger.warning(
-            "[Tracing] MLflow not installed. Skipping tracing."
-        )
     except Exception as e:
         logger.warning(
             f"[Tracing] Failed to configure MLflow tracing at {tracking_uri}. "

--- a/agents/langgraph/react_with_database_memory/src/react_with_database_memory/tracing.py
+++ b/agents/langgraph/react_with_database_memory/src/react_with_database_memory/tracing.py
@@ -74,7 +74,7 @@ def enable_tracing() -> None:
     except ModuleNotFoundError as e:
         raise ModuleNotFoundError(
             "MLFLOW_TRACKING_URI is set but mlflow is not installed. "
-            "Install it with: uv sync --extra tracing'"
+            "Install it with: uv sync --extra tracing"
         ) from e
 
     # Check if server is reachable

--- a/agents/langgraph/react_with_database_memory/src/react_with_database_memory/tracing.py
+++ b/agents/langgraph/react_with_database_memory/src/react_with_database_memory/tracing.py
@@ -43,8 +43,7 @@ def check_mlflow_health(mlflow_tracking_uri: str, max_wait_time: int = 5, retry_
                 logger.warning(
                     f"MLflow returned status code {response.status_code} at {mlflow_url}\n"
                     f"  Status Code: {response.status_code}\n"
-                    f"  Reason: {response.reason}\n"
-                    f"  Response Body: {response.text[:500]}"
+                    f"  Reason: {response.reason}"
                 )
         except requests.exceptions.RequestException as e:
             logger.warning(f"Failed to connect to MLflow at {mlflow_url}: {e}")
@@ -69,6 +68,15 @@ def enable_tracing() -> None:
         logger.info("[Tracing] MLFLOW_TRACKING_URI not set. Tracing is disabled.")
         return
 
+    try:
+        import mlflow
+        import mlflow.langchain
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "MLFLOW_TRACKING_URI is set but mlflow is not installed. "
+            "Install it with: uv sync --extra tracing'"
+        ) from e
+
     # Check if server is reachable
     try:
         try:
@@ -77,7 +85,7 @@ def enable_tracing() -> None:
             health_check_timeout = 5
         check_mlflow_health(mlflow_tracking_uri=tracking_uri, max_wait_time=health_check_timeout)
         logger.info(f"[Tracing] MLflow server is reachable at {tracking_uri}")
-    except (RuntimeError, ModuleNotFoundError) as e:
+    except RuntimeError as e:
         logger.warning(
             f"[Tracing] MLflow server is unreachable at {tracking_uri}. "
             f"Tried connecting for {health_check_timeout}s. Continuing without tracing. Error: {e}"
@@ -86,9 +94,6 @@ def enable_tracing() -> None:
 
     # Server is reachable → enable tracing
     try:
-        import mlflow
-        import mlflow.langchain
-
         mlflow.set_tracking_uri(tracking_uri)
         experiment_name: str = getenv("MLFLOW_EXPERIMENT_NAME", "default-agent-experiment")
         mlflow.set_experiment(experiment_name)
@@ -97,10 +102,6 @@ def enable_tracing() -> None:
         mlflow.langchain.autolog()
 
         logger.info(f"[Tracing Enabled] MLflow -> {tracking_uri}, Experiment: {experiment_name}")
-    except ModuleNotFoundError:
-        logger.warning(
-            "[Tracing] MLflow not installed. Skipping tracing."
-        )
     except Exception as e:
         logger.warning(
             f"[Tracing] Failed to configure MLflow tracing at {tracking_uri}. "

--- a/agents/llamaindex/websearch_agent/src/websearch_agent/tracing.py
+++ b/agents/llamaindex/websearch_agent/src/websearch_agent/tracing.py
@@ -74,7 +74,7 @@ def enable_tracing() -> None:
     except ModuleNotFoundError as e:
         raise ModuleNotFoundError(
             "MLFLOW_TRACKING_URI is set but mlflow is not installed. "
-            "Install it with: uv sync --extra tracing'"
+            "Install it with: uv sync --extra tracing"
         ) from e
 
     # Check if server is reachable

--- a/agents/llamaindex/websearch_agent/src/websearch_agent/tracing.py
+++ b/agents/llamaindex/websearch_agent/src/websearch_agent/tracing.py
@@ -43,8 +43,7 @@ def check_mlflow_health(mlflow_tracking_uri: str, max_wait_time: int = 5, retry_
                 logger.warning(
                     f"MLflow returned status code {response.status_code} at {mlflow_url}\n"
                     f"  Status Code: {response.status_code}\n"
-                    f"  Reason: {response.reason}\n"
-                    f"  Response Body: {response.text[:500]}"
+                    f"  Reason: {response.reason}"
                 )
         except requests.exceptions.RequestException as e:
             logger.warning(f"Failed to connect to MLflow at {mlflow_url}: {e}")
@@ -69,6 +68,15 @@ def enable_tracing() -> None:
         logger.info("[Tracing] MLFLOW_TRACKING_URI not set. Tracing is disabled.")
         return
 
+    try:
+        import mlflow
+        import mlflow.llama_index
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "MLFLOW_TRACKING_URI is set but mlflow is not installed. "
+            "Install it with: uv sync --extra tracing'"
+        ) from e
+
     # Check if server is reachable
     try:
         try:
@@ -77,7 +85,7 @@ def enable_tracing() -> None:
             health_check_timeout = 5
         check_mlflow_health(mlflow_tracking_uri=tracking_uri, max_wait_time=health_check_timeout)
         logger.info(f"[Tracing] MLflow server is reachable at {tracking_uri}")
-    except (RuntimeError, ModuleNotFoundError) as e:
+    except RuntimeError as e:
         logger.warning(
             f"[Tracing] MLflow server is unreachable at {tracking_uri}. "
             f"Tried connecting for {health_check_timeout}s. Continuing without tracing. Error: {e}"
@@ -86,9 +94,6 @@ def enable_tracing() -> None:
 
     # Server is reachable → enable tracing
     try:
-        import mlflow
-        import mlflow.llama_index
-
         mlflow.set_tracking_uri(tracking_uri)
         experiment_name: str = getenv("MLFLOW_EXPERIMENT_NAME", "default-agent-experiment")
         mlflow.set_experiment(experiment_name)
@@ -97,10 +102,6 @@ def enable_tracing() -> None:
         mlflow.llama_index.autolog()
 
         logger.info(f"[Tracing Enabled] MLflow -> {tracking_uri}, Experiment: {experiment_name}")
-    except ModuleNotFoundError:
-        logger.warning(
-            "[Tracing] MLflow not installed. Skipping tracing."
-        )
     except Exception as e:
         logger.warning(
             f"[Tracing] Failed to configure MLflow tracing at {tracking_uri}. "

--- a/agents/vanilla_python/openai_responses_agent/src/openai_responses_agent/tracing.py
+++ b/agents/vanilla_python/openai_responses_agent/src/openai_responses_agent/tracing.py
@@ -97,7 +97,7 @@ def enable_tracing() -> None:
     except ModuleNotFoundError as e:
         raise ModuleNotFoundError(
             "MLFLOW_TRACKING_URI is set but mlflow is not installed. "
-            "Install it with: uv sync --extra tracing'"
+            "Install it with: uv sync --extra tracing"
         ) from e
 
     # Check if server is reachable

--- a/agents/vanilla_python/openai_responses_agent/src/openai_responses_agent/tracing.py
+++ b/agents/vanilla_python/openai_responses_agent/src/openai_responses_agent/tracing.py
@@ -45,8 +45,7 @@ def check_mlflow_health(mlflow_tracking_uri: str, max_wait_time: int = 5, retry_
                 logger.warning(
                     f"MLflow returned status code {response.status_code} at {mlflow_url}\n"
                     f"  Status Code: {response.status_code}\n"
-                    f"  Reason: {response.reason}\n"
-                    f"  Response Body: {response.text[:500]}"
+                    f"  Reason: {response.reason}"
                 )
         except requests.exceptions.RequestException as e:
             logger.warning(f"Failed to connect to MLflow at {mlflow_url}: {e}")
@@ -92,6 +91,15 @@ def enable_tracing() -> None:
         logger.info("[Tracing] MLFLOW_TRACKING_URI not set. Tracing is disabled.")
         return
 
+    try:
+        import mlflow
+        import mlflow.openai
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "MLFLOW_TRACKING_URI is set but mlflow is not installed. "
+            "Install it with: uv sync --extra tracing'"
+        ) from e
+
     # Check if server is reachable
     try:
         try:
@@ -100,7 +108,7 @@ def enable_tracing() -> None:
             health_check_timeout = 5
         check_mlflow_health(mlflow_tracking_uri=tracking_uri, max_wait_time=health_check_timeout)
         logger.info(f"[Tracing] MLflow server is reachable at {tracking_uri}")
-    except (RuntimeError, ModuleNotFoundError) as e:
+    except RuntimeError as e:
         logger.warning(
             f"[Tracing] MLflow server is unreachable at {tracking_uri}. "
             f"Tried connecting for {health_check_timeout}s. Continuing without tracing. Error: {e}"
@@ -109,9 +117,6 @@ def enable_tracing() -> None:
 
     # Server is reachable → enable tracing
     try:
-        import mlflow
-        import mlflow.openai
-
         mlflow.set_tracking_uri(tracking_uri)
         experiment_name: str = getenv("MLFLOW_EXPERIMENT_NAME", "default-agent-experiment")
         mlflow.set_experiment(experiment_name)
@@ -121,10 +126,6 @@ def enable_tracing() -> None:
 
         _TRACING_ENABLED = True
         logger.info(f"[Tracing Enabled] MLflow -> {tracking_uri}, Experiment: {experiment_name}")
-    except ModuleNotFoundError:
-        logger.warning(
-            "[Tracing] MLflow not installed. Skipping tracing."
-        )
     except Exception as e:
         logger.warning(
             f"[Tracing] Failed to configure MLflow tracing at {tracking_uri}. "


### PR DESCRIPTION
## Summary
- Remove `response.text` from health check warning logs across all 8 agents to avoid logging sensitive data (addresses Tarun's review on PR #62)
- Align `enable_tracing()` structure in 6 agents (react_agent, agentic_rag, react_with_database_memory, llamaindex, crewai, openai_responses) to match the HITL reference pattern:
  - Import mlflow early and raise `ModuleNotFoundError` immediately if missing
  - Health check catches only `RuntimeError` instead of `(RuntimeError, ModuleNotFoundError)`
  - Remove redundant `except ModuleNotFoundError` from the enable block

## Test plan
- [ ] Verify agents start correctly with `MLFLOW_TRACKING_URI` set and MLflow server running
- [ ] Verify agents raise `ModuleNotFoundError` when `MLFLOW_TRACKING_URI` is set but mlflow is not installed
- [ ] Verify agents log a warning and continue without tracing when MLflow server is unreachable
- [ ] Verify health check warning logs no longer include response body