### PR TITLE
RHAIENG-4028: Add QG4 cluster connection verification workflow

### DIFF
--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -1,0 +1,70 @@
+# QG4: Agent Deployment Health Checks
+#
+# Foundation workflow: validates that the GitHub Actions runner can connect
+# to the OpenShift cluster. Agent deployment and health checks will be
+# wired up in follow-up tickets.
+
+name: "QG4: Agent Deployment Health Checks"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  verify-cluster-connection:
+    name: "Verify Cluster Connection"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install Python 3.12
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+
+      - name: Install OpenShift CLI and Helm
+        uses: redhat-actions/openshift-tools-installer@144527c7d98999f2652264c048c7a9bd103f8a82 # v1.13.1
+        with:
+          oc: "4"
+          helm: "3"
+
+      - name: Verify installed tools
+        run: |
+          echo "--- oc ---"
+          oc version --client
+          echo ""
+          echo "--- helm ---"
+          helm version --short
+          echo ""
+          echo "--- python ---"
+          python3 --version
+          echo ""
+          echo "--- uv ---"
+          uv --version
+
+      - name: Login to OpenShift
+        run: |
+          oc login \
+            --token="${{ secrets.OC_TOKEN }}" \
+            --server="${{ secrets.CLUSTER_API_URL }}" \
+            --namespace=ci-testing
+
+      - name: Verify cluster connection
+        run: |
+          echo "--- Logged in as ---"
+          oc whoami
+          echo ""
+          echo "--- Current project ---"
+          oc project
+          echo ""
+          echo "--- Namespace resources ---"
+          oc get all -n ci-testing --no-headers 2>&1 | head -10
+          echo ""
+          echo "Cluster connection verified successfully."
+
+      - name: Logout
+        if: always()
+        run: oc logout || true

--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -7,6 +7,8 @@
 name: "QG4: Agent Deployment Health Checks"
 
 on:
+  schedule:
+    - cron: "0 3 * * *" # 11 PM EDT / 10 PM EST
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -8,6 +8,9 @@ name: "QG4: Agent Deployment Health Checks"
 
 on:
   workflow_dispatch:
+  push: # TEMPORARY: remove before merging to main
+    branches:
+      - feat/RHAIENG-4028-ci-health-checks
 
 jobs:
   verify-cluster-connection:

--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -11,10 +11,14 @@ on:
     - cron: "0 3 * * *" # 11 PM EDT / 10 PM EST
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   verify-cluster-connection:
     name: "Verify Cluster Connection"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -48,14 +48,18 @@ jobs:
           uv --version
 
       - name: Login to OpenShift
+        env:
+          OC_TOKEN: ${{ secrets.OC_TOKEN }}
+          CLUSTER_API_URL: ${{ secrets.CLUSTER_API_URL }}
         run: |
           oc login \
-            --token="${{ secrets.OC_TOKEN }}" \
-            --server="${{ secrets.CLUSTER_API_URL }}" \
+            --token="$OC_TOKEN" \
+            --server="$CLUSTER_API_URL" \
             --namespace=ci-testing
 
       - name: Verify cluster connection
         run: |
+          set -o pipefail
           echo "--- Logged in as ---"
           oc whoami
           echo ""
@@ -63,7 +67,7 @@ jobs:
           oc project
           echo ""
           echo "--- Namespace resources ---"
-          oc get all -n ci-testing --no-headers 2>&1 | head -10
+          oc get all -n ci-testing --no-headers | head -10
           echo ""
           echo "Cluster connection verified successfully."
 

--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -8,9 +8,6 @@ name: "QG4: Agent Deployment Health Checks"
 
 on:
   workflow_dispatch:
-  push: # TEMPORARY: remove before merging to main
-    branches:
-      - feat/RHAIENG-4028-ci-health-checks
 
 jobs:
   verify-cluster-connection:


### PR DESCRIPTION
## Summary

- Adds a `workflow_dispatch` + nightly (`cron: 0 3 * * *` / 11 PM EDT) GitHub Actions workflow that verifies the CI runner can authenticate to the OpenShift cluster
- Installs oc, helm, Python 3.12, and uv in the runner environment
- Logs into the cluster using a service account token scoped to the `ci-testing` namespace with `edit` permissions
- Verifies the connection by running namespace-scoped queries (no cluster-level access required)
- Logs out in an `always()` step to clean up credentials

## Infrastructure setup

- OpenShift service account `github-actions` created in `ci-testing` namespace on `agen-e2e-rhoai2` cluster
- Long-lived token stored as repo-level GitHub secret `OC_TOKEN`
- Cluster API URL stored as repo-level GitHub secret `CLUSTER_API_URL`

## Validation

Workflow tested successfully via temporary push trigger — [run #24795729447](https://github.com/red-hat-data-services/agentic-starter-kits/actions/runs/24795729447). All steps passed: tool installation, login, namespace query, logout.

## Test plan

- [x] Create service account (`github-actions`) with `edit` role in `ci-testing` namespace
- [x] Generate long-lived token and store as repo-level GitHub secret `OC_TOKEN`
- [x] Store cluster API URL as repo-level GitHub secret `CLUSTER_API_URL`
- [x] Trigger workflow via temporary push trigger on feature branch
- [x] Verify all steps pass: tool install (oc 4.21.11, helm 3.18.0, Python 3.12.13, uv 0.11.7), login, namespace query, logout
- [x] Confirm service account authenticates as `system:serviceaccount:ci-testing:github-actions`
- [x] Confirm no cluster-level access is required (no `oc get nodes` or `oc cluster-info`)
- [x] Remove temporary push trigger after successful test
- [ ] Trigger workflow manually via Actions tab after merge to main
- [ ] Verify nightly schedule triggers at 11 PM EDT

Ticket: [RHAIENG-4028](https://redhat.atlassian.net/browse/RHAIENG-4028)

🤖 Generated with [Claude Code](https://claude.com/claude-code)