### PR TITLE
chore: add conventional commits pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+# Pre-commit configuration for agentic-starter-kits
+# Install: pre-commit install --install-hooks
+# Run manually: pre-commit run --all-files
+
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
+
+repos:
+  # Enforce Conventional Commits in commit messages
+  - repo: https://github.com/espressif/conventional-precommit-linter
+    rev: v1.11.0
+    hooks:
+      - id: conventional-precommit-linter
+        stages: [commit-msg]
+        # more args can be added here to customize the linter behavior
+        # more args can be found here: https://github.com/espressif/conventional-precommit-linter
+        args:
+          - --types=feat,fix,docs,chore,test,perf,refactor,ci,build,style,revert
+          - --subject-min-length=10
+          - --subject-max-length=72
+          - --allow-breaking

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,17 @@ Thank you for your interest in contributing. This document gives a short overvie
 
 Before submitting, please read our [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold it.
 
+## Development setup
+
+This repository uses [pre-commit](https://pre-commit.com/) hooks to enforce code quality checks before each commit. Set it up once after cloning:
+
+```bash
+pip install pre-commit
+pre-commit install --install-hooks
+```
+
+After this, every `git commit` will automatically validate your commit message format (see below).
+
 ## Linting and formatting
 
 This project uses [ruff](https://docs.astral.sh/ruff/) for Python linting and formatting. CI runs ruff as a blocking check on all pull requests.
@@ -31,18 +42,33 @@ Configuration is in [`ruff.toml`](ruff.toml) at the repo root.
 
 ## Commit message conventions
 
-We encourage [Conventional Commits](https://www.conventionalcommits.org/) so that history and release notes stay clear.
+This repository enforces the [Conventional Commits](https://www.conventionalcommits.org/) specification via a pre-commit hook. Commits that don't follow this format will be rejected.
 
-Use one of these prefixes at the start of your commit message:
+### Format
 
-| Prefix    | Meaning |
-| --------- | -------- |
-| **feat:** | A new feature |
-| **fix:**  | A bug fix |
-| **perf:** | A change that improves performance |
-| **chore:**| Maintenance (deps, tooling, config) |
-| **docs:** | Documentation only |
-| **test:** | Adding or updating tests |
+```
+<type>(optional scope): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Allowed types
+
+| Prefix        | Meaning |
+| ------------- | -------- |
+| **feat:**     | A new feature |
+| **fix:**      | A bug fix |
+| **docs:**     | Documentation only |
+| **chore:**    | Maintenance (deps, tooling, config) |
+| **test:**     | Adding or updating tests |
+| **perf:**     | A change that improves performance |
+| **refactor:** | Code change that neither fixes a bug nor adds a feature |
+| **ci:**       | CI/CD changes |
+| **build:**    | Build system or external dependency changes |
+| **style:**    | Code style (formatting, whitespace — no logic changes) |
+| **revert:**   | Reverts a previous commit |
 
 You can optionally add a scope (e.g. the agent or module name) in parentheses after the type.
 
@@ -54,9 +80,18 @@ fix: correct env var name in deployment in langgraph_react_agent
 docs: update README with OpenShift deploy steps
 test: add tests for tool registration
 chore: bump python-dotenv in requirements
+refactor(langgraph): extract tool registration into helper
+ci: add ruff linting workflow
+feat!: change /chat response format
 ```
 
-This is optional but appreciated; maintainers may ask you to reword commits when preparing a release.
+For breaking changes, add `!` after the type/scope (e.g. `feat!:`) or include a `BREAKING CHANGE:` footer:
+
+```
+feat: change /chat response format
+
+BREAKING CHANGE: response field "text" renamed to "content"
+```
 
 ## Automated PR labels
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Before submitting, please read our [Code of Conduct](CODE_OF_CONDUCT.md). By par
 This repository uses [pre-commit](https://pre-commit.com/) hooks to enforce code quality checks before each commit. Set it up once after cloning:
 
 ```bash
-pip install pre-commit
+uv tool install pre-commit
 pre-commit install --install-hooks
 ```
 
@@ -42,7 +42,9 @@ Configuration is in [`ruff.toml`](ruff.toml) at the repo root.
 
 ## Commit message conventions
 
-This repository enforces the [Conventional Commits](https://www.conventionalcommits.org/) specification via a pre-commit hook. Commits that don't follow this format will be rejected.
+This repository enforces the [Conventional Commits](https://www.conventionalcommits.org/) specification via a pre-commit hook. Commits that don't follow this format will be blocked locally by the pre-commit hook.
+
+> **Tip:** To bypass the hook in rare cases (e.g., merge commits, emergency hotfixes): `git commit --no-verify`
 
 ### Format
 


### PR DESCRIPTION
## Description

Adds a pre-commit hook to enforce the [Conventional Commits](https://www.conventionalcommits.org/) specification on all commit messages. Uses the [espressif/conventional-precommit-linter](https://github.com/espressif/conventional-precommit-linter) hook, which validates commit message format at the `commit-msg` stage.

Changes:
- `.pre-commit-config.yaml`: new file with the conventional commits hook configured with allowed types, subject length limits, and breaking change support
- `CONTRIBUTING.md`: added "Development setup" section with pre-commit install instructions and updated "Commit message conventions" with the enforced format, all allowed types, and examples

## Jira Ticket

 RHAIENG-4066

## Testing

- [ ] `make test` passes (run from the affected agent directory)
- [x] Manual testing performed (describe steps below)
- [x] No testing required (documentation/config change only)

Verified locally:
- Bad commit messages (e.g. `"updated stuff"`, `"chore: doc"`) are rejected
- Valid commit messages (e.g. `"chore: add conventional commits pre-commit hook"`) pass

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket

## Review Guidance

## Review Guidance

- `.pre-commit-config.yaml` — review the args to confirm the team is happy with the allowed types and subject length limits (min 10, max 72)
- Additional args available from the [linter](https://github.com/espressif/conventional-precommit-linter) that we're not currently using:
  - `--scopes`: restrict to specific scopes (currently unrestricted)
  - `--body-max-line-length`: limit body line length (currently unrestricted)
  - `--summary-uppercase`: enforce uppercase first letter
  - `--scope-case-insensitive`: allow uppercase in scopes
- This is phase 1 of pre-commit setup. Ruff, markdownlint, and file-hygiene hooks will be added in a follow-up PR once the linter configs (`ruff.toml`, `.markdownlint.json`) are in place.


## Related PRs

#80 (Tarun's Ruff linting and formatting — provides `ruff.toml` that future pre-commit hooks will use)
