### PR TITLE
docs: document Jira + GitHub PR linking integration

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ## Jira Ticket
 
-<!-- e.g. RHAIENG-123 -->
+<!-- e.g. RHAIENG-123. Include the ticket ID so the PR appears as a linked pull request on the Jira issue. -->
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ BREAKING CHANGE: response field "text" renamed to "content"
 
 ## Linking PRs to Jira
 
-This repository has GitHub + Jira integration enabled. When you include a Jira ticket ID (e.g. `RHAIENG-123`) in your PR title, branch name, or the **Jira Ticket** field in the PR template, the pull request automatically appears under **Development** on the Jira issue. This gives the visibility into which tickets have active or merged code without leaving Jira.
+This repository has GitHub + Jira integration enabled. When you include a Jira ticket ID (e.g. `RHAIENG-123`) in your PR title, branch name, commit message, or PR description, the pull request automatically appears under **Development** on the Jira issue. This gives visibility into which tickets have active or merged code without leaving Jira.
 
 ## Automated PR labels
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,10 @@ feat: change /chat response format
 BREAKING CHANGE: response field "text" renamed to "content"
 ```
 
+## Linking PRs to Jira
+
+This repository has GitHub + Jira integration enabled. When you include a Jira ticket ID (e.g. `RHAIENG-123`) in your PR title, branch name, or the **Jira Ticket** field in the PR template, the pull request automatically appears under **Development** on the Jira issue. This gives the visibility into which tickets have active or merged code without leaving Jira.
+
 ## Automated PR labels
 
 Every pull request is automatically labeled when opened or updated:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ This repository enforces the [Conventional Commits](https://www.conventionalcomm
 
 ### Format
 
-```
+```text
 <type>(optional scope): <description>
 
 [optional body]
@@ -102,7 +102,7 @@ feat!: change /chat response format
 
 For breaking changes, add `!` after the type/scope (e.g. `feat!:`) or include a `BREAKING CHANGE:` footer:
 
-```
+```text
 feat: change /chat response format
 
 BREAKING CHANGE: response field "text" renamed to "content"


### PR DESCRIPTION
## Description

Adds documentation for the Jira + GitHub integration that shows linked PRs on Jira issues. Updates CONTRIBUTING.md with a new "Linking PRs to Jira" section and clarifies the Jira Ticket field in the PR template.

## Jira Ticket

[RHAIENG-4115](https://redhat.atlassian.net/browse/RHAIENG-4115)

## Testing

- [x] No testing required (documentation/config change only)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)

## Review Guidance

Documentation-only change — two files affected:
- `CONTRIBUTING.md` — new "Linking PRs to Jira" section after "Commit message conventions"
- `.github/PULL_REQUEST_TEMPLATE.md` — expanded comment on the Jira Ticket field

## Related PRs

<!-- None -->

[RHAIENG-4115]: https://redhat.atlassian.net/browse/RHAIENG-4115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ