### PR TITLE
feat: add actionlint to CI and pre-commit for workflow validation

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -38,6 +38,13 @@ jobs:
         run: ruff format --check .
 
       - name: Markdownlint
+        # v23.0.0 bundles markdownlint-cli2 0.22.1 — keep in sync with .pre-commit-config.yaml
         uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9  # v23.0.0
         with:
           globs: "**/*.md"
+
+      - name: Actionlint
+        # shellcheck is pre-installed on ubuntu-latest, so run: steps are also linted
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8  # v2.1.2
+        with:
+          version: 1.7.12

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,3 +58,11 @@ repos:
     hooks:
       - id: markdownlint-cli2
         args: [--fix]
+
+  # Actionlint — GitHub Actions workflow validation
+  # Keep version in sync with raven-actions/actionlint in .github/workflows/code-quality.yml
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+        files: ^\.github/workflows/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,9 +69,13 @@ General-purpose checks from [pre-commit/pre-commit-hooks](https://github.com/pre
 | `no-commit-to-branch` | Blocks direct commits to `main` |
 | `detect-private-key` | Catches accidentally committed private keys |
 
+### GitHub Actions workflow validation (actionlint)
+
+Validates `.github/workflows/` files using [actionlint](https://github.com/rhysd/actionlint). Only runs when workflow files are staged.
+
 ## Linting and formatting
 
-This project uses [ruff](https://docs.astral.sh/ruff/) for Python linting and formatting, and [markdownlint](https://github.com/DavidAnson/markdownlint) for Markdown linting. Both run as blocking CI checks on all pull requests via the `Code Quality` workflow.
+This project uses [ruff](https://docs.astral.sh/ruff/) (Python), [markdownlint](https://github.com/DavidAnson/markdownlint) (Markdown), and [actionlint](https://github.com/rhysd/actionlint) (GitHub Actions workflows). All three run as blocking CI checks on every pull request via the `Code Quality` workflow.
 
 ### Python (ruff)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,31 +75,9 @@ Validates `.github/workflows/` files using [actionlint](https://github.com/rhysd
 
 ## Linting and formatting
 
-This project uses [ruff](https://docs.astral.sh/ruff/) (Python), [markdownlint](https://github.com/DavidAnson/markdownlint) (Markdown), and [actionlint](https://github.com/rhysd/actionlint) (GitHub Actions workflows). All three run as blocking CI checks on every pull request via the `Code Quality` workflow.
+This project uses [ruff](https://docs.astral.sh/ruff/) for Python linting and formatting, [markdownlint](https://github.com/DavidAnson/markdownlint) for Markdown linting, and [actionlint](https://github.com/rhysd/actionlint) for GitHub Actions workflow validation. All three run as blocking CI checks on every pull request via the `Code Quality` workflow, and locally via the [pre-commit hooks](#pre-commit-hooks) described above.
 
-### Python (ruff)
-
-Run locally before pushing:
-
-```bash
-uv tool install ruff==0.15.11
-ruff check .          # lint
-ruff format --check . # format check
-ruff format .         # auto-format
-```
-
-Configuration is in [`ruff.toml`](ruff.toml) at the repo root.
-
-### Markdown (markdownlint)
-
-Run locally before pushing:
-
-```bash
-npx markdownlint-cli2@0.22.1 "**/*.md"          # lint
-npx markdownlint-cli2@0.22.1 --fix "**/*.md"    # auto-fix
-```
-
-Configuration is in [`.markdownlint.jsonc`](.markdownlint.jsonc) (rules) and [`.markdownlint-cli2.yaml`](.markdownlint-cli2.yaml) (ignored paths) at the repo root.
+Configuration files: [`ruff.toml`](ruff.toml) (Python rules), [`.markdownlint.jsonc`](.markdownlint.jsonc) (Markdown rules), [`.markdownlint-cli2.yaml`](.markdownlint-cli2.yaml) (ignored paths).
 
 ## Commit message conventions
 


### PR DESCRIPTION
## Description

Add actionlint to the CI pipeline and pre-commit configuration to validate GitHub Actions workflow files, completing the workflow validation scope of RHAIENG-4067.

Changes:
- Add actionlint step to the `Code Quality` CI workflow using SHA-pinned `raven-actions/actionlint` action (v2.1.2, actionlint binary v1.7.12)
- Add actionlint hook to `.pre-commit-config.yaml` with `files: ^\.github/workflows/` filter
- Document actionlint in `CONTRIBUTING.md` under Pre-commit hooks and Linting sections
- Remove redundant manual linter instructions from `CONTRIBUTING.md` (now covered by pre-commit hooks)

## Jira Ticket

RHAIENG-4067

## Testing

- [ ] `make test` passes (run from the affected agent directory)
- [ ] Manual testing performed (describe steps below)
- [x] No testing required (documentation/config change only)

Verified locally:
- `actionlint` passes on all existing workflow files with zero violations
- `pre-commit run actionlint --all-files` passes
- Actionlint binary version (1.7.12) is consistent between CI and pre-commit

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)

## Review Guidance

- `code-quality.yml`: actionlint step uses SHA-pinned action with explicit binary version pinned to match pre-commit
- `.pre-commit-config.yaml`: actionlint hook only runs when `.github/workflows/` files are staged
- `CONTRIBUTING.md`: removed redundant manual ruff/markdownlint instructions (pre-commit handles them), added actionlint to Pre-commit hooks section and Linting intro

## Related PRs

- #91 — pre-commit hooks for ruff, markdownlint, conventional commits, and file-hygiene