### PR TITLE
feat: Add llm-d infrastructure deployment guide and test tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ agentic-starter-kits/
 ├── charts/
 │   ├── agent/                       # Shared Helm chart for all standard agents
 │   └── a2a-langgraph-crewai/        # Dedicated Helm chart for A2A agent
+├── infrastructure/
+│   └── llm-d/                       # llm-d deployment manifests and test tooling
 ├── docs/                            # Guides: local dev, deployment, contributing
 ├── pyproject.toml                   # Test deps & pytest config
 └── README.md
@@ -148,6 +150,7 @@ See `tests/behavioral/` for full details.
 - [Adding a New Agent](./docs/adding-a-new-agent.md) — How to contribute a new agent template
 - [Adding Behavioral Tests](./docs/adding-behavioral-tests.md) — How to add test coverage for an agent
 - [Adding an EvalHub Agent Integration](./docs/adding-evalhub-agent-integration.md) — How to integrate a new agent into the EvalHub evaluation pipeline
+- [llm-d Deployment](./docs/llm-d-deployment.md) — Deploy llm-d for intelligent LLM inference routing on OpenShift AI
 
 ## Additional Resources
 

--- a/docs/llm-d-deployment.md
+++ b/docs/llm-d-deployment.md
@@ -1,0 +1,170 @@
+# Deploying llm-d on OpenShift AI
+
+Deploy multiple vLLM instances across separate GPU nodes with llm-d orchestrating intelligent request routing (prefix-cache-aware, queue-based, active-request scoring). Optionally integrate with Llama Stack for the Responses API.
+
+## Architecture
+
+```
+Client → Llama Stack (optional) → Gateway → llm-d scheduler → vLLM pods (N x GPU nodes)
+```
+
+llm-d is a **routing and orchestration layer**, not a model-sharding tool. Each vLLM instance holds a complete copy of the model. llm-d intelligently routes requests across replicas to maximize KV cache hits and balance load.
+
+## Prerequisites
+
+| Requirement | Description |
+|-------------|-------------|
+| **OpenShift cluster** | 4.19+ with ROSA HCP or self-managed |
+| **RHOAI 3.4+** | Red Hat OpenShift AI operator (fast-3.x channel) |
+| **NFD Operator** | Node Feature Discovery — detects GPU hardware. Create a `NodeFeatureDiscovery` instance after installing. |
+| **NVIDIA GPU Operator** | Installs drivers and device plugins. Create a `ClusterPolicy` after installing. |
+| **Red Hat Connectivity Link** | Provides Kuadrant/Authorino for auth — required by RHOAI 3.4 MaaS. Install from OperatorHub. |
+| **Models-as-a-Service enabled** | Must be enabled in the DataScienceCluster (see below) |
+| **Red Hat registry pull secret** | Access to `registry.redhat.io` for vLLM images |
+
+### Enable Models-as-a-Service
+
+```bash
+oc patch dsc default-dsc --type merge \
+  -p '{"spec":{"components":{"kserve":{"modelsAsService":{"managementState":"Managed"}}}}}'
+```
+
+## Configuration Reference
+
+The following values are specific to your environment. Replace all `<PLACEHOLDER>` values in the commands and YAML files below with your own.
+
+| Placeholder | Description | Example |
+|-------------|-------------|---------|
+| `<CLUSTER_NAME>` | Your ROSA cluster name | `my-cluster` |
+| `<REGION>` | AWS region where the cluster runs | `us-east-2` |
+| `<MODEL_URI>` | HuggingFace model URI (must fit on a single GPU) | `hf://openai/gpt-oss-20b` |
+| `<MODEL_NAME>` | Model identifier used in API requests | `openai/gpt-oss-20b` |
+| `<REPLICAS>` | Number of vLLM replicas (one per GPU node) | `6` |
+| `<INSTANCE_TYPE>` | GPU instance type for the node pool | `g6.xlarge` (1x L4 23GB) |
+| `<NODE_POOL_NAME>` | Label for GPU node pool scheduling | `gpu-llmd-nodes` |
+| `<PULL_SECRET_FILE>` | Path to your Red Hat registry pull secret YAML | `my-pull-secret.yaml` |
+| `<PULL_SECRET_NAME>` | Name of the pull secret in the cluster | `my-pull-secret` |
+| `<VLLM_IMAGE>` | vLLM container image — get the latest digest from the [Red Hat Ecosystem Catalog](https://catalog.redhat.com/en/software/containers/rhaiis/vllm-cuda-rhel9) | `registry.redhat.io/rhaiis/vllm-cuda-rhel9@sha256:...` |
+| `<GATEWAY_HOST>` | The maas-default-gateway external hostname (auto-assigned ELB or manually configured) | `a1b2c3.us-east-2.elb.amazonaws.com` |
+| `<LLAMASTACK_ROUTE>` | Llama Stack external route hostname (if using Llama Stack) | `llamastack-route-redhat-ods-applications.apps.example.com` |
+
+## Step 1: Create GPU Node Pool
+
+Create a machine pool with GPU nodes. Each node should have at least one GPU with enough VRAM to hold your model.
+
+```bash
+rosa create machinepool --cluster <CLUSTER_NAME> \
+  --name <NODE_POOL_NAME> \
+  --instance-type <INSTANCE_TYPE> \
+  --replicas <REPLICAS> \
+  --labels "node-pool=<NODE_POOL_NAME>" \
+  --region <REGION>
+```
+
+Wait for all nodes to be ready and GPUs detected:
+
+```bash
+oc get nodes -l node-pool=<NODE_POOL_NAME> \
+  -o custom-columns='NAME:.metadata.name,GPU:.status.capacity.nvidia\.com/gpu,GPU_PRODUCT:.metadata.labels.nvidia\.com/gpu\.product'
+```
+
+## Step 2: Apply Pull Secret
+
+Apply your Red Hat registry pull secret and link it to the default service account:
+
+```bash
+oc apply -f <PULL_SECRET_FILE> -n redhat-ods-applications
+oc secrets link default <PULL_SECRET_NAME> --for=pull -n redhat-ods-applications
+```
+
+## Step 3: Deploy LLMInferenceService
+
+Deploy the LLMInferenceService in the `redhat-ods-applications` namespace. This is required because the `data-science-gateway` only allows routes from this namespace.
+
+A ready-to-use YAML template is at [`infrastructure/llm-d/llminferenceservice.yaml`](../infrastructure/llm-d/llminferenceservice.yaml). Edit the placeholders and apply:
+
+```bash
+oc apply -f infrastructure/llm-d/llminferenceservice.yaml
+```
+
+**Important:** `spec.router.scheduler: {}` must be explicitly set. Without it, the controller skips scheduler/router creation and you get vLLM pods but no intelligent routing.
+
+**Gateway choice:** The YAML uses `maas-default-gateway` instead of `data-science-gateway`. The `data-science-gateway` has an OAuth proxy designed for browser access, which blocks programmatic API calls. The `maas-default-gateway` has no OAuth proxy and is suitable for API clients like Llama Stack.
+
+## Step 4: Create Network Policies
+
+The default RHOAI network policy blocks port 8000. Apply the required network policies:
+
+```bash
+oc apply -f infrastructure/llm-d/network-policies.yaml
+```
+
+See [`infrastructure/llm-d/network-policies.yaml`](../infrastructure/llm-d/network-policies.yaml) for details.
+
+## Step 5: Configure Llama Stack (Optional)
+
+If integrating with Llama Stack, set these environment variables in your Llama Stack deployment:
+
+| Variable | Value | Notes |
+|----------|-------|-------|
+| `VLLM_URL` | `http://<GATEWAY_HOST>/redhat-ods-applications/<SERVICE_NAME>/v1` | Must end with `/v1` — the OpenAI SDK appends `/models`, `/chat/completions`, etc. to this base URL |
+| `VLLM_TLS_VERIFY` | `false` | Required when using self-signed certs |
+| `VLLM_API_KEY` | *(leave empty)* | Not needed — the maas-default-gateway has no auth |
+
+To find your `<GATEWAY_HOST>`:
+
+```bash
+oc get llminferenceservice <SERVICE_NAME> -n redhat-ods-applications -o jsonpath='{.status.url}'
+```
+
+If deploying Llama Stack in the same namespace with an external route, apply the Llama Stack network policy from `network-policies.yaml` to allow ingress from the OpenShift router.
+
+## Verification
+
+### Check deployment status
+
+```bash
+# LLMInferenceService should show Ready: True
+oc get llminferenceservice -n redhat-ods-applications
+
+# Expected: N vLLM pods (1/1 Running) + 1 router-scheduler pod (2/2 Running)
+oc get pods -n redhat-ods-applications | grep <SERVICE_NAME>
+
+# InferencePool should exist
+oc get inferencepool -n redhat-ods-applications
+```
+
+### Test inference
+
+```bash
+# Direct to llm-d gateway
+curl -s http://<GATEWAY_HOST>/redhat-ods-applications/<SERVICE_NAME>/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"<MODEL_NAME>","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}'
+
+# Through Llama Stack (if configured)
+curl -s https://<LLAMASTACK_ROUTE>/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"<MODEL_NAME>","input":"Who is the president of the United States?"}'
+```
+
+### Test traffic distribution
+
+Use the included test script to validate llm-d's intelligent routing:
+
+```bash
+uv run --with aiohttp python infrastructure/llm-d/test_distribution.py \
+  --url http://<GATEWAY_HOST>/redhat-ods-applications/<SERVICE_NAME>/v1 \
+  --model <MODEL_NAME>
+```
+
+See [`infrastructure/llm-d/test_distribution.py`](../infrastructure/llm-d/test_distribution.py) for details.
+
+## Key Notes
+
+- **llm-d is a routing/orchestration layer.** Each vLLM instance holds a complete copy of the model. llm-d routes requests intelligently (prefix-cache-aware, queue-based, active-request scoring) rather than round-robin.
+- **LLMInferenceService** is the RHOAI-native way to deploy llm-d. It manages vLLM pods, the scheduler, InferencePool, and HTTPRoute automatically.
+- **RHOAI 3.4+ MaaS** requires Red Hat Connectivity Link (Kuadrant/Authorino) for auth and rate limiting.
+- **Use `maas-default-gateway`** for programmatic/API access. The `data-science-gateway` has an OAuth proxy meant for browser access.
+- **Custom NetworkPolicies are required.** The default RHOAI network policy blocks port 8000, which vLLM uses for serving.
+- **Choose a model that fits on a single GPU.** llm-d does not shard models across GPUs — each replica needs the full model in VRAM.

--- a/docs/llm-d-deployment.md
+++ b/docs/llm-d-deployment.md
@@ -4,7 +4,7 @@ Deploy multiple vLLM instances across separate GPU nodes with llm-d orchestratin
 
 ## Architecture
 
-```
+```text
 Client → Llama Stack (optional) → Gateway → llm-d scheduler → vLLM pods (N x GPU nodes)
 ```
 

--- a/docs/llm-d-deployment.md
+++ b/docs/llm-d-deployment.md
@@ -19,8 +19,15 @@ llm-d is a **routing and orchestration layer**, not a model-sharding tool. Each 
 | **NFD Operator** | Node Feature Discovery — detects GPU hardware. Create a `NodeFeatureDiscovery` instance after installing. |
 | **NVIDIA GPU Operator** | Installs drivers and device plugins. Create a `ClusterPolicy` after installing. |
 | **Red Hat Connectivity Link** | Provides Kuadrant/Authorino for auth — required by RHOAI 3.4 MaaS. Install from OperatorHub. |
+| **Authorino TLS configured** | Authorino must have TLS enabled with a valid certificate. See [RHOAI documentation](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4). |
+| **PostgreSQL database** | MaaS controller requires a `maas-db-config` secret in `redhat-ods-applications` with a `DB_CONNECTION_URL` key pointing to a PostgreSQL instance. See [RHOAI documentation](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4). |
+| **User Workload Monitoring** | Must be enabled on the cluster for MaaS metrics. See [OpenShift monitoring documentation](https://docs.openshift.com/container-platform/latest/observability/monitoring/enabling-monitoring-for-user-defined-projects.html). |
 | **Models-as-a-Service enabled** | Must be enabled in the DataScienceCluster (see below) |
 | **Red Hat registry pull secret** | Access to `registry.redhat.io` for vLLM images |
+
+> **Note:** The MaaS controller will fail to start if Authorino TLS, the PostgreSQL
+> database secret, or User Workload Monitoring are not configured. Check the
+> `maas-controller` pod logs for specific error messages if provisioning fails.
 
 ### Enable Models-as-a-Service
 
@@ -47,6 +54,17 @@ The following values are specific to your environment. Replace all `<PLACEHOLDER
 | `<VLLM_IMAGE>` | vLLM container image — get the latest digest from the [Red Hat Ecosystem Catalog](https://catalog.redhat.com/en/software/containers/rhaiis/vllm-cuda-rhel9) | `registry.redhat.io/rhaiis/vllm-cuda-rhel9@sha256:...` |
 | `<GATEWAY_HOST>` | The maas-default-gateway external hostname (auto-assigned ELB or manually configured) | `a1b2c3.us-east-2.elb.amazonaws.com` |
 | `<LLAMASTACK_ROUTE>` | Llama Stack external route hostname (if using Llama Stack) | `llamastack-route-redhat-ods-applications.apps.example.com` |
+
+## Recommended Models
+
+Choose a model that fits entirely on a single GPU — llm-d does not shard models across GPUs. Each replica loads the full model.
+
+| Model | Size | Min GPU VRAM | Notes |
+|-------|------|-------------|-------|
+| `openai/gpt-oss-20b` | ~20B params | ~16 GB (quantized) | Tested with this guide on L4 (23GB) nodes |
+| `meta-llama/Llama-3.1-8B-Instruct` | 8B params | ~8 GB (FP8) | Smaller model, works on most GPU types |
+
+Set `<MODEL_URI>` to `hf://<model_name>` (e.g., `hf://openai/gpt-oss-20b`) and `<MODEL_NAME>` to the model identifier used in API requests (e.g., `openai/gpt-oss-20b`).
 
 ## Step 1: Create GPU Node Pool
 

--- a/infrastructure/llm-d/README.md
+++ b/infrastructure/llm-d/README.md
@@ -1,0 +1,25 @@
+# llm-d Infrastructure
+
+Deploy llm-d on OpenShift AI for intelligent LLM inference routing across multiple vLLM replicas.
+
+llm-d is a Kubernetes-native routing and orchestration layer that sits in front of vLLM instances, providing prefix-cache-aware routing, queue-based load balancing, and active-request scoring instead of naive round-robin.
+
+## Contents
+
+| File | Description |
+|------|-------------|
+| [`llminferenceservice.yaml`](llminferenceservice.yaml) | LLMInferenceService custom resource template |
+| [`network-policies.yaml`](network-policies.yaml) | Required NetworkPolicies (RHOAI defaults block port 8000) |
+| [`test_distribution.py`](test_distribution.py) | Traffic distribution and performance test script |
+
+## Quick Start
+
+See the full deployment guide: [docs/llm-d-deployment.md](../../docs/llm-d-deployment.md)
+
+## Test Script Usage
+
+```bash
+uv run --with aiohttp python test_distribution.py \
+  --url http://<GATEWAY_HOST>/redhat-ods-applications/<SERVICE_NAME>/v1 \
+  --model <MODEL_NAME>
+```

--- a/infrastructure/llm-d/llminferenceservice.yaml
+++ b/infrastructure/llm-d/llminferenceservice.yaml
@@ -1,0 +1,81 @@
+# LLMInferenceService for llm-d deployment on OpenShift AI
+#
+# Before applying, replace the following placeholders with your values:
+#
+#   <SERVICE_NAME>    - Name for this deployment (e.g., my-model-llmd)
+#   <MODEL_URI>       - HuggingFace model URI (e.g., hf://openai/gpt-oss-20b)
+#   <MODEL_NAME>      - Model identifier for API requests (e.g., openai/gpt-oss-20b)
+#   <REPLICAS>        - Number of vLLM replicas, one per GPU node (e.g., 6)
+#   <NODE_POOL_NAME>  - Label on GPU nodes for scheduling (e.g., gpu-llmd-nodes)
+#   <VLLM_IMAGE>      - vLLM image from Red Hat Ecosystem Catalog
+#                       (e.g., registry.redhat.io/rhaiis/vllm-cuda-rhel9@sha256:...)
+#                       Find the latest at: https://catalog.redhat.com/en/software/containers/rhaiis/vllm-cuda-rhel9
+#
+# Deploy in redhat-ods-applications namespace (required by the gateway routing).
+#
+# Usage:
+#   oc apply -f llminferenceservice.yaml
+
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: <SERVICE_NAME>
+  namespace: redhat-ods-applications
+  annotations:
+    opendatahub.io/model-type: generative
+    openshift.io/display-name: <SERVICE_NAME>
+    security.opendatahub.io/enable-auth: 'false'
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8000"
+spec:
+  replicas: <REPLICAS>
+  model:
+    uri: <MODEL_URI>
+    name: <MODEL_NAME>
+  router:
+    # route: {} creates the HTTPRoute for external access
+    route: {}
+    # scheduler: {} is REQUIRED — without it, the controller skips
+    # creating the scheduler/router deployment and InferencePool
+    scheduler: {}
+    # Use maas-default-gateway (no OAuth proxy) instead of
+    # data-science-gateway (which has OAuth and blocks API clients)
+    gateway:
+      refs:
+        - name: maas-default-gateway
+          namespace: openshift-ingress
+  template:
+    nodeSelector:
+      node-pool: <NODE_POOL_NAME>
+    containers:
+      - name: main
+        image: <VLLM_IMAGE>
+        env:
+          - name: VLLM_ADDITIONAL_ARGS
+            value: "--max-model-len=16000 --tool-call-parser=openai --enable-auto-tool-choice"
+          - name: HF_HOME
+            value: /tmp/huggingface
+          - name: HOME
+            value: /tmp
+          - name: XDG_CACHE_HOME
+            value: /tmp/.cache
+          - name: VLLM_LOGGING_LEVEL
+            value: "DEBUG"
+        resources:
+          limits:
+            cpu: '4'
+            memory: 16Gi
+            nvidia.com/gpu: "1"
+          requests:
+            cpu: '2'
+            memory: 8Gi
+            nvidia.com/gpu: "1"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: HTTPS
+          initialDelaySeconds: 120
+          periodSeconds: 30
+          timeoutSeconds: 30
+          failureThreshold: 5

--- a/infrastructure/llm-d/llminferenceservice.yaml
+++ b/infrastructure/llm-d/llminferenceservice.yaml
@@ -24,6 +24,9 @@ metadata:
   annotations:
     opendatahub.io/model-type: generative
     openshift.io/display-name: <SERVICE_NAME>
+    # Auth is disabled because maas-default-gateway has no OAuth proxy.
+    # For production, consider enabling auth and using a ServiceAccount token
+    # or restricting access via NetworkPolicies.
     security.opendatahub.io/enable-auth: 'false'
     prometheus.io/path: /metrics
     prometheus.io/port: "8000"
@@ -70,6 +73,8 @@ spec:
             cpu: '2'
             memory: 8Gi
             nvidia.com/gpu: "1"
+        # KServe automatically injects TLS certs (--ssl-certfile, --ssl-keyfile)
+        # into the vLLM container at startup, so vLLM serves HTTPS on port 8000.
         livenessProbe:
           httpGet:
             path: /health

--- a/infrastructure/llm-d/network-policies.yaml
+++ b/infrastructure/llm-d/network-policies.yaml
@@ -1,0 +1,59 @@
+# Network Policies for llm-d on OpenShift AI
+#
+# The default RHOAI network policy blocks port 8000, which vLLM uses for serving.
+# These additional policies allow traffic to reach the vLLM and scheduler pods.
+#
+# Before applying, replace the following placeholder with your value:
+#
+#   <SERVICE_NAME>  - Must match the LLMInferenceService name (e.g., my-model-llmd)
+#
+# Usage:
+#   oc apply -f network-policies.yaml
+
+# Policy 1: Allow ingress to vLLM pods (port 8000) and scheduler pods (ports 9002-9090)
+# Without this, the gateway cannot route traffic to the vLLM inference endpoints.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-llmd-ingress
+  namespace: redhat-ods-applications
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: <SERVICE_NAME>
+  ingress:
+  - ports:
+    - port: 8000
+      protocol: TCP
+    - port: 9002
+      protocol: TCP
+    - port: 9003
+      protocol: TCP
+    - port: 9090
+      protocol: TCP
+  policyTypes:
+  - Ingress
+---
+# Policy 2: Allow ingress to Llama Stack from the OpenShift router
+# Only needed if you deploy Llama Stack in the same namespace and expose it
+# via an OpenShift Route. The Llama Stack operator creates its own network
+# policy that restricts ingress to the same namespace, which blocks the
+# OpenShift router (running in openshift-ingress namespace).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-llamastack-from-router
+  namespace: redhat-ods-applications
+spec:
+  podSelector:
+    matchLabels:
+      app: llama-stack
+      app.kubernetes.io/instance: llamastack-distribution
+  ingress:
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - port: 8321
+      protocol: TCP
+  policyTypes:
+  - Ingress

--- a/infrastructure/llm-d/network-policies.yaml
+++ b/infrastructure/llm-d/network-policies.yaml
@@ -51,7 +51,9 @@ spec:
       app.kubernetes.io/instance: llamastack-distribution
   ingress:
   - from:
-    - namespaceSelector: {}
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-ingress
     ports:
     - port: 8321
       protocol: TCP

--- a/infrastructure/llm-d/test_distribution.py
+++ b/infrastructure/llm-d/test_distribution.py
@@ -1,0 +1,513 @@
+"""
+llm-d Traffic Distribution Test
+
+Tests intelligent routing across vLLM replicas via the llm-d scheduler.
+After running, queries vLLM pod metrics to show per-node traffic distribution.
+
+Tests:
+  1. Concurrent load    - parallel requests to verify distribution across pods
+  2. Prefix cache       - repeated prompts to verify cache-aware routing
+  3. Sustained throughput - steady-state performance over a duration
+
+Requirements:
+  pip install aiohttp   (or: uv run --with aiohttp python test_distribution.py ...)
+
+Usage:
+  python test_distribution.py --url <LLMD_URL> --model <MODEL_NAME>
+
+  # Example:
+  python test_distribution.py \\
+    --url http://my-gateway.example.com/redhat-ods-applications/my-model-llmd/v1 \\
+    --model openai/gpt-oss-20b
+
+  # With custom settings:
+  python test_distribution.py \\
+    --url http://my-gateway.example.com/redhat-ods-applications/my-model-llmd/v1 \\
+    --model openai/gpt-oss-20b \\
+    --namespace my-namespace \\
+    --concurrency 4 \\
+    --duration 60
+
+Arguments:
+  --url          llm-d gateway URL ending with /v1 (required)
+  --model        Model name as registered in vLLM (required)
+  --namespace    Kubernetes namespace where vLLM pods run (default: redhat-ods-applications)
+  --service-name LLMInferenceService name for pod label lookup (derived from URL path by default)
+  --concurrency  Number of concurrent requests (default: 6)
+  --duration     Duration in seconds for sustained throughput test (default: 30)
+
+Environment variables (alternative to CLI args):
+  LLMD_URL       - Same as --url
+  LLMD_MODEL     - Same as --model
+  LLMD_NAMESPACE - Same as --namespace
+"""
+
+import argparse
+import asyncio
+import os
+import re
+import subprocess
+import sys
+import time
+from collections import defaultdict
+
+try:
+    import aiohttp
+except ImportError:
+    print("Error: aiohttp is required. Install with:")
+    print("  pip install aiohttp")
+    print("  # or run with: uv run --with aiohttp python test_distribution.py ...")
+    sys.exit(1)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Test llm-d traffic distribution across vLLM replicas"
+    )
+    parser.add_argument(
+        "--url",
+        default=os.environ.get("LLMD_URL"),
+        help="llm-d gateway URL ending with /v1 (or set LLMD_URL env var)",
+    )
+    parser.add_argument(
+        "--model",
+        default=os.environ.get("LLMD_MODEL"),
+        help="Model name as registered in vLLM (or set LLMD_MODEL env var)",
+    )
+    parser.add_argument(
+        "--namespace",
+        default=os.environ.get("LLMD_NAMESPACE", "redhat-ods-applications"),
+        help="Kubernetes namespace (default: redhat-ods-applications)",
+    )
+    parser.add_argument(
+        "--service-name",
+        default=None,
+        help="LLMInferenceService name for pod label lookup (derived from URL if omitted)",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=6,
+        help="Number of concurrent requests (default: 6)",
+    )
+    parser.add_argument(
+        "--duration",
+        type=int,
+        default=30,
+        help="Duration in seconds for sustained throughput test (default: 30)",
+    )
+    args = parser.parse_args()
+
+    if not args.url:
+        parser.error("--url is required (or set LLMD_URL env var)")
+    if not args.model:
+        parser.error("--model is required (or set LLMD_MODEL env var)")
+
+    if not args.service_name:
+        parts = args.url.rstrip("/").split("/")
+        for i, p in enumerate(parts):
+            if p == "v1" and i > 0:
+                args.service_name = parts[i - 1]
+                break
+        if not args.service_name:
+            args.service_name = parts[-1] if parts[-1] != "v1" else parts[-2]
+
+    return args
+
+
+def get_pod_metrics(namespace, service_name):
+    """Fetch vLLM metrics from each pod via oc exec."""
+    pod_label = f"app.kubernetes.io/name={service_name},kserve.io/component=workload"
+    try:
+        result = subprocess.run(
+            [
+                "oc", "get", "pods", "-n", namespace, "-l", pod_label,
+                "-o", r"jsonpath={range .items[*]}{.metadata.name},{.spec.nodeName}{'\n'}{end}",
+            ],
+            capture_output=True, text=True, timeout=15,
+        )
+        pods = []
+        for line in result.stdout.strip().split("\n"):
+            line = line.strip()
+            if "," in line:
+                name, node = line.split(",", 1)
+                short_node = re.sub(r"ip-[\d-]+\..*", lambda m: m.group().split(".")[0].split("-")[-1], node)
+                if short_node == node:
+                    short_node = node.split(".")[0]
+                pods.append((name, short_node))
+
+        pod_stats = []
+        for pod_name, short_node in pods:
+            try:
+                metrics_result = subprocess.run(
+                    [
+                        "oc", "exec", pod_name, "-n", namespace, "--",
+                        "curl", "-sk", "--max-time", "10", "https://localhost:8000/metrics",
+                    ],
+                    capture_output=True, text=True, timeout=30,
+                )
+                metrics = metrics_result.stdout
+            except subprocess.TimeoutExpired:
+                print(f"  Warning: Timeout fetching metrics from {short_node} ({pod_name})")
+                metrics = ""
+
+            requests = 0
+            prompt_tokens = 0
+            gen_tokens = 0
+            cache_hit = "N/A"
+
+            for line in metrics.split("\n"):
+                if line.startswith("vllm:request_success_total"):
+                    requests += int(float(line.split()[-1]))
+                elif line.startswith("vllm:prompt_tokens_total"):
+                    prompt_tokens = int(float(line.split()[-1]))
+                elif line.startswith("vllm:generation_tokens_total"):
+                    gen_tokens = int(float(line.split()[-1]))
+                elif "prefix_cache_hit_rate" in line and not line.startswith("#"):
+                    try:
+                        cache_hit = f"{float(line.split()[-1]):.1%}"
+                    except ValueError:
+                        pass
+
+            pod_stats.append({
+                "node": short_node,
+                "pod": pod_name,
+                "requests": requests,
+                "prompt_tokens": prompt_tokens,
+                "gen_tokens": gen_tokens,
+                "cache_hit": cache_hit,
+            })
+
+        return pod_stats
+    except Exception as e:
+        print(f"  Warning: Could not fetch pod metrics: {e}")
+        return []
+
+
+def print_distribution(before, after):
+    """Print per-pod traffic distribution showing both delta and cumulative totals."""
+    print(f"\n{'='*60}")
+    print("Pod Traffic Distribution")
+    print(f"{'='*60}")
+
+    before_map = {s["pod"]: s for s in before}
+
+    print(f"\n  This run (delta):")
+    header = f"  {'Node':<16} {'Requests':>10} {'Prompt Tok':>12} {'Gen Tok':>10} {'Cache Hit':>10}"
+    print(header)
+    print(f"  {'-'*16} {'-'*10} {'-'*12} {'-'*10} {'-'*10}")
+
+    total_reqs = 0
+    total_prompt = 0
+    total_gen = 0
+    rows = []
+
+    for s in after:
+        b = before_map.get(s["pod"], {"requests": 0, "prompt_tokens": 0, "gen_tokens": 0})
+        delta_reqs = s["requests"] - b["requests"]
+        delta_prompt = s["prompt_tokens"] - b["prompt_tokens"]
+        delta_gen = s["gen_tokens"] - b["gen_tokens"]
+        rows.append((s["node"], delta_reqs, delta_prompt, delta_gen, s["cache_hit"]))
+        total_reqs += delta_reqs
+        total_prompt += delta_prompt
+        total_gen += delta_gen
+
+    for node, reqs, prompt, gen, cache in sorted(rows, key=lambda r: -r[1]):
+        pct = f"({reqs/total_reqs*100:.0f}%)" if total_reqs > 0 else ""
+        bar = "#" * min(reqs // 2, 30) if reqs > 0 else ""
+        print(f"  {node:<16} {reqs:>6} {pct:>4} {prompt:>12} {gen:>10} {cache:>10}  {bar}")
+
+    print(f"  {'-'*16} {'-'*10} {'-'*12} {'-'*10} {'-'*10}")
+    print(f"  {'TOTAL':<16} {total_reqs:>10} {total_prompt:>12} {total_gen:>10}")
+
+    print(f"\n  Cumulative totals (since pod start):")
+    header = f"  {'Node':<16} {'Requests':>10} {'Prompt Tok':>12} {'Gen Tok':>10}"
+    print(header)
+    print(f"  {'-'*16} {'-'*10} {'-'*12} {'-'*10}")
+
+    cum_total = sum(s["requests"] for s in after)
+    cum_rows = []
+    for s in after:
+        cum_rows.append((s["node"], s["requests"], s["prompt_tokens"], s["gen_tokens"]))
+
+    for node, reqs, prompt, gen in sorted(cum_rows, key=lambda r: -r[1]):
+        pct = f"({reqs/cum_total*100:.0f}%)" if cum_total > 0 else ""
+        bar = "#" * min(reqs // 5, 30) if reqs > 0 else ""
+        print(f"  {node:<16} {reqs:>6} {pct:>4} {prompt:>12} {gen:>10}  {bar}")
+
+    print(f"  {'-'*16} {'-'*10} {'-'*12} {'-'*10}")
+    cum_prompt = sum(s["prompt_tokens"] for s in after)
+    cum_gen = sum(s["gen_tokens"] for s in after)
+    print(f"  {'TOTAL':<16} {cum_total:>10} {cum_prompt:>12} {cum_gen:>10}")
+
+    if cum_total > 0 and len(after) > 0:
+        expected = cum_total / len(after)
+        max_reqs = max(r[1] for r in cum_rows)
+        skew = max_reqs / expected if expected > 0 else 0
+        print(f"\n  Distribution skew: {skew:.2f}x (1.0 = perfectly even)")
+        if skew > 2.0:
+            print("  -> Highly skewed: llm-d prefix-cache scorer is routing repeat prompts to same pods")
+        elif skew > 1.3:
+            print("  -> Moderately skewed: llm-d is favoring pods with cached prefixes")
+        else:
+            print("  -> Relatively even distribution across pods")
+
+
+async def send_request(session, url, model, prompt, max_tokens=20, request_id=0):
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+    }
+    start = time.monotonic()
+    try:
+        async with session.post(
+            f"{url}/chat/completions",
+            json=payload,
+            timeout=aiohttp.ClientTimeout(total=60),
+        ) as resp:
+            data = await resp.json()
+            elapsed = time.monotonic() - start
+            usage = data.get("usage", {})
+            return {
+                "request_id": request_id,
+                "status": resp.status,
+                "elapsed": elapsed,
+                "prompt_tokens": usage.get("prompt_tokens", 0),
+                "completion_tokens": usage.get("completion_tokens", 0),
+                "total_tokens": usage.get("total_tokens", 0),
+                "model": data.get("model", ""),
+                "error": None,
+            }
+    except Exception as e:
+        elapsed = time.monotonic() - start
+        return {
+            "request_id": request_id,
+            "status": 0,
+            "elapsed": elapsed,
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+            "model": "",
+            "error": str(e),
+        }
+
+
+async def test_concurrent_load(url, model, num_requests=30, concurrency=6):
+    print(f"\n{'='*60}")
+    print(f"TEST 1: Concurrent Load Distribution")
+    print(f"Sending {num_requests} requests with concurrency={concurrency}")
+    print(f"{'='*60}")
+
+    prompts = [
+        "What is machine learning?",
+        "Explain quantum computing.",
+        "How does photosynthesis work?",
+        "What causes earthquakes?",
+        "Describe the solar system.",
+        "What is artificial intelligence?",
+        "How do vaccines work?",
+        "Explain the theory of relativity.",
+        "What is blockchain technology?",
+        "How does the internet work?",
+    ]
+
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def bounded_request(session, prompt, req_id):
+        async with semaphore:
+            return await send_request(session, url, model, prompt, max_tokens=20, request_id=req_id)
+
+    start = time.monotonic()
+    async with aiohttp.ClientSession() as session:
+        tasks = [
+            bounded_request(session, prompts[i % len(prompts)], i)
+            for i in range(num_requests)
+        ]
+        results = await asyncio.gather(*tasks)
+    total_time = time.monotonic() - start
+
+    successful = [r for r in results if r["error"] is None and r["status"] == 200]
+    failed = [r for r in results if r["error"] is not None or r["status"] != 200]
+
+    print(f"\nResults:")
+    print(f"  Successful: {len(successful)}/{num_requests}")
+    print(f"  Failed: {len(failed)}")
+    print(f"  Total time: {total_time:.2f}s")
+    print(f"  Throughput: {len(successful)/total_time:.2f} req/s")
+
+    if successful:
+        latencies = [r["elapsed"] for r in successful]
+        latencies.sort()
+        total_tokens = sum(r["total_tokens"] for r in successful)
+        print(f"\nLatency (seconds):")
+        print(f"  Min:    {min(latencies):.3f}")
+        print(f"  Median: {latencies[len(latencies)//2]:.3f}")
+        print(f"  P95:    {latencies[int(len(latencies)*0.95)]:.3f}")
+        print(f"  Max:    {max(latencies):.3f}")
+        print(f"  Avg:    {sum(latencies)/len(latencies):.3f}")
+        print(f"\nTokens:")
+        print(f"  Total: {total_tokens}")
+        print(f"  Tokens/sec: {total_tokens/total_time:.1f}")
+
+    if failed:
+        print(f"\nErrors:")
+        for r in failed[:3]:
+            err = r["error"] or f"HTTP {r['status']}"
+            print(f"  Request {r['request_id']}: {err}")
+
+    return results
+
+
+async def test_prefix_cache_routing(url, model, num_rounds=3, prompts_per_round=6):
+    print(f"\n{'='*60}")
+    print(f"TEST 2: Prefix Cache Routing")
+    print(f"Sending same prompts {num_rounds} rounds to test cache-aware routing")
+    print(f"{'='*60}")
+
+    base_prompts = [
+        "You are a helpful assistant that explains science concepts. Explain the concept of gravity in detail, including Newton's law of universal gravitation and Einstein's general theory of relativity.",
+        "You are a helpful assistant that explains science concepts. Explain the concept of evolution by natural selection, including Darwin's original theory and modern synthesis.",
+        "You are a helpful assistant that explains science concepts. Explain the concept of thermodynamics, including the three laws and their practical applications.",
+    ]
+
+    round_results = []
+    async with aiohttp.ClientSession() as session:
+        for round_num in range(num_rounds):
+            print(f"\n  Round {round_num + 1}/{num_rounds}...")
+            start = time.monotonic()
+            tasks = [
+                send_request(session, url, model, base_prompts[i % len(base_prompts)], max_tokens=30, request_id=i)
+                for i in range(prompts_per_round)
+            ]
+            results = await asyncio.gather(*tasks)
+            elapsed = time.monotonic() - start
+
+            successful = [r for r in results if r["error"] is None]
+            avg_latency = sum(r["elapsed"] for r in successful) / len(successful) if successful else 0
+
+            round_results.append({
+                "round": round_num + 1,
+                "avg_latency": avg_latency,
+                "total_time": elapsed,
+                "successful": len(successful),
+            })
+            print(f"    Avg latency: {avg_latency:.3f}s | Total: {elapsed:.2f}s | Success: {len(successful)}/{prompts_per_round}")
+
+    if len(round_results) >= 2:
+        first = round_results[0]["avg_latency"]
+        last = round_results[-1]["avg_latency"]
+        change_pct = ((last - first) / first) * 100 if first > 0 else 0
+        print(f"\n  Latency: {first:.3f}s (round 1) -> {last:.3f}s (round {num_rounds}): {change_pct:+.1f}%")
+        if change_pct < -10:
+            print("  -> Prefix cache routing is effective (latency decreased on repeated prompts)")
+        elif change_pct < 0:
+            print("  -> Slight latency decrease, prefix caching may be working")
+        else:
+            print("  -> No latency decrease detected (cache may need more repetitions or longer prompts)")
+
+
+async def test_sustained_throughput(url, model, duration_seconds=30, concurrency=6):
+    print(f"\n{'='*60}")
+    print(f"TEST 3: Sustained Throughput ({duration_seconds}s, concurrency={concurrency})")
+    print(f"{'='*60}")
+
+    prompts = [
+        "Write a short poem about the ocean.",
+        "What are the benefits of exercise?",
+        "Explain how a computer processor works.",
+        "Describe the water cycle.",
+        "What is the meaning of life?",
+        "How do birds fly?",
+    ]
+
+    results = []
+    start = time.monotonic()
+    request_count = 0
+
+    async with aiohttp.ClientSession() as session:
+        semaphore = asyncio.Semaphore(concurrency)
+
+        async def worker():
+            nonlocal request_count
+            while time.monotonic() - start < duration_seconds:
+                async with semaphore:
+                    req_id = request_count
+                    request_count += 1
+                    prompt = prompts[req_id % len(prompts)]
+                    result = await send_request(session, url, model, prompt, max_tokens=30, request_id=req_id)
+                    results.append(result)
+
+        workers = [asyncio.create_task(worker()) for _ in range(concurrency)]
+        await asyncio.gather(*workers)
+
+    total_time = time.monotonic() - start
+    successful = [r for r in results if r["error"] is None and r["status"] == 200]
+    total_tokens = sum(r["total_tokens"] for r in successful)
+
+    print(f"\nResults:")
+    print(f"  Duration: {total_time:.1f}s")
+    print(f"  Total requests: {len(results)}")
+    print(f"  Successful: {len(successful)}")
+    print(f"  Throughput: {len(successful)/total_time:.2f} req/s")
+    print(f"  Total tokens: {total_tokens}")
+    print(f"  Tokens/sec: {total_tokens/total_time:.1f}")
+
+    if successful:
+        latencies = sorted(r["elapsed"] for r in successful)
+        print(f"\nLatency (seconds):")
+        print(f"  Min:    {min(latencies):.3f}")
+        print(f"  Median: {latencies[len(latencies)//2]:.3f}")
+        print(f"  P95:    {latencies[int(len(latencies)*0.95)]:.3f}")
+        print(f"  Max:    {max(latencies):.3f}")
+
+        bucket_size = 5
+        print(f"\n  Requests completed per {bucket_size}s window:")
+        time_buckets = defaultdict(int)
+        for i, r in enumerate(successful):
+            t = (i / len(successful)) * total_time
+            bucket = int(t // bucket_size) * bucket_size
+            time_buckets[bucket] += 1
+        for t in sorted(time_buckets.keys()):
+            bar = "#" * time_buckets[t]
+            print(f"    {t:3d}-{t+bucket_size:3d}s: {time_buckets[t]:3d} {bar}")
+
+
+async def main():
+    args = parse_args()
+
+    print("llm-d Traffic Distribution Test")
+    print(f"Endpoint: {args.url}")
+    print(f"Model: {args.model}")
+    print(f"Namespace: {args.namespace}")
+    print(f"Service: {args.service_name}")
+    print(f"Concurrency: {args.concurrency}")
+
+    async with aiohttp.ClientSession() as session:
+        result = await send_request(session, args.url, args.model, "hello", max_tokens=5)
+        if result["error"]:
+            print(f"\nConnection failed: {result['error']}")
+            sys.exit(1)
+        print(f"Connection OK (latency: {result['elapsed']:.3f}s)")
+
+    print("\nCollecting baseline pod metrics...")
+    before = get_pod_metrics(args.namespace, args.service_name)
+
+    num_requests = args.concurrency * 5
+    await test_concurrent_load(args.url, args.model, num_requests=num_requests, concurrency=args.concurrency)
+    await test_prefix_cache_routing(args.url, args.model, num_rounds=3, prompts_per_round=args.concurrency)
+    await test_sustained_throughput(args.url, args.model, duration_seconds=args.duration, concurrency=args.concurrency)
+
+    print("\nCollecting final pod metrics...")
+    after = get_pod_metrics(args.namespace, args.service_name)
+
+    if before and after:
+        print_distribution(before, after)
+
+    print(f"\n{'='*60}")
+    print("All tests complete.")
+    print(f"{'='*60}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/infrastructure/llm-d/test_distribution.py
+++ b/infrastructure/llm-d/test_distribution.py
@@ -121,17 +121,30 @@ def get_pod_metrics(namespace, service_name):
     try:
         result = subprocess.run(
             [
-                "oc", "get", "pods", "-n", namespace, "-l", pod_label,
-                "-o", r"jsonpath={range .items[*]}{.metadata.name},{.spec.nodeName}{'\n'}{end}",
+                "oc",
+                "get",
+                "pods",
+                "-n",
+                namespace,
+                "-l",
+                pod_label,
+                "-o",
+                r"jsonpath={range .items[*]}{.metadata.name},{.spec.nodeName}{'\n'}{end}",
             ],
-            capture_output=True, text=True, timeout=15,
+            capture_output=True,
+            text=True,
+            timeout=15,
         )
         pods = []
         for line in result.stdout.strip().split("\n"):
             line = line.strip()
             if "," in line:
                 name, node = line.split(",", 1)
-                short_node = re.sub(r"ip-[\d-]+\..*", lambda m: m.group().split(".")[0].split("-")[-1], node)
+                short_node = re.sub(
+                    r"ip-[\d-]+\..*",
+                    lambda m: m.group().split(".")[0].split("-")[-1],
+                    node,
+                )
                 if short_node == node:
                     short_node = node.split(".")[0]
                 pods.append((name, short_node))
@@ -141,14 +154,27 @@ def get_pod_metrics(namespace, service_name):
             try:
                 metrics_result = subprocess.run(
                     [
-                        "oc", "exec", pod_name, "-n", namespace, "--",
-                        "curl", "-sk", "--max-time", "10", "https://localhost:8000/metrics",
+                        "oc",
+                        "exec",
+                        pod_name,
+                        "-n",
+                        namespace,
+                        "--",
+                        "curl",
+                        "-sk",
+                        "--max-time",
+                        "10",
+                        "https://localhost:8000/metrics",
                     ],
-                    capture_output=True, text=True, timeout=30,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
                 )
                 metrics = metrics_result.stdout
             except subprocess.TimeoutExpired:
-                print(f"  Warning: Timeout fetching metrics from {short_node} ({pod_name})")
+                print(
+                    f"  Warning: Timeout fetching metrics from {short_node} ({pod_name})"
+                )
                 metrics = ""
 
             requests = 0
@@ -169,14 +195,16 @@ def get_pod_metrics(namespace, service_name):
                     except ValueError:
                         pass
 
-            pod_stats.append({
-                "node": short_node,
-                "pod": pod_name,
-                "requests": requests,
-                "prompt_tokens": prompt_tokens,
-                "gen_tokens": gen_tokens,
-                "cache_hit": cache_hit,
-            })
+            pod_stats.append(
+                {
+                    "node": short_node,
+                    "pod": pod_name,
+                    "requests": requests,
+                    "prompt_tokens": prompt_tokens,
+                    "gen_tokens": gen_tokens,
+                    "cache_hit": cache_hit,
+                }
+            )
 
         return pod_stats
     except Exception as e:
@@ -186,16 +214,16 @@ def get_pod_metrics(namespace, service_name):
 
 def print_distribution(before, after):
     """Print per-pod traffic distribution showing both delta and cumulative totals."""
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print("Pod Traffic Distribution")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
 
     before_map = {s["pod"]: s for s in before}
 
     print("\n  This run (delta):")
     header = f"  {'Node':<16} {'Requests':>10} {'Prompt Tok':>12} {'Gen Tok':>10} {'Cache Hit':>10}"
     print(header)
-    print(f"  {'-'*16} {'-'*10} {'-'*12} {'-'*10} {'-'*10}")
+    print(f"  {'-' * 16} {'-' * 10} {'-' * 12} {'-' * 10} {'-' * 10}")
 
     total_reqs = 0
     total_prompt = 0
@@ -203,7 +231,9 @@ def print_distribution(before, after):
     rows = []
 
     for s in after:
-        b = before_map.get(s["pod"], {"requests": 0, "prompt_tokens": 0, "gen_tokens": 0})
+        b = before_map.get(
+            s["pod"], {"requests": 0, "prompt_tokens": 0, "gen_tokens": 0}
+        )
         delta_reqs = s["requests"] - b["requests"]
         delta_prompt = s["prompt_tokens"] - b["prompt_tokens"]
         delta_gen = s["gen_tokens"] - b["gen_tokens"]
@@ -213,17 +243,19 @@ def print_distribution(before, after):
         total_gen += delta_gen
 
     for node, reqs, prompt, gen, cache in sorted(rows, key=lambda r: -r[1]):
-        pct = f"({reqs/total_reqs*100:.0f}%)" if total_reqs > 0 else ""
+        pct = f"({reqs / total_reqs * 100:.0f}%)" if total_reqs > 0 else ""
         bar = "#" * min(reqs // 2, 30) if reqs > 0 else ""
-        print(f"  {node:<16} {reqs:>6} {pct:>4} {prompt:>12} {gen:>10} {cache:>10}  {bar}")
+        print(
+            f"  {node:<16} {reqs:>6} {pct:>4} {prompt:>12} {gen:>10} {cache:>10}  {bar}"
+        )
 
-    print(f"  {'-'*16} {'-'*10} {'-'*12} {'-'*10} {'-'*10}")
+    print(f"  {'-' * 16} {'-' * 10} {'-' * 12} {'-' * 10} {'-' * 10}")
     print(f"  {'TOTAL':<16} {total_reqs:>10} {total_prompt:>12} {total_gen:>10}")
 
     print("\n  Cumulative totals (since pod start):")
     header = f"  {'Node':<16} {'Requests':>10} {'Prompt Tok':>12} {'Gen Tok':>10}"
     print(header)
-    print(f"  {'-'*16} {'-'*10} {'-'*12} {'-'*10}")
+    print(f"  {'-' * 16} {'-' * 10} {'-' * 12} {'-' * 10}")
 
     cum_total = sum(s["requests"] for s in after)
     cum_rows = []
@@ -231,11 +263,11 @@ def print_distribution(before, after):
         cum_rows.append((s["node"], s["requests"], s["prompt_tokens"], s["gen_tokens"]))
 
     for node, reqs, prompt, gen in sorted(cum_rows, key=lambda r: -r[1]):
-        pct = f"({reqs/cum_total*100:.0f}%)" if cum_total > 0 else ""
+        pct = f"({reqs / cum_total * 100:.0f}%)" if cum_total > 0 else ""
         bar = "#" * min(reqs // 5, 30) if reqs > 0 else ""
         print(f"  {node:<16} {reqs:>6} {pct:>4} {prompt:>12} {gen:>10}  {bar}")
 
-    print(f"  {'-'*16} {'-'*10} {'-'*12} {'-'*10}")
+    print(f"  {'-' * 16} {'-' * 10} {'-' * 12} {'-' * 10}")
     cum_prompt = sum(s["prompt_tokens"] for s in after)
     cum_gen = sum(s["gen_tokens"] for s in after)
     print(f"  {'TOTAL':<16} {cum_total:>10} {cum_prompt:>12} {cum_gen:>10}")
@@ -246,7 +278,9 @@ def print_distribution(before, after):
         skew = max_reqs / expected if expected > 0 else 0
         print(f"\n  Distribution skew: {skew:.2f}x (1.0 = perfectly even)")
         if skew > 2.0:
-            print("  -> Highly skewed: llm-d prefix-cache scorer is routing repeat prompts to same pods")
+            print(
+                "  -> Highly skewed: llm-d prefix-cache scorer is routing repeat prompts to same pods"
+            )
         elif skew > 1.3:
             print("  -> Moderately skewed: llm-d is favoring pods with cached prefixes")
         else:
@@ -294,10 +328,10 @@ async def send_request(session, url, model, prompt, max_tokens=20, request_id=0)
 
 
 async def test_concurrent_load(url, model, num_requests=30, concurrency=6):
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print("TEST 1: Concurrent Load Distribution")
     print(f"Sending {num_requests} requests with concurrency={concurrency}")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
 
     prompts = [
         "What is machine learning?",
@@ -316,7 +350,9 @@ async def test_concurrent_load(url, model, num_requests=30, concurrency=6):
 
     async def bounded_request(session, prompt, req_id):
         async with semaphore:
-            return await send_request(session, url, model, prompt, max_tokens=20, request_id=req_id)
+            return await send_request(
+                session, url, model, prompt, max_tokens=20, request_id=req_id
+            )
 
     start = time.monotonic()
     async with aiohttp.ClientSession() as session:
@@ -334,7 +370,7 @@ async def test_concurrent_load(url, model, num_requests=30, concurrency=6):
     print(f"  Successful: {len(successful)}/{num_requests}")
     print(f"  Failed: {len(failed)}")
     print(f"  Total time: {total_time:.2f}s")
-    print(f"  Throughput: {len(successful)/total_time:.2f} req/s")
+    print(f"  Throughput: {len(successful) / total_time:.2f} req/s")
 
     if successful:
         latencies = [r["elapsed"] for r in successful]
@@ -342,13 +378,13 @@ async def test_concurrent_load(url, model, num_requests=30, concurrency=6):
         total_tokens = sum(r["total_tokens"] for r in successful)
         print("\nLatency (seconds):")
         print(f"  Min:    {min(latencies):.3f}")
-        print(f"  Median: {latencies[len(latencies)//2]:.3f}")
-        print(f"  P95:    {latencies[int(len(latencies)*0.95)]:.3f}")
+        print(f"  Median: {latencies[len(latencies) // 2]:.3f}")
+        print(f"  P95:    {latencies[int(len(latencies) * 0.95)]:.3f}")
         print(f"  Max:    {max(latencies):.3f}")
-        print(f"  Avg:    {sum(latencies)/len(latencies):.3f}")
+        print(f"  Avg:    {sum(latencies) / len(latencies):.3f}")
         print("\nTokens:")
         print(f"  Total: {total_tokens}")
-        print(f"  Tokens/sec: {total_tokens/total_time:.1f}")
+        print(f"  Tokens/sec: {total_tokens / total_time:.1f}")
 
     if failed:
         print("\nErrors:")
@@ -360,10 +396,10 @@ async def test_concurrent_load(url, model, num_requests=30, concurrency=6):
 
 
 async def test_prefix_cache_routing(url, model, num_rounds=3, prompts_per_round=6):
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print("TEST 2: Prefix Cache Routing")
     print(f"Sending same prompts {num_rounds} rounds to test cache-aware routing")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
 
     base_prompts = [
         "You are a helpful assistant that explains science concepts. Explain the concept of gravity in detail, including Newton's law of universal gravitation and Einstein's general theory of relativity.",
@@ -377,40 +413,63 @@ async def test_prefix_cache_routing(url, model, num_rounds=3, prompts_per_round=
             print(f"\n  Round {round_num + 1}/{num_rounds}...")
             start = time.monotonic()
             tasks = [
-                send_request(session, url, model, base_prompts[i % len(base_prompts)], max_tokens=30, request_id=i)
+                send_request(
+                    session,
+                    url,
+                    model,
+                    base_prompts[i % len(base_prompts)],
+                    max_tokens=30,
+                    request_id=i,
+                )
                 for i in range(prompts_per_round)
             ]
             results = await asyncio.gather(*tasks)
             elapsed = time.monotonic() - start
 
             successful = [r for r in results if r["error"] is None]
-            avg_latency = sum(r["elapsed"] for r in successful) / len(successful) if successful else 0
+            avg_latency = (
+                sum(r["elapsed"] for r in successful) / len(successful)
+                if successful
+                else 0
+            )
 
-            round_results.append({
-                "round": round_num + 1,
-                "avg_latency": avg_latency,
-                "total_time": elapsed,
-                "successful": len(successful),
-            })
-            print(f"    Avg latency: {avg_latency:.3f}s | Total: {elapsed:.2f}s | Success: {len(successful)}/{prompts_per_round}")
+            round_results.append(
+                {
+                    "round": round_num + 1,
+                    "avg_latency": avg_latency,
+                    "total_time": elapsed,
+                    "successful": len(successful),
+                }
+            )
+            print(
+                f"    Avg latency: {avg_latency:.3f}s | Total: {elapsed:.2f}s | Success: {len(successful)}/{prompts_per_round}"
+            )
 
     if len(round_results) >= 2:
         first = round_results[0]["avg_latency"]
         last = round_results[-1]["avg_latency"]
         change_pct = ((last - first) / first) * 100 if first > 0 else 0
-        print(f"\n  Latency: {first:.3f}s (round 1) -> {last:.3f}s (round {num_rounds}): {change_pct:+.1f}%")
+        print(
+            f"\n  Latency: {first:.3f}s (round 1) -> {last:.3f}s (round {num_rounds}): {change_pct:+.1f}%"
+        )
         if change_pct < -10:
-            print("  -> Prefix cache routing is effective (latency decreased on repeated prompts)")
+            print(
+                "  -> Prefix cache routing is effective (latency decreased on repeated prompts)"
+            )
         elif change_pct < 0:
             print("  -> Slight latency decrease, prefix caching may be working")
         else:
-            print("  -> No latency decrease detected (cache may need more repetitions or longer prompts)")
+            print(
+                "  -> No latency decrease detected (cache may need more repetitions or longer prompts)"
+            )
 
 
 async def test_sustained_throughput(url, model, duration_seconds=30, concurrency=6):
-    print(f"\n{'='*60}")
-    print(f"TEST 3: Sustained Throughput ({duration_seconds}s, concurrency={concurrency})")
-    print(f"{'='*60}")
+    print(f"\n{'=' * 60}")
+    print(
+        f"TEST 3: Sustained Throughput ({duration_seconds}s, concurrency={concurrency})"
+    )
+    print(f"{'=' * 60}")
 
     prompts = [
         "Write a short poem about the ocean.",
@@ -435,7 +494,9 @@ async def test_sustained_throughput(url, model, duration_seconds=30, concurrency
                     req_id = request_count
                     request_count += 1
                     prompt = prompts[req_id % len(prompts)]
-                    result = await send_request(session, url, model, prompt, max_tokens=30, request_id=req_id)
+                    result = await send_request(
+                        session, url, model, prompt, max_tokens=30, request_id=req_id
+                    )
                     results.append(result)
 
         workers = [asyncio.create_task(worker()) for _ in range(concurrency)]
@@ -449,16 +510,16 @@ async def test_sustained_throughput(url, model, duration_seconds=30, concurrency
     print(f"  Duration: {total_time:.1f}s")
     print(f"  Total requests: {len(results)}")
     print(f"  Successful: {len(successful)}")
-    print(f"  Throughput: {len(successful)/total_time:.2f} req/s")
+    print(f"  Throughput: {len(successful) / total_time:.2f} req/s")
     print(f"  Total tokens: {total_tokens}")
-    print(f"  Tokens/sec: {total_tokens/total_time:.1f}")
+    print(f"  Tokens/sec: {total_tokens / total_time:.1f}")
 
     if successful:
         latencies = sorted(r["elapsed"] for r in successful)
         print("\nLatency (seconds):")
         print(f"  Min:    {min(latencies):.3f}")
-        print(f"  Median: {latencies[len(latencies)//2]:.3f}")
-        print(f"  P95:    {latencies[int(len(latencies)*0.95)]:.3f}")
+        print(f"  Median: {latencies[len(latencies) // 2]:.3f}")
+        print(f"  P95:    {latencies[int(len(latencies) * 0.95)]:.3f}")
         print(f"  Max:    {max(latencies):.3f}")
 
         bucket_size = 5
@@ -470,7 +531,7 @@ async def test_sustained_throughput(url, model, duration_seconds=30, concurrency
             time_buckets[bucket] += 1
         for t in sorted(time_buckets.keys()):
             bar = "#" * time_buckets[t]
-            print(f"    {t:3d}-{t+bucket_size:3d}s: {time_buckets[t]:3d} {bar}")
+            print(f"    {t:3d}-{t + bucket_size:3d}s: {time_buckets[t]:3d} {bar}")
 
 
 async def main():
@@ -484,7 +545,9 @@ async def main():
     print(f"Concurrency: {args.concurrency}")
 
     async with aiohttp.ClientSession() as session:
-        result = await send_request(session, args.url, args.model, "hello", max_tokens=5)
+        result = await send_request(
+            session, args.url, args.model, "hello", max_tokens=5
+        )
         if result["error"]:
             print(f"\nConnection failed: {result['error']}")
             sys.exit(1)
@@ -494,9 +557,18 @@ async def main():
     before = get_pod_metrics(args.namespace, args.service_name)
 
     num_requests = args.concurrency * 5
-    await test_concurrent_load(args.url, args.model, num_requests=num_requests, concurrency=args.concurrency)
-    await test_prefix_cache_routing(args.url, args.model, num_rounds=3, prompts_per_round=args.concurrency)
-    await test_sustained_throughput(args.url, args.model, duration_seconds=args.duration, concurrency=args.concurrency)
+    await test_concurrent_load(
+        args.url, args.model, num_requests=num_requests, concurrency=args.concurrency
+    )
+    await test_prefix_cache_routing(
+        args.url, args.model, num_rounds=3, prompts_per_round=args.concurrency
+    )
+    await test_sustained_throughput(
+        args.url,
+        args.model,
+        duration_seconds=args.duration,
+        concurrency=args.concurrency,
+    )
 
     print("\nCollecting final pod metrics...")
     after = get_pod_metrics(args.namespace, args.service_name)
@@ -504,9 +576,9 @@ async def main():
     if before and after:
         print_distribution(before, after)
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print("All tests complete.")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
 
 
 if __name__ == "__main__":

--- a/infrastructure/llm-d/test_distribution.py
+++ b/infrastructure/llm-d/test_distribution.py
@@ -192,7 +192,7 @@ def print_distribution(before, after):
 
     before_map = {s["pod"]: s for s in before}
 
-    print(f"\n  This run (delta):")
+    print("\n  This run (delta):")
     header = f"  {'Node':<16} {'Requests':>10} {'Prompt Tok':>12} {'Gen Tok':>10} {'Cache Hit':>10}"
     print(header)
     print(f"  {'-'*16} {'-'*10} {'-'*12} {'-'*10} {'-'*10}")
@@ -220,7 +220,7 @@ def print_distribution(before, after):
     print(f"  {'-'*16} {'-'*10} {'-'*12} {'-'*10} {'-'*10}")
     print(f"  {'TOTAL':<16} {total_reqs:>10} {total_prompt:>12} {total_gen:>10}")
 
-    print(f"\n  Cumulative totals (since pod start):")
+    print("\n  Cumulative totals (since pod start):")
     header = f"  {'Node':<16} {'Requests':>10} {'Prompt Tok':>12} {'Gen Tok':>10}"
     print(header)
     print(f"  {'-'*16} {'-'*10} {'-'*12} {'-'*10}")
@@ -295,7 +295,7 @@ async def send_request(session, url, model, prompt, max_tokens=20, request_id=0)
 
 async def test_concurrent_load(url, model, num_requests=30, concurrency=6):
     print(f"\n{'='*60}")
-    print(f"TEST 1: Concurrent Load Distribution")
+    print("TEST 1: Concurrent Load Distribution")
     print(f"Sending {num_requests} requests with concurrency={concurrency}")
     print(f"{'='*60}")
 
@@ -330,7 +330,7 @@ async def test_concurrent_load(url, model, num_requests=30, concurrency=6):
     successful = [r for r in results if r["error"] is None and r["status"] == 200]
     failed = [r for r in results if r["error"] is not None or r["status"] != 200]
 
-    print(f"\nResults:")
+    print("\nResults:")
     print(f"  Successful: {len(successful)}/{num_requests}")
     print(f"  Failed: {len(failed)}")
     print(f"  Total time: {total_time:.2f}s")
@@ -340,18 +340,18 @@ async def test_concurrent_load(url, model, num_requests=30, concurrency=6):
         latencies = [r["elapsed"] for r in successful]
         latencies.sort()
         total_tokens = sum(r["total_tokens"] for r in successful)
-        print(f"\nLatency (seconds):")
+        print("\nLatency (seconds):")
         print(f"  Min:    {min(latencies):.3f}")
         print(f"  Median: {latencies[len(latencies)//2]:.3f}")
         print(f"  P95:    {latencies[int(len(latencies)*0.95)]:.3f}")
         print(f"  Max:    {max(latencies):.3f}")
         print(f"  Avg:    {sum(latencies)/len(latencies):.3f}")
-        print(f"\nTokens:")
+        print("\nTokens:")
         print(f"  Total: {total_tokens}")
         print(f"  Tokens/sec: {total_tokens/total_time:.1f}")
 
     if failed:
-        print(f"\nErrors:")
+        print("\nErrors:")
         for r in failed[:3]:
             err = r["error"] or f"HTTP {r['status']}"
             print(f"  Request {r['request_id']}: {err}")
@@ -361,7 +361,7 @@ async def test_concurrent_load(url, model, num_requests=30, concurrency=6):
 
 async def test_prefix_cache_routing(url, model, num_rounds=3, prompts_per_round=6):
     print(f"\n{'='*60}")
-    print(f"TEST 2: Prefix Cache Routing")
+    print("TEST 2: Prefix Cache Routing")
     print(f"Sending same prompts {num_rounds} rounds to test cache-aware routing")
     print(f"{'='*60}")
 
@@ -445,7 +445,7 @@ async def test_sustained_throughput(url, model, duration_seconds=30, concurrency
     successful = [r for r in results if r["error"] is None and r["status"] == 200]
     total_tokens = sum(r["total_tokens"] for r in successful)
 
-    print(f"\nResults:")
+    print("\nResults:")
     print(f"  Duration: {total_time:.1f}s")
     print(f"  Total requests: {len(results)}")
     print(f"  Successful: {len(successful)}")
@@ -455,7 +455,7 @@ async def test_sustained_throughput(url, model, duration_seconds=30, concurrency
 
     if successful:
         latencies = sorted(r["elapsed"] for r in successful)
-        print(f"\nLatency (seconds):")
+        print("\nLatency (seconds):")
         print(f"  Min:    {min(latencies):.3f}")
         print(f"  Median: {latencies[len(latencies)//2]:.3f}")
         print(f"  P95:    {latencies[int(len(latencies)*0.95)]:.3f}")


### PR DESCRIPTION
## Summary

- Add deployment guide for llm-d on OpenShift AI (`docs/llm-d-deployment.md`)
- Add `infrastructure/llm-d/` with LLMInferenceService YAML template, NetworkPolicy manifests, and a traffic distribution test script
- Add llm-d references to the main README (repo structure + documentation section)

## What's included

| File | Description |
|------|-------------|
| `docs/llm-d-deployment.md` | Step-by-step guide covering prerequisites, GPU node pool creation, LLMInferenceService deployment, network policies, Llama Stack integration, and verification |
| `infrastructure/llm-d/llminferenceservice.yaml` | Parameterized LLMInferenceService template with placeholder comments |
| `infrastructure/llm-d/network-policies.yaml` | Required NetworkPolicies (RHOAI defaults block port 8000) |
| `infrastructure/llm-d/test_distribution.py` | Test script that validates llm-d's intelligent routing across vLLM replicas (concurrent load, prefix cache routing, sustained throughput, per-pod metrics) |
| `infrastructure/llm-d/README.md` | Overview and quick start |

All manifests and scripts are fully parameterized with no hardcoded cluster-specific values.

## Test plan

- [ ] Review YAML templates for correctness (`oc apply --dry-run=client`)
- [ ] Verify test script runs with `--help` without errors
- [ ] Deploy on an OpenShift AI 3.4+ cluster following the guide end-to-end
- [ ] Run `test_distribution.py` against a live llm-d deployment