### PR TITLE
RHAIENG-5038: fix missing milvus deps in llama-server targets

### DIFF
--- a/agents/crewai/websearch_agent/Makefile
+++ b/agents/crewai/websearch_agent/Makefile
@@ -58,7 +58,8 @@ ollama: ## Install Ollama, start it, and pull models
 llama-server: ## Install llama-stack and start Llama Stack server
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Installing llama-stack..." && \
-	  uv pip install "llama-stack==0.5.0" "llama-stack-api==0.5.0" ollama && \
+	  uv pip install "llama-stack==0.5.0" "llama-stack-api==0.5.0" ollama "pymilvus==2.6.9" "milvus-lite>=2.5.1" "setuptools>=80.9.0,<82.0.0" && \
+	  mkdir -p ../../../milvus_data && \
 	  echo "==> Killing any existing process on port 8321..." && \
 	  lsof -ti:8321 | xargs kill -9 2>/dev/null; true && \
 	  echo "==> Starting Llama Stack server on port 8321..." && \

--- a/agents/google/adk/Makefile
+++ b/agents/google/adk/Makefile
@@ -52,15 +52,14 @@ ollama: ## Install Ollama, start it, and pull models
 	  done && \
 	  echo "==> Pulling $(MODEL)..." && \
 	  ollama pull $(MODEL) && \
-	  echo "==> Creating Milvus dir..." && \
-	  mkdir -p ../../../milvus_data && \
 	  echo "" && \
 	  echo "Done. Run 'make llama-server' to start the Llama Stack server."
 
 llama-server: ## Install llama-stack and start Llama Stack server
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Installing llama-stack..." && \
-	  uv pip install "llama-stack==0.5.0" "llama-stack-api==0.5.0" ollama && \
+	  uv pip install "llama-stack==0.5.0" "llama-stack-api==0.5.0" ollama "pymilvus==2.6.9" "milvus-lite>=2.5.1" "setuptools>=80.9.0,<82.0.0" && \
+	  mkdir -p ../../../milvus_data && \
 	  echo "==> Killing any existing process on port 8321..." && \
 	  lsof -ti:8321 | xargs kill -9 2>/dev/null; true && \
 	  echo "==> Starting Llama Stack server on port 8321..." && \

--- a/agents/langflow/simple_tool_calling_agent/Makefile
+++ b/agents/langflow/simple_tool_calling_agent/Makefile
@@ -60,7 +60,8 @@ llama-server: ## Install llama-stack and start Llama Stack server
 	fi && \
 	source .venv/bin/activate && \
 	  echo "==> Installing llama-stack..." && \
-	  uv pip install "llama-stack==0.5.0" "llama-stack-api==0.5.0" ollama && \
+	  uv pip install "llama-stack==0.5.0" "llama-stack-api==0.5.0" ollama "pymilvus==2.6.9" "milvus-lite>=2.5.1" "setuptools>=80.9.0,<82.0.0" && \
+	  mkdir -p ../../../milvus_data && \
 	  echo "==> Killing any existing process on port 8321..." && \
 	  lsof -ti:8321 | xargs kill -9 2>/dev/null; true && \
 	  echo "==> Starting Llama Stack server on port 8321..." && \

--- a/agents/langgraph/agentic_rag/Makefile
+++ b/agents/langgraph/agentic_rag/Makefile
@@ -55,15 +55,14 @@ ollama: ## Install Ollama, start it, and pull models
 	  ollama pull $(MODEL) && \
 	  echo "==> Pulling embedding model ($(OLLAMA_EMBEDDING_MODEL))..." && \
 	  ollama pull $(OLLAMA_EMBEDDING_MODEL) && \
-	  echo "==> Creating Milvus dir..." && \
-	  mkdir -p ../../../milvus_data && \
 	  echo "" && \
 	  echo "Done. Run 'make llama-server' to start the Llama Stack server."
 
 llama-server: ## Install llama-stack and start Llama Stack server
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Installing llama-stack..." && \
-	  uv pip install "llama-stack==0.5.0" "llama-stack-api==0.5.0" ollama && \
+	  uv pip install "llama-stack==0.5.0" "llama-stack-api==0.5.0" ollama "pymilvus==2.6.9" "milvus-lite>=2.5.1" "setuptools>=80.9.0,<82.0.0" && \
+	  mkdir -p ../../../milvus_data && \
 	  echo "==> Killing any existing process on port 8321..." && \
 	  lsof -ti:8321 | xargs kill -9 2>/dev/null; true && \
 	  echo "==> Starting Llama Stack server on port 8321..." && \

--- a/agents/langgraph/human_in_the_loop/Makefile
+++ b/agents/langgraph/human_in_the_loop/Makefile
@@ -52,15 +52,14 @@ ollama: ## Install Ollama, start it, and pull models
 	  done && \
 	  echo "==> Pulling $(MODEL)..." && \
 	  ollama pull $(MODEL) && \
-	  echo "==> Creating Milvus dir..." && \
-	  mkdir -p ../../../milvus_data && \
 	  echo "" && \
 	  echo "Done. Run 'make llama-server' to start the Llama Stack server."
 
 llama-server: ## Install llama-stack and start Llama Stack server
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Installing llama-stack..." && \
-	  uv pip install "llama-stack==0.5.0" "llama-stack-api==0.5.0" ollama && \
+	  uv pip install "llama-stack==0.5.0" "llama-stack-api==0.5.0" ollama "pymilvus==2.6.9" "milvus-lite>=2.5.1" "setuptools>=80.9.0,<82.0.0" && \
+	  mkdir -p ../../../milvus_data && \
 	  echo "==> Killing any existing process on port 8321..." && \
 	  lsof -ti:8321 | xargs kill -9 2>/dev/null; true && \
 	  echo "==> Starting Llama Stack server on port 8321..." && \

--- a/agents/langgraph/react_agent/Makefile
+++ b/agents/langgraph/react_agent/Makefile
@@ -52,15 +52,14 @@ ollama: ## Install Ollama, start it, and pull models
 	  done && \
 	  echo "==> Pulling $(MODEL)..." && \
 	  ollama pull $(MODEL) && \
-	  echo "==> Creating Milvus dir..." && \
-	  mkdir -p ../../../milvus_data && \
 	  echo "" && \
 	  echo "Done. Run 'make llama-server' to start the Llama Stack server."
 
 llama-server: ## Install llama-stack and start Llama Stack server
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Installing llama-stack..." && \
-	  uv pip install "llama-stack==0.5.0" "llama-stack-api==0.5.0" ollama && \
+	  uv pip install "llama-stack==0.5.0" "llama-stack-api==0.5.0" ollama "pymilvus==2.6.9" "milvus-lite>=2.5.1" "setuptools>=80.9.0,<82.0.0" && \
+	  mkdir -p ../../../milvus_data && \
 	  echo "==> Killing any existing process on port 8321..." && \
 	  lsof -ti:8321 | xargs kill -9 2>/dev/null; true && \
 	  echo "==> Starting Llama Stack server on port 8321..." && \

--- a/agents/langgraph/react_with_database_memory/Makefile
+++ b/agents/langgraph/react_with_database_memory/Makefile
@@ -52,15 +52,14 @@ ollama: ## Install Ollama, start it, and pull models
 	  done && \
 	  echo "==> Pulling $(MODEL)..." && \
 	  ollama pull $(MODEL) && \
-	  echo "==> Creating Milvus dir..." && \
-	  mkdir -p ../../../milvus_data && \
 	  echo "" && \
 	  echo "Done. Run 'make llama-server' to start the Llama Stack server."
 
 llama-server: ## Install llama-stack and start Llama Stack server
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Installing llama-stack..." && \
-	  uv pip install "llama-stack==0.5.0" "llama-stack-api==0.5.0" ollama && \
+	  uv pip install "llama-stack==0.5.0" "llama-stack-api==0.5.0" ollama "pymilvus==2.6.9" "milvus-lite>=2.5.1" "setuptools>=80.9.0,<82.0.0" && \
+	  mkdir -p ../../../milvus_data && \
 	  echo "==> Killing any existing process on port 8321..." && \
 	  lsof -ti:8321 | xargs kill -9 2>/dev/null; true && \
 	  echo "==> Starting Llama Stack server on port 8321..." && \

--- a/agents/llamaindex/websearch_agent/Makefile
+++ b/agents/llamaindex/websearch_agent/Makefile
@@ -52,15 +52,14 @@ ollama: ## Install Ollama, start it, and pull models
 	  done && \
 	  echo "==> Pulling $(MODEL)..." && \
 	  ollama pull $(MODEL) && \
-	  echo "==> Creating Milvus dir..." && \
-	  mkdir -p ../../../milvus_data && \
 	  echo "" && \
 	  echo "Done. Run 'make llama-server' to start the Llama Stack server."
 
 llama-server: ## Install llama-stack and start Llama Stack server
 	@source .venv/bin/activate && set -a && source .env && set +a && \
 	  echo "==> Installing llama-stack..." && \
-	  uv pip install "llama-stack==0.5.0" "llama-stack-api==0.5.0" ollama && \
+	  uv pip install "llama-stack==0.5.0" "llama-stack-api==0.5.0" ollama "pymilvus==2.6.9" "milvus-lite>=2.5.1" "setuptools>=80.9.0,<82.0.0" && \
+	  mkdir -p ../../../milvus_data && \
 	  echo "==> Killing any existing process on port 8321..." && \
 	  lsof -ti:8321 | xargs kill -9 2>/dev/null; true && \
 	  echo "==> Starting Llama Stack server on port 8321..." && \


### PR DESCRIPTION
## Ticket
[RHAIENG-5038](https://redhat.atlassian.net/browse/RHAIENG-5038)

## Summary
- Added `pymilvus==2.6.9`, `milvus-lite>=2.5.1`, and `setuptools>=80.9.0,<82.0.0` to the `llama-server` Makefile target in 8 agents (langgraph/{react_agent, human_in_the_loop, agentic_rag, react_with_database_memory}, llamaindex/websearch_agent, crewai/websearch_agent, google/adk, langflow/simple_tool_calling_agent)
- Added `mkdir -p ../../../milvus_data` to the `llama-server` target so it works standalone without running `make ollama` first
- Removed `milvus_data` directory creation from the `ollama` target (6 agents) since it's a llama-stack concern, not an ollama concern
- `autogen/mcp_agent` already had correct deps in its pyproject.toml `[llama]` extra — no changes needed
- `vanilla_python/openai_responses_agent` and `a2a/langgraph_crewai_agent` have no `llama-server` target (by design) — not affected

## Test plan
For all 9 agents with a `llama-server` target, verified clean venv install + milvus imports:

- [x] `langgraph/react_agent` — pymilvus 2.6.9, milvus_lite OK, setuptools 81.0.0, llama_stack OK, milvus_data OK
- [x] `langgraph/human_in_the_loop` — pymilvus 2.6.9, milvus_lite OK, setuptools 81.0.0, llama_stack OK, milvus_data OK
- [x] `langgraph/agentic_rag` — pymilvus 2.6.9, milvus_lite OK, setuptools 81.0.0, llama_stack OK, milvus_data OK
- [x] `langgraph/react_with_database_memory` — pymilvus 2.6.9, milvus_lite OK, setuptools 81.0.0, llama_stack OK, milvus_data OK
- [x] `llamaindex/websearch_agent` — pymilvus 2.6.9, milvus_lite OK, setuptools 81.0.0, llama_stack OK, milvus_data OK
- [x] `crewai/websearch_agent` — pymilvus 2.6.9, milvus_lite OK, setuptools 81.0.0, llama_stack OK, milvus_data OK
- [x] `google/adk` — pymilvus 2.6.9, milvus_lite OK, setuptools 81.0.0, llama_stack OK, milvus_data OK
- [x] `langflow/simple_tool_calling_agent` — pymilvus 2.6.9, milvus_lite OK, setuptools 81.0.0, llama_stack OK, milvus_data OK
- [x] `autogen/mcp_agent` (no changes, baseline) — pymilvus 3.0.0, milvus_lite OK, setuptools 81.0.0, llama_stack OK, milvus_data OK

Assisted by Claude Opus 4.6 (1M context)

[RHAIENG-5038]: https://redhat.atlassian.net/browse/RHAIENG-5038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ