### PR TITLE
BUG : Fix documentation gap in Langgraph based Agent templates

### DIFF
--- a/agents/langgraph/agentic_rag/README.md
+++ b/agents/langgraph/agentic_rag/README.md
@@ -38,6 +38,14 @@ cd agents/langgraph/agentic_rag
 make init
 ```
 
+### Creating environment
+
+Now you will remove old .venv and create new. Next dependencies will be installed.
+
+```bash
+make env
+```
+
 ### Tracing (optional)
 
 Tracing is optional. If MLflow tracing is required, enable it by uncommenting and setting the following environment variables in the `.env` file.
@@ -107,14 +115,6 @@ DOCS_TO_LOAD=./data/sample_knowledge.txt
 - `VECTOR_STORE_PROVIDER` - Vector store backend: `milvus` for local development (default), `pgvector` for OpenShift deployments.
 - `VECTOR_STORE_PATH` - Absolute path where the Milvus Lite database will be stored. Not used when `VECTOR_STORE_PROVIDER=pgvector`.
 - `DOCS_TO_LOAD` - Path to the text file containing documents to load into the vector store. A sample file is provided at `./data/sample_knowledge.txt`.
-
-### Creating environment
-
-Now you will remove old .venv and create new. Next dependencies will be installed.
-
-```bash
-make env
-```
 
 ### Setup Ollama
 

--- a/agents/langgraph/human_in_the_loop/README.md
+++ b/agents/langgraph/human_in_the_loop/README.md
@@ -48,6 +48,14 @@ cd agents/langgraph/human_in_the_loop
 make init
 ```
 
+### Creating environment
+
+Now you will remove old .venv and create new. Next dependencies will be installed.
+
+```bash
+make env
+```
+
 ### Tracing (optional)
 
 Tracing is optional. If MLflow tracing is required, enable it by uncommenting and setting the following environment variables in the `.env` file.
@@ -95,14 +103,6 @@ MLFLOW_WORKSPACE="default"
 - If `MLFLOW_TRACKING_URI` is set, the application will attempt to connect to the MLflow server at startup. If the server is unreachable, the application will log a warning and continue running without tracing.
 
 - You can control how long the application waits for the MLflow server by setting `MLFLOW_HEALTH_CHECK_TIMEOUT` (in seconds, default: `5`).
-
-### Creating environment
-
-Now you will remove old .venv and create new. Next dependencies will be installed.
-
-```bash
-make env
-```
 
 ### Setup Ollama
 

--- a/agents/langgraph/react_agent/README.md
+++ b/agents/langgraph/react_agent/README.md
@@ -37,6 +37,14 @@ cd agents/langgraph/react_agent
 make init
 ```
 
+### Creating environment
+
+Now you will remove old .venv and create new. Next dependencies will be installed.
+
+```bash
+make env
+```
+
 ### Tracing (optional)
 
 Tracing is optional. If MLflow tracing is required, enable it by uncommenting and setting the following environment variables in the `.env` file.
@@ -84,14 +92,6 @@ MLFLOW_WORKSPACE="default"
 - If `MLFLOW_TRACKING_URI` is set, the application will attempt to connect to the MLflow server at startup. If the server is unreachable, the application will log a warning and continue running without tracing.
 
 - You can control how long the application waits for the MLflow server by setting `MLFLOW_HEALTH_CHECK_TIMEOUT` (in seconds, default: `5`).
-
-### Creating environment
-
-Now you will remove old .venv and create new. Next dependencies will be installed.
-
-```bash
-make env
-```
 
 ### Setup Ollama
 

--- a/agents/langgraph/react_with_database_memory/README.md
+++ b/agents/langgraph/react_with_database_memory/README.md
@@ -47,6 +47,14 @@ cd agents/langgraph/react_with_database_memory
 make init
 ```
 
+### Creating environment
+
+Now you will remove old .venv and create new. Next dependencies will be installed.
+
+```bash
+make env
+```
+
 ### Tracing (optional)
 
 Tracing is optional. If MLflow tracing is required, enable it by uncommenting and setting the following environment variables in the `.env` file.
@@ -136,14 +144,6 @@ createdb agent_memory
 ```
 
 The database tables are created automatically on first run -- no manual schema setup is needed.
-
-### Creating environment
-
-Now you will remove old .venv and create new. Next dependencies will be installed.
-
-```bash
-make env
-```
 
 ### Setup Ollama
 


### PR DESCRIPTION
## Description

The fix is regarding a bug in the langgraph agent templates documentation. The documentation walks through ML Flow setup using uv even before uv environment is configured. The fix is adding documentation to to create venv before running the MLFlow step.


## Jira Ticket

RHAIENG-5065
<!-- e.g. RHAIENG-123. Include the ticket ID so the PR appears as a linked pull request on the Jira issue. -->

## Testing

- [x] `make test` passes (run from the affected agent directory)
- [x] Manual testing performed (describe steps below)
- [x] No testing required (documentation/config change only)

<!-- Describe any additional verification steps -->

## Checklist

- [ x ] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [ x ] No `.env` or secret files are included in this PR
- [ x ] All changes are within scope of the linked Jira ticket (if not, explain in Description)

## Review Guidance

<!-- Optional: highlight areas that need careful review, key design decisions, or files that can be safely skipped -->

## Related PRs

<!-- Link any related pull requests, e.g. #42, #56 -->
