### PR TITLE
RHAIENG-4645: add integration test for CrewAI websearch agent

### DIFF
--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -59,6 +59,7 @@ jobs:
         agent:
           - { name: langgraph-react-agent, dir: agents/langgraph/react_agent }
           - { name: langgraph-hitl-agent, dir: agents/langgraph/human_in_the_loop }
+          - { name: crewai-websearch-agent, dir: agents/crewai/websearch_agent }
     env:
       API_KEY: ${{ vars.API_KEY }}
       BASE_URL: ${{ vars.BASE_URL }}

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ STATUS.md
 .e2e-workdir
 evals/evalhub_adapter/eval-*.yaml
 evals/evalhub_adapter/provider-*.json
+results.xml

--- a/agents/crewai/websearch_agent/Makefile
+++ b/agents/crewai/websearch_agent/Makefile
@@ -5,7 +5,7 @@ VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 MODEL          ?= llama3.1:8b
 
-.PHONY: init re-init env ollama llama-server run-app run-app-fresh run-cli build push build-openshift deploy undeploy test dry-run help
+.PHONY: init re-init env ollama llama-server run-app run-app-fresh run-cli build push build-openshift deploy undeploy test test-integration dry-run help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-12s %s\n", $$1, $$2}'
@@ -168,4 +168,7 @@ undeploy: ## Remove deployment from cluster
 	helm uninstall $(AGENT_NAME)
 
 test: ## Run tests
-	uv run --extra dev python -m pytest tests/
+	uv run --extra dev python -m pytest tests/ --ignore=tests/integration
+
+test-integration: ## Run integration deployment tests
+	PYTHONPATH=$$(git rev-parse --show-toplevel)/tests uv run --extra dev python -m pytest tests/integration/test_deployment.py -v --tb=long --junitxml=results.xml

--- a/agents/crewai/websearch_agent/Makefile
+++ b/agents/crewai/websearch_agent/Makefile
@@ -170,5 +170,7 @@ undeploy: ## Remove deployment from cluster
 test: ## Run tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration
 
-test-integration: ## Run integration deployment tests
-	PYTHONPATH=$$(git rev-parse --show-toplevel)/tests uv run --extra dev python -m pytest tests/integration/test_deployment.py -v --tb=long --junitxml=results.xml
+test-integration: ## Run integration deployment test
+	PYTHONPATH=$$(git rev-parse --show-toplevel)/tests \
+	  uv run --extra dev python -m pytest tests/integration/test_deployment.py \
+	    -v --tb=long --junitxml=results.xml

--- a/agents/crewai/websearch_agent/pyproject.toml
+++ b/agents/crewai/websearch_agent/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "httpx>=0.27",
     "pytest>=9.0.2",
 ]
 tracing = [

--- a/agents/crewai/websearch_agent/tests/integration/conftest.py
+++ b/agents/crewai/websearch_agent/tests/integration/conftest.py
@@ -1,0 +1,2 @@
+# Re-export shared integration fixtures so pytest discovers them.
+from integration.conftest import cluster_auth, repo_root  # noqa: F401

--- a/agents/crewai/websearch_agent/tests/integration/test_deployment.py
+++ b/agents/crewai/websearch_agent/tests/integration/test_deployment.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+from integration.utils import (
+    MakeTargetError,
+    RouteNotFoundError,
+    get_route,
+    health_check,
+    load_agent_name,
+    run_make,
+)
+
+logger = logging.getLogger(__name__)
+
+INTERNAL_REGISTRY = "image-registry.openshift-image-registry.svc:5000"
+
+
+@pytest.fixture(scope="module")
+def agent_dir(repo_root):
+    return repo_root / "agents" / "crewai" / "websearch_agent"
+
+
+@pytest.fixture(scope="module")
+def agent_name(agent_dir):
+    return load_agent_name(agent_dir)
+
+
+def _write_env_file(agent_dir, container_image):
+    """Write a .env file so Makefile targets can source it."""
+    missing = [v for v in ("BASE_URL", "MODEL_ID") if v not in os.environ]
+    if missing:
+        pytest.fail(
+            f"Missing required env vars: {', '.join(missing)}. "
+            "Set them in the CI workflow or export locally."
+        )
+    env_path = agent_dir / ".env"
+    env_path.write_text(
+        f"API_KEY={os.environ.get('API_KEY', 'not-needed')}\n"
+        f"BASE_URL={os.environ['BASE_URL']}\n"
+        f"MODEL_ID={os.environ['MODEL_ID']}\n"
+        f"CONTAINER_IMAGE={container_image}\n"
+    )
+    return env_path
+
+
+@pytest.fixture(scope="module")
+def deployed_agent(cluster_auth, agent_dir, agent_name):
+    namespace = cluster_auth["namespace"]
+    container_image = f"{INTERNAL_REGISTRY}/{namespace}/{agent_name}:latest"
+    env_path = _write_env_file(agent_dir, container_image)
+
+    deployed = False
+    try:
+        logger.info("Building image on cluster via build-openshift...")
+        run_make("build-openshift", cwd=agent_dir, timeout=600)
+
+        logger.info("Deploying to cluster...")
+        run_make("deploy", cwd=agent_dir, timeout=300)
+        deployed = True
+
+        route_url = get_route(agent_name, namespace=namespace)
+        logger.info("Agent deployed at %s", route_url)
+
+        yield route_url
+
+    except (MakeTargetError, RouteNotFoundError) as exc:
+        pytest.fail(f"Deployment failed: {exc}")
+
+    finally:
+        if deployed:
+            logger.info("Tearing down deployment...")
+            try:
+                run_make("undeploy", cwd=agent_dir, timeout=120)
+            except MakeTargetError:
+                logger.warning(
+                    "Cleanup failed — manual undeploy may be needed", exc_info=True
+                )
+        env_path.unlink(missing_ok=True)
+
+
+@pytest.mark.integration
+def test_health_endpoint(deployed_agent):
+    route_url = deployed_agent
+    result = health_check(f"{route_url}/health", retries=12, backoff=5.0)
+
+    assert result["status"] == "healthy"
+    assert result["agent_initialized"] is True


### PR DESCRIPTION
## Ticket
[RHAIENG-4645](https://redhat.atlassian.net/browse/RHAIENG-4645)

## Summary
- Add deployment integration test (`test_deployment.py`) for the CrewAI websearch agent, consistent with the existing LangGraph agent tests
- Add `test-integration` Makefile target with proper `PYTHONPATH` for shared utils
- Exclude `tests/integration/` from the unit `test` target
- Add `httpx>=0.27` dev dependency (required by shared integration utils)
- Add `crewai-websearch-agent` to the nightly CI workflow matrix

## Test plan
- [x] `make test` from `agents/crewai/websearch_agent/` still runs unit tests without integration tests
- [ ] `make test-integration` runs the deployment test — requires cluster auth, will be verified by nightly CI
- [ ] Integration test builds image, deploys via Helm, validates `/health` returns 200, and tears down via `make undeploy` — requires cluster auth, will be verified by nightly CI
- [x] JUnit XML output (`results.xml`) is configured via `--junitxml=results.xml` in the Makefile target

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHAIENG-4645]: https://redhat.atlassian.net/browse/RHAIENG-4645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ