### PR TITLE
ci: add CODEOWNERS and fix Unit Tests check for required status checks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @red-hat-data-services/agentic-starter-kits-maintainers

--- a/.github/workflows/agent-tests.yml
+++ b/.github/workflows/agent-tests.yml
@@ -16,28 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  changes:
-    name: Detect changes
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    outputs:
-      agents: ${{ steps.filter.outputs.agents }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
-
-      - name: Check for agent changes
-        id: filter
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
-        with:
-          filters: |
-            agents:
-              - 'agents/**'
-
   test:
     name: Unit Tests
-    needs: changes
-    if: needs.changes.outputs.agents == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -46,15 +26,30 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check for agent changes
+        id: changes
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base_ref="origin/${{ github.event.pull_request.base.ref }}"
+            if git diff --name-only "${base_ref}...HEAD" | grep -q '^agents/'; then
+              echo "agents=true" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "agents=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup Python
+        if: steps.changes.outputs.agents == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
 
       - name: Install uv
+        if: steps.changes.outputs.agents == 'true'
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
 
       - name: Run tests
+        if: steps.changes.outputs.agents == 'true'
         id: run-tests
         run: |
           # Discover agent dirs containing unit-test files
@@ -104,20 +99,10 @@ jobs:
           exit "$failed"
 
       - name: Publish test report
-        if: always()
+        if: always() && steps.run-tests.outcome != 'skipped'
         uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386  # v6.4.0
         with:
           report_paths: test-results/*.xml
           check_name: Agent Test Results
           include_passed: true
           annotate_only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-
-  skip:
-    name: Unit Tests
-    needs: changes
-    if: needs.changes.outputs.agents != 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-    steps:
-      - name: No agent changes
-        run: echo "No agent files changed — skipping tests."

--- a/.github/workflows/agent-tests.yml
+++ b/.github/workflows/agent-tests.yml
@@ -3,10 +3,8 @@ name: Agent Tests
 on:
   push:
     branches: [main]
-    paths: ['agents/**']
   pull_request:
     branches: [main]
-    paths: ['agents/**']
   workflow_dispatch:
 
 permissions:
@@ -18,8 +16,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      agents: ${{ steps.filter.outputs.agents }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+
+      - name: Check for agent changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+        with:
+          filters: |
+            agents:
+              - 'agents/**'
+
   test:
     name: Unit Tests
+    needs: changes
+    if: needs.changes.outputs.agents == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -93,3 +111,13 @@ jobs:
           check_name: Agent Test Results
           include_passed: true
           annotate_only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+
+  skip:
+    name: Unit Tests
+    needs: changes
+    if: needs.changes.outputs.agents != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: No agent changes
+        run: echo "No agent files changed — skipping tests."


### PR DESCRIPTION
## Description

Two changes to support the new repo-level ruleset ("Require reviews"):

1. **Adds `.github/CODEOWNERS`** — assigns `@red-hat-data-services/agentic-starter-kits-maintainers` as code owners for all files, activating the `require_code_owner_review` rule so at least one team member must approve every PR.

2. **Updates `agent-tests.yml`** — the ruleset requires the `Unit Tests` check to pass, but the workflow previously used path-based triggers (`paths: ['agents/**']`), so PRs not touching agent files never reported the check, leaving it pending indefinitely. The workflow now always runs but skips the expensive test steps (Python setup, uv, test execution) when no `agents/` files changed.

## Jira Ticket

RHAIENG-4065

## Testing

- [ ] No testing required (documentation/config change only)

After merge:
- Open a test PR touching non-agent files and confirm `Unit Tests` check passes (skipped) and review is requested from `agentic-starter-kits-maintainers`
- Open a test PR touching `agents/` and confirm tests actually run

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)

## Review Guidance

- `.github/CODEOWNERS` — single line, confirm the team name matches the GitHub team
- `.github/workflows/agent-tests.yml` — removed `paths` trigger, added a `changes` step that sets `agents=true` only when `agents/` files are modified; all subsequent steps are gated on that output

## Related PRs

- #103 — Added the `agent-tests.yml` workflow (the `Unit Tests` check now required by the ruleset)