### PR TITLE
RHAIENG-5096: extract shared load_golden() from duplicated conftest files

### DIFF
--- a/agents/autogen/mcp_agent/tests/behavioral/conftest.py
+++ b/agents/autogen/mcp_agent/tests/behavioral/conftest.py
@@ -13,6 +13,7 @@ from typing import Any, AsyncGenerator, Callable, Coroutine
 import httpx
 import pytest
 import yaml
+from harness.fixtures import load_golden as _load_golden_from
 from harness.runner import TaskConfig, TaskResult, run_task
 
 try:
@@ -56,15 +57,12 @@ def eval_config() -> dict[str, Any]:
         return yaml.safe_load(f)
 
 
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
 def load_golden(category: str | None = None) -> list[dict[str, Any]]:
     """Load golden queries from the fixtures directory, optionally filtering by category."""
-    path = Path(__file__).parent / "fixtures" / "golden_queries.yaml"
-    with open(path, encoding="utf-8") as f:
-        data = yaml.safe_load(f)
-    queries = data.get("queries", [])
-    if category:
-        queries = [q for q in queries if q.get("category") == category]
-    return queries
+    return _load_golden_from(FIXTURES_DIR, category)
 
 
 @pytest.fixture

--- a/agents/crewai/websearch_agent/tests/behavioral/conftest.py
+++ b/agents/crewai/websearch_agent/tests/behavioral/conftest.py
@@ -13,6 +13,7 @@ from typing import Any, AsyncGenerator, Callable, Coroutine
 import httpx
 import pytest
 import yaml
+from harness.fixtures import load_golden as _load_golden_from
 from harness.runner import TaskConfig, TaskResult, run_task
 
 try:
@@ -58,16 +59,12 @@ def eval_config() -> dict[str, Any]:
 
 SEARCH_EVIDENCE = ["openshift ai"]
 
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
 
 def load_golden(category: str | None = None) -> list[dict[str, Any]]:
     """Load golden queries from the fixtures directory, optionally filtering by category."""
-    path = Path(__file__).parent / "fixtures" / "golden_queries.yaml"
-    with open(path, encoding="utf-8") as f:
-        data = yaml.safe_load(f)
-    queries = data.get("queries", [])
-    if category:
-        queries = [q for q in queries if q.get("category") == category]
-    return queries
+    return _load_golden_from(FIXTURES_DIR, category)
 
 
 @pytest.fixture

--- a/agents/langgraph/agentic_rag/tests/behavioral/conftest.py
+++ b/agents/langgraph/agentic_rag/tests/behavioral/conftest.py
@@ -13,6 +13,7 @@ from typing import Any, AsyncGenerator, Callable, Coroutine
 import httpx
 import pytest
 import yaml
+from harness.fixtures import load_golden as _load_golden_from
 from harness.runner import TaskConfig, TaskResult, run_task
 
 try:
@@ -48,15 +49,12 @@ def _find_repo_root() -> Path:
     )
 
 
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
 def load_golden(category: str | None = None) -> list[dict[str, Any]]:
     """Load golden queries from the fixtures directory, optionally filtering by category."""
-    path = Path(__file__).parent / "fixtures" / "golden_queries.yaml"
-    with open(path, encoding="utf-8") as f:
-        data = yaml.safe_load(f)
-    queries = data.get("queries", [])
-    if category:
-        queries = [q for q in queries if q.get("category") == category]
-    return queries
+    return _load_golden_from(FIXTURES_DIR, category)
 
 
 @pytest.fixture

--- a/agents/langgraph/react_agent/tests/behavioral/test_tool_usage.py
+++ b/agents/langgraph/react_agent/tests/behavioral/test_tool_usage.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-import yaml
+from harness.fixtures import load_golden as _load_golden_from
 from harness.scorers.tool_sequence import (
     score_hallucinated_tools,
     score_tool_call_validity,
@@ -29,16 +29,12 @@ from harness.scorers.tool_sequence import (
 
 pytestmark = pytest.mark.langgraph_react
 
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
 
 def _load_golden(category: str | None = None) -> list[dict[str, Any]]:
     """Load golden queries, optionally filtering by category."""
-    path = Path(__file__).parent / "fixtures" / "golden_queries.yaml"
-    with open(path, encoding="utf-8") as f:
-        data = yaml.safe_load(f)
-    queries = data.get("queries", [])
-    if category:
-        queries = [q for q in queries if q.get("category") == category]
-    return queries
+    return _load_golden_from(FIXTURES_DIR, category)
 
 
 def _factual_queries() -> list[dict[str, Any]]:

--- a/agents/vanilla_python/openai_responses_agent/tests/behavioral/conftest.py
+++ b/agents/vanilla_python/openai_responses_agent/tests/behavioral/conftest.py
@@ -13,6 +13,7 @@ from typing import Any, AsyncGenerator, Callable, Coroutine
 import httpx
 import pytest
 import yaml
+from harness.fixtures import load_golden as _load_golden_from
 from harness.runner import TaskConfig, TaskResult, run_task
 
 try:
@@ -59,16 +60,12 @@ def eval_config() -> dict[str, Any]:
 PRICE_EVIDENCE = ["price", "cost", "$", "dollar"]
 REVIEW_EVIDENCE = ["review", "rating", "star", "recommend"]
 
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
 
 def load_golden(category: str | None = None) -> list[dict[str, Any]]:
     """Load golden queries from the fixtures directory, optionally filtering by category."""
-    path = Path(__file__).parent / "fixtures" / "golden_queries.yaml"
-    with open(path, encoding="utf-8") as f:
-        data = yaml.safe_load(f)
-    queries = data.get("queries", [])
-    if category:
-        queries = [q for q in queries if q.get("category") == category]
-    return queries
+    return _load_golden_from(FIXTURES_DIR, category)
 
 
 @pytest.fixture

--- a/docs/adding-behavioral-tests.md
+++ b/docs/adding-behavioral-tests.md
@@ -38,6 +38,20 @@ The conftest defines fixtures specific to your agent. Because agent tests live u
 - `agent_thresholds` — pulls from the shared `eval_config` fixture
 - `run_eval` — overrides the root fixture to add MLflow trace enrichment
 
+**`load_golden()` helper:** Import the shared loader from `harness.fixtures` and create a thin wrapper that binds `fixtures_dir` to `Path(__file__).parent / "fixtures"`:
+
+```python
+from pathlib import Path
+from typing import Any
+
+from harness.fixtures import load_golden as _load_golden_from
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+def load_golden(category: str | None = None) -> list[dict[str, Any]]:
+    return _load_golden_from(FIXTURES_DIR, category)
+```
+
 See existing agent implementations for working examples:
 
 - `agents/langgraph/react_agent/tests/behavioral/conftest.py`

--- a/evals/harness/fixtures.py
+++ b/evals/harness/fixtures.py
@@ -1,0 +1,25 @@
+"""Golden-query loader for behavioral tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def load_golden(
+    fixtures_dir: Path | str,
+    category: str | None = None,
+) -> list[dict[str, Any]]:
+    """Load golden queries from *fixtures_dir*/golden_queries.yaml.
+
+    Expected YAML shape: ``{"queries": [{"category": str, "query": str, ...}]}``
+    """
+    path = Path(fixtures_dir) / "golden_queries.yaml"
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    queries = data.get("queries", [])
+    if category:
+        queries = [q for q in queries if q.get("category") == category]
+    return queries


### PR DESCRIPTION
## Summary
- Extracts the duplicated `load_golden()` helper (load `golden_queries.yaml`, optionally filter by category) from 5 behavioral test files into a shared `evals/harness/fixtures.py` module
- Each consumer keeps a thin 2-line wrapper that binds `fixtures_dir` and preserves the existing zero-arg call signature — no test logic changes
- Updates `docs/adding-behavioral-tests.md` with the new pattern

## Files changed
| File | Change |
|------|--------|
| `evals/harness/fixtures.py` | **New** — shared `load_golden(fixtures_dir, category)` |
| `agents/autogen/mcp_agent/tests/behavioral/conftest.py` | Use shared loader |
| `agents/crewai/websearch_agent/tests/behavioral/conftest.py` | Use shared loader |
| `agents/langgraph/agentic_rag/tests/behavioral/conftest.py` | Use shared loader |
| `agents/langgraph/react_agent/tests/behavioral/test_tool_usage.py` | Use shared loader |
| `agents/vanilla_python/openai_responses_agent/tests/behavioral/conftest.py` | Use shared loader |
| `docs/adding-behavioral-tests.md` | Document the new pattern |

## Test plan
- [x] Import resolution: `from harness.fixtures import load_golden` resolves via `pythonpath = ["evals"]`
- [x] `load_golden` is NOT re-exported from `harness.__init__` (consumers import from `harness.fixtures` directly)
- [x] `pytest --collect-only` passes for all 5 affected agents (77 tests collected, 0 errors)
- [x] Cross-agent consistency check: 10/10 checks pass (import alias, FIXTURES_DIR naming, wrapper signature/body, no leftover inline implementations, no stale imports, doc accuracy)
- [x] No remaining `golden_queries.yaml` references in agent Python files (`grep` returns 0 matches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)