### PR TITLE
refactor: align react_agent conftest with standard load_golden pattern

### DIFF
--- a/agents/langgraph/react_agent/tests/behavioral/conftest.py
+++ b/agents/langgraph/react_agent/tests/behavioral/conftest.py
@@ -13,6 +13,7 @@ from typing import Any, AsyncGenerator, Callable, Coroutine
 import httpx
 import pytest
 import yaml
+from harness.fixtures import load_golden as _load_golden_from
 from harness.runner import TaskConfig, TaskResult, run_task
 
 try:
@@ -37,6 +38,14 @@ def _find_repo_root() -> Path:
     raise FileNotFoundError(
         "Could not find repo root (no tests/behavioral/configs/thresholds.yaml)"
     )
+
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def load_golden(category: str | None = None) -> list[dict[str, Any]]:
+    """Load golden queries from the fixtures directory, optionally filtering by category."""
+    return _load_golden_from(FIXTURES_DIR, category)
 
 
 @pytest.fixture

--- a/agents/langgraph/react_agent/tests/behavioral/test_tool_usage.py
+++ b/agents/langgraph/react_agent/tests/behavioral/test_tool_usage.py
@@ -16,11 +16,10 @@ we also verify tool selection accuracy via scorers.
 from __future__ import annotations
 
 import warnings
-from pathlib import Path
 from typing import Any
 
 import pytest
-from harness.fixtures import load_golden as _load_golden_from
+from conftest import load_golden
 from harness.scorers.tool_sequence import (
     score_hallucinated_tools,
     score_tool_call_validity,
@@ -29,17 +28,10 @@ from harness.scorers.tool_sequence import (
 
 pytestmark = pytest.mark.langgraph_react
 
-FIXTURES_DIR = Path(__file__).parent / "fixtures"
-
-
-def _load_golden(category: str | None = None) -> list[dict[str, Any]]:
-    """Load golden queries, optionally filtering by category."""
-    return _load_golden_from(FIXTURES_DIR, category)
-
 
 def _factual_queries() -> list[dict[str, Any]]:
     """Return golden queries that should trigger tool calls."""
-    return [q for q in _load_golden() if q.get("expected_tools")]
+    return [q for q in load_golden() if q.get("expected_tools")]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Moves `load_golden()` wrapper from `test_tool_usage.py` into `conftest.py`, matching the convention used by agentic_rag, websearch_agent, and mcp_agent
- Removes duplicated `FIXTURES_DIR` constant and unused `pathlib.Path` import from `test_tool_usage.py`
- No behavioral change — all call sites delegate to the same `harness.fixtures.load_golden` with identical arguments

## Test plan
- [x] Verify `make test` passes for react_agent (behavioral tests use the relocated `load_golden`)
- [x] Confirm pattern matches agentic_rag/conftest.py exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)