### PR TITLE
fix: add missing stream parameter to autogen_mcp run_eval fixture

### DIFF
--- a/agents/autogen/mcp_agent/tests/behavioral/conftest.py
+++ b/agents/autogen/mcp_agent/tests/behavioral/conftest.py
@@ -101,6 +101,7 @@ def run_eval(
         timeout_seconds: float = 30.0,
         max_tokens_budget: int | None = None,
         model: str | None = None,
+        stream: bool = False,
     ) -> TaskResult:
         config = TaskConfig(
             agent_url=agent_url,


### PR DESCRIPTION
## Summary
- Adds `stream: bool = False` to the `_run()` inner function in the autogen_mcp `run_eval` fixture, aligning its signature with all other agents (react_agent, agentic_rag, etc.)
- The parameter is accepted for interface consistency but not wired to `TaskConfig` — autogen always uses non-streaming for evals since tool_invocations are only exposed in non-streaming JSON responses

## Test plan
- [x] Verify existing autogen_mcp behavioral tests still pass
- [x] Confirm `_run()` signature matches react_agent and agentic_rag patterns

Closes RHAIENG-5127

🤖 Generated with [Claude Code](https://claude.com/claude-code)