### PR TITLE
feat: add gitleaks secret scanning to pre-commit and CI

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -49,6 +49,17 @@ jobs:
         with:
           version: 1.7.12
 
+  secret-scanning:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          fetch-depth: 0
+
       - name: Gitleaks
         env:
           GITLEAKS_VERSION: "8.30.1"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -48,3 +48,8 @@ jobs:
         uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8  # v2.1.2
         with:
           version: 1.7.12
+
+      - name: Gitleaks
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -50,6 +50,8 @@ jobs:
           version: 1.7.12
 
       - name: Gitleaks
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.9
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_VERSION: "8.30.1"
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar xz
+          ./gitleaks detect --source . --verbose --redact

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -63,6 +63,13 @@ jobs:
       - name: Gitleaks
         env:
           GITLEAKS_VERSION: "8.30.1"
+          GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
         run: |
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar xz
-          ./gitleaks detect --source . --verbose --redact
+          curl -sSfL -o gitleaks.tar.gz "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf gitleaks.tar.gz gitleaks
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            ./gitleaks detect --source . --config .gitleaks.toml --log-opts="origin/main..HEAD" --verbose --redact
+          else
+            ./gitleaks detect --source . --config .gitleaks.toml --verbose --redact
+          fi

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -3,12 +3,3 @@
 
 [extend]
 useDefault = true
-
-[allowlist]
-  description = "Global allowlist for false positives"
-
-  regexTarget = "match"
-  regexes = [
-    # curl + sed piped examples in README files trigger the curl-auth-user rule
-    '''s/\^data: //''',
-  ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,14 @@
+# Gitleaks configuration for agentic-starter-kits
+# https://github.com/gitleaks/gitleaks
+
+[extend]
+useDefault = true
+
+[allowlist]
+  description = "Global allowlist for false positives"
+
+  regexTarget = "match"
+  regexes = [
+    # curl + sed piped examples in README files trigger the curl-auth-user rule
+    '''s/\^data: //''',
+  ]

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,4 @@
+# False positive: deleted README with a curl | sed streaming example
+# that gitleaks misidentifies as curl -u (curl-auth-user rule).
+# Commit: 15a4a06, file: agents/base/crewai_websearch_agent/README.md
+15a4a062e618093eb9d4fe3baa8e865cde7a8f50:agents/base/crewai_websearch_agent/README.md:curl-auth-user:194

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
         args: [--fix]
 
   # Gitleaks — secret scanning
-  # Keep version in sync with gitleaks/gitleaks-action in .github/workflows/code-quality.yml
+  # Keep version in sync with the gitleaks version in .github/workflows/code-quality.yml
   # Allowlist rules are defined in .gitleaks.toml at the repo root
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.30.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,14 @@ repos:
       - id: markdownlint-cli2
         args: [--fix]
 
+  # Gitleaks — secret scanning
+  # Keep version in sync with gitleaks/gitleaks-action in .github/workflows/code-quality.yml
+  # Allowlist rules are defined in .gitleaks.toml at the repo root
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
   # Actionlint — GitHub Actions workflow validation
   # Keep version in sync with raven-actions/actionlint in .github/workflows/code-quality.yml
   - repo: https://github.com/rhysd/actionlint


### PR DESCRIPTION
## Description

Integrate gitleaks for secret detection at two gates:
- **Pre-commit hook** — gitleaks v8.30.1 blocks secrets before they enter git history
- **CI job** — dedicated `secret-scanning` job in `code-quality.yml` downloads the open-source gitleaks CLI (no paid license required, works on fork PRs) and runs a full history scan
- **Allowlist config** — `.gitleaks.toml` at the repo root suppresses the one known false positive (curl + sed pipe patterns in README examples)

## Jira Ticket

RHAIENG-4062

## Testing

- [x] No testing required (documentation/config change only)
- [x] `pre-commit run gitleaks --all-files` passes cleanly
- [x] Planted a high-entropy test secret — hook correctly blocked the commit
- [x] TruffleHog full git history scan — 0 verified, 0 unverified secrets found
- [x] Verified `.env.example` placeholder values (`sk-your-openai-api-key`, `miniosecret`, `local-dev-secret`) do not trigger false positives

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)

## Review Guidance

- `.gitleaks.toml` — single allowlist entry for a `curl-auth-user` false positive triggered by `curl | sed` examples in README files. All other default gitleaks rules apply unchanged.
- `.pre-commit-config.yaml` — gitleaks hook placed before actionlint, includes comment pointing to `.gitleaks.toml` for allowlist maintenance.
- `code-quality.yml` — gitleaks runs as a separate `secret-scanning` job (parallel with `lint`), using the open-source CLI binary directly instead of the commercial `gitleaks-action` which requires a paid license and fails on fork PRs.

## Related PRs

<!-- None -->