### PR TITLE
fix: normalize stream parameter handling in behavioral test run_eval fixtures

### DIFF
--- a/agents/autogen/mcp_agent/tests/behavioral/conftest.py
+++ b/agents/autogen/mcp_agent/tests/behavioral/conftest.py
@@ -58,6 +58,7 @@ def eval_config() -> dict[str, Any]:
 
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+# AutoGen MCP exposes tool_invocations only in non-streaming JSON responses.
 STREAM = False
 
 

--- a/agents/autogen/mcp_agent/tests/behavioral/conftest.py
+++ b/agents/autogen/mcp_agent/tests/behavioral/conftest.py
@@ -58,6 +58,7 @@ def eval_config() -> dict[str, Any]:
 
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+STREAM = False
 
 
 def load_golden(category: str | None = None) -> list[dict[str, Any]]:
@@ -85,8 +86,6 @@ def run_eval(
 
     Overrides the root run_eval fixture to add MLflow trace data
     (tool calls, token usage) after each request.
-    Always uses stream=False — the AutoGen MCP agent exposes tool_invocations
-    in non-streaming JSON but not in standard SSE delta.tool_calls.
     """
     mlflow = None
     if MLflowTraceClient is not None:
@@ -101,7 +100,6 @@ def run_eval(
         timeout_seconds: float = 30.0,
         max_tokens_budget: int | None = None,
         model: str | None = None,
-        stream: bool = False,
     ) -> TaskResult:
         config = TaskConfig(
             agent_url=agent_url,
@@ -110,7 +108,7 @@ def run_eval(
             timeout_seconds=timeout_seconds,
             max_tokens_budget=max_tokens_budget,
             model=model,
-            stream=False,
+            stream=STREAM,
         )
         request_start_ms = int(time.time() * 1000)
         result = await run_task(config, client=http_client)

--- a/agents/crewai/websearch_agent/tests/behavioral/conftest.py
+++ b/agents/crewai/websearch_agent/tests/behavioral/conftest.py
@@ -60,6 +60,7 @@ def eval_config() -> dict[str, Any]:
 SEARCH_EVIDENCE = ["openshift ai"]
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+STREAM = False
 
 
 def load_golden(category: str | None = None) -> list[dict[str, Any]]:
@@ -103,7 +104,6 @@ def run_eval(
         timeout_seconds: float = 30.0,
         max_tokens_budget: int | None = None,
         model: str | None = None,
-        stream: bool = False,
     ) -> TaskResult:
         config = TaskConfig(
             agent_url=agent_url,
@@ -112,7 +112,7 @@ def run_eval(
             timeout_seconds=timeout_seconds,
             max_tokens_budget=max_tokens_budget,
             model=model,
-            stream=stream,
+            stream=STREAM,
         )
         request_start_ms = int(time.time() * 1000)
         result = await run_task(config, client=http_client)

--- a/agents/langgraph/agentic_rag/tests/behavioral/conftest.py
+++ b/agents/langgraph/agentic_rag/tests/behavioral/conftest.py
@@ -50,6 +50,7 @@ def _find_repo_root() -> Path:
 
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+STREAM = False
 
 
 def load_golden(category: str | None = None) -> list[dict[str, Any]]:
@@ -98,9 +99,8 @@ def run_eval(
 ) -> Callable[..., Coroutine[Any, Any, TaskResult]]:
     """Run eval with automatic MLflow enrichment when available.
 
-    Always uses stream=False — the Agentic RAG agent does not expose
-    tool_calls in the response context; MLflow traces are the only
-    source for tool-call data.
+    Overrides the root run_eval fixture to add MLflow trace data
+    (tool calls, token usage) after each request.
     """
     mlflow = None
     if MLflowTraceClient is not None:
@@ -115,7 +115,6 @@ def run_eval(
         timeout_seconds: float = 30.0,
         max_tokens_budget: int | None = None,
         model: str | None = None,
-        stream: bool = False,
     ) -> TaskResult:
         config = TaskConfig(
             agent_url=agent_url,
@@ -124,7 +123,7 @@ def run_eval(
             timeout_seconds=timeout_seconds,
             max_tokens_budget=max_tokens_budget,
             model=model,
-            stream=False,
+            stream=STREAM,
         )
         request_start_ms = int(time.time() * 1000)
         result = await run_task(config, client=http_client)

--- a/agents/langgraph/agentic_rag/tests/behavioral/conftest.py
+++ b/agents/langgraph/agentic_rag/tests/behavioral/conftest.py
@@ -50,6 +50,7 @@ def _find_repo_root() -> Path:
 
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+# Agentic RAG does not expose tool_calls in streaming; MLflow traces are the only source.
 STREAM = False
 
 

--- a/agents/langgraph/react_agent/tests/behavioral/conftest.py
+++ b/agents/langgraph/react_agent/tests/behavioral/conftest.py
@@ -41,6 +41,7 @@ def _find_repo_root() -> Path:
 
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+STREAM = False
 
 
 def load_golden(category: str | None = None) -> list[dict[str, Any]]:
@@ -105,7 +106,6 @@ def run_eval(
         timeout_seconds: float = 30.0,
         max_tokens_budget: int | None = None,
         model: str | None = None,
-        stream: bool = False,
     ) -> TaskResult:
         config = TaskConfig(
             agent_url=agent_url,
@@ -114,7 +114,7 @@ def run_eval(
             timeout_seconds=timeout_seconds,
             max_tokens_budget=max_tokens_budget,
             model=model,
-            stream=stream,
+            stream=STREAM,
         )
         request_start_ms = int(time.time() * 1000)
         result = await run_task(config, client=http_client)

--- a/agents/vanilla_python/openai_responses_agent/tests/behavioral/conftest.py
+++ b/agents/vanilla_python/openai_responses_agent/tests/behavioral/conftest.py
@@ -61,6 +61,7 @@ PRICE_EVIDENCE = ["price", "cost", "$", "dollar"]
 REVIEW_EVIDENCE = ["review", "rating", "star", "recommend"]
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+STREAM = False
 
 
 def load_golden(category: str | None = None) -> list[dict[str, Any]]:
@@ -102,7 +103,6 @@ def run_eval(
         timeout_seconds: float = 30.0,
         max_tokens_budget: int | None = None,
         model: str | None = None,
-        stream: bool = False,
     ) -> TaskResult:
         config = TaskConfig(
             agent_url=agent_url,
@@ -111,7 +111,7 @@ def run_eval(
             timeout_seconds=timeout_seconds,
             max_tokens_budget=max_tokens_budget,
             model=model,
-            stream=stream,
+            stream=STREAM,
         )
         request_start_ms = int(time.time() * 1000)
         result = await run_task(config, client=http_client)

--- a/tests/behavioral/conftest.py
+++ b/tests/behavioral/conftest.py
@@ -115,6 +115,9 @@ async def http_client() -> AsyncGenerator[httpx.AsyncClient, None]:
         yield client
 
 
+STREAM = False
+
+
 @pytest.fixture
 def run_eval(
     agent_url: str, http_client: httpx.AsyncClient
@@ -133,7 +136,6 @@ def run_eval(
         timeout_seconds: float = 30.0,
         max_tokens_budget: int | None = None,
         model: str | None = None,
-        stream: bool = False,
     ) -> TaskResult:
         config = TaskConfig(
             agent_url=agent_url,
@@ -142,7 +144,7 @@ def run_eval(
             timeout_seconds=timeout_seconds,
             max_tokens_budget=max_tokens_budget,
             model=model,
-            stream=stream,
+            stream=STREAM,
         )
         return await run_task(config, client=http_client)
 


### PR DESCRIPTION
## Summary
- Replace inconsistent `stream` parameter handling across all `run_eval` fixture overrides with a uniform `STREAM = False` module-level constant
- Normalize the root `run_eval` fixture in `tests/behavioral/conftest.py` to use the same `STREAM` constant pattern, ensuring a consistent interface across base and agent-level fixtures
- Preserve agent-specific rationale as comments next to the constant in `autogen/mcp_agent` (tool data only in non-streaming JSON) and `agentic_rag` (MLflow traces only source for tool calls)

## Test plan
- [x] Verify no behavioral test calls `run_eval(..., stream=...)` — confirmed via grep, zero callers
- [x] Run `make test` in affected agent directories to confirm no regressions
- [x] Confirm all 6 conftest files (root + 5 agents) use the same `STREAM` constant pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)