### PR TITLE
docs: improve Claude Code OpenShift deployment instructions

### DIFF
--- a/agents/claude-code/deployment/README.md
+++ b/agents/claude-code/deployment/README.md
@@ -182,6 +182,8 @@ gcloud iam service-accounts keys create ~/claude-vertex-key.json \
 
 If you already have credentials via `gcloud auth application-default login`, you can use your ADC file (typically at `~/.config/gcloud/application_default_credentials.json`) in place of a service account key. Substitute this path wherever the instructions reference your service account key file.
 
+**Important:** ADC credentials are user-scoped and typically carry broader permissions than a dedicated service account. Use ADC for local development and testing only. For shared or production clusters, create a least-privilege service account with only the **Vertex AI User** role as described above.
+
 ### 1. Build and test locally
 
 ```bash
@@ -226,6 +228,12 @@ oc apply -f deployment-vertex.yaml
 ```bash
 oc patch configmap claude-vertex-config \
   -p '{"data":{"ANTHROPIC_VERTEX_PROJECT_ID":"your-gcp-project-id","CLOUD_ML_REGION":"global"}}'
+```
+
+Restart the deployment so pods pick up the patched ConfigMap values:
+
+```bash
+oc rollout restart deployment/claude-code-vertex
 ```
 
 ### 5. Build the image on OpenShift

--- a/agents/claude-code/deployment/README.md
+++ b/agents/claude-code/deployment/README.md
@@ -8,7 +8,7 @@ A step-by-step guide to build, test, and deploy the Claude Code container image.
 
 ## Prerequisites
 
-- `podman` installed locally
+- `podman` installed locally (on macOS, you also need to run `podman machine init` and `podman machine start` before building)
 - `oc` CLI installed and logged into your OpenShift cluster
 - An Anthropic API key OR a GCP service account key for Vertex AI
 - The Containerfile and entrypoint.sh files
@@ -178,6 +178,10 @@ gcloud iam service-accounts keys create ~/claude-vertex-key.json \
 
 **Note**: Creating service accounts requires **IAM Admin** or **Service Account Admin** permissions in the GCP project.
 
+**Alternative: Application Default Credentials (ADC)**
+
+If you already have credentials via `gcloud auth application-default login`, you can use your ADC file (typically at `~/.config/gcloud/application_default_credentials.json`) in place of a service account key. Substitute this path wherever the instructions reference your service account key file.
+
 ### 1. Build and test locally
 
 ```bash
@@ -211,26 +215,26 @@ oc create secret generic claude-vertex-credentials \
   --from-file=key.json=/path/to/your-service-account-key.json
 ```
 
-### 4. Apply the Vertex AI deployment manifest
+### 4. Apply the Vertex AI deployment manifest and update the ConfigMap
+
+Apply the manifest first to create all the resources, then immediately patch the ConfigMap with your actual project details before the pod starts using them:
 
 ```bash
 oc apply -f deployment-vertex.yaml
 ```
-
-### 5. Update the ConfigMap with your project details
 
 ```bash
 oc patch configmap claude-vertex-config \
   -p '{"data":{"ANTHROPIC_VERTEX_PROJECT_ID":"your-gcp-project-id","CLOUD_ML_REGION":"global"}}'
 ```
 
-### 6. Build the image on OpenShift
+### 5. Build the image on OpenShift
 
 ```bash
 oc start-build claude-code --from-dir=. --follow
 ```
 
-### 7. Wait for deployment and test
+### 6. Wait for deployment and test
 
 ```bash
 oc rollout status deployment/claude-code-vertex
@@ -252,7 +256,13 @@ oc exec deployment/claude-code-vertex -- bash -c '
 '
 ```
 
-### 8. Interactive mode (optional)
+**Note on model selection:** On Vertex AI (and Bedrock/Foundry), the default `sonnet` model alias may resolve to an older model than on the direct Anthropic API. If you want a specific model version, set the `CLAUDE_MODEL` environment variable in your deployment manifest or patch it directly:
+
+```bash
+oc set env deployment/claude-code-vertex CLAUDE_MODEL=claude-sonnet-4-6
+```
+
+### 7. Interactive mode (optional)
 
 For a full interactive Claude Code experience with multi-turn conversations:
 
@@ -286,7 +296,7 @@ oc exec -it deployment/claude-code-vertex -- bash -c '
 
 **Note**: Interactive mode requires a TTY, so use `-it` flags with podman and `oc exec`.
 
-### 9. Debug mode (optional)
+### 8. Debug mode (optional)
 
 To see detailed logging of Claude Code activity, use the `--debug` flag:
 


### PR DESCRIPTION
## Summary

- Add macOS `podman machine` prerequisite note (users hit a confusing "cannot connect" error without it)
- Document Application Default Credentials (ADC) as an alternative to service account keys for Vertex AI
- Consolidate ConfigMap patch into the same step as manifest apply, avoiding pods starting with placeholder values
- Add model selection guidance for Vertex AI users, where the default `sonnet` alias resolves to an older model than on the direct Anthropic API
- Renumber Vertex AI steps accordingly

## Test plan

- [x] Walked through the full Vertex AI deployment path end-to-end on a live OpenShift cluster
- [x] Verified all five issues firsthand during the walkthrough
- [x] Review rendered markdown for formatting correctness

This PR is from Bill Murdock with assistance from Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)