### PR TITLE
fix(docs): update broken OpenAI Responses API links

### DIFF
--- a/agents/vanilla_python/README.md
+++ b/agents/vanilla_python/README.md
@@ -11,4 +11,4 @@ Agent templates using plain Python SDK clients (e.g. [OpenAI Python client](http
 ## Resources
 
 - [OpenAI Python Client](https://github.com/openai/openai-python)
-- [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses/create)
+- [OpenAI Responses API](https://developers.openai.com/api/reference/resources/responses/methods/create)

--- a/agents/vanilla_python/openai_responses_agent/README.md
+++ b/agents/vanilla_python/openai_responses_agent/README.md
@@ -11,7 +11,7 @@
 ## What this agent does
 
 Minimal agent with no framework: only the OpenAI Python client and an Action/Observation loop with tools. Requires the
-[OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses/create) — works with OpenAI or any
+[OpenAI Responses API](https://developers.openai.com/api/reference/resources/responses/methods/create) — works with OpenAI or any
 endpoint that supports the Responses API.
 
 ---
@@ -29,7 +29,7 @@ endpoint that supports the Responses API.
 
 ## Local Development
 
-> **Note:** This agent uses the [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses/create),
+> **Note:** This agent uses the [OpenAI Responses API](https://developers.openai.com/api/reference/resources/responses/methods/create),
 > which is specific to OpenAI. It does not use Ollama or Llama Stack for local model serving.
 
 ### Initiating base
@@ -268,4 +268,4 @@ curl http://localhost:8000/health
 ## Resources
 
 - [OpenAI Python Client](https://github.com/openai/openai-python)
-- [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses/create)
+- [OpenAI Responses API](https://developers.openai.com/api/reference/resources/responses/methods/create)


### PR DESCRIPTION
## Description

OpenAI moved their API documentation from platform.openai.com to developers.openai.com, breaking 4 links across 2 README files. Updated all occurrences to the new URL.

Files changed:
- agents/vanilla_python/README.md (1 link)
- agents/vanilla_python/openai_responses_agent/README.md (3 links)

## Jira Ticket

https://redhat.atlassian.net/browse/RHAIENG-5042

## Testing

- [ ] `make test` passes (run from the affected agent directory)
- [ ] Manual testing performed (describe steps below)
- [x] No testing required (documentation/config change only)

Verified the new URL resolves correctly in a browser.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)

## Review Guidance

Straightforward find-and-replace. All 4 links point to the same new URL.

## Related PRs

None
