### PR TITLE
fix: enable cross-directory grouping and group major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
         applies-to: "version-updates"
         update-types:
           - "minor"
+      major:
+        applies-to: "version-updates"
+        update-types:
+          - "major"
 
   - package-ecosystem: "pip"
     directories:
@@ -28,17 +32,16 @@ updates:
     groups:
       patch:
         applies-to: "version-updates"
-        dependency-type: "production"
+        group-by: "dependency-name"
         update-types:
           - "patch"
       minor:
         applies-to: "version-updates"
-        dependency-type: "production"
+        group-by: "dependency-name"
         update-types:
           - "minor"
-      dev-patch-minor:
+      major:
         applies-to: "version-updates"
-        dependency-type: "development"
+        group-by: "dependency-name"
         update-types:
-          - "patch"
-          - "minor"
+          - "major"


### PR DESCRIPTION
## Description

Follow-up to #115 — the cross-directory grouping changes
Changes:
- **Cross-directory grouping** — adds `group-by: dependency-name` so the same dependency bump across multiple agent directories creates one PR instead of one per agent (e.g., `setuptools` across 8 agents → 1 PR)
- **Major update grouping** — adds a `major` group so major bumps are also consolidated across directories (e.g., `pymilvus` 2→3 across 4 agents → 1 PR)
- **GitHub Actions major grouping** — groups major action bumps together (e.g., `checkout 4→6`, `setup-python 5→6`)
- **Removes production/development split** — `group-by: dependency-name` handles consolidation regardless of dependency type

After merging, Dependabot will close the existing ungrouped PRs and reopen them as consolidated grouped PRs.

## Jira Ticket

RHAIENG-4062

## Testing

- [x] No testing required (documentation/config change only)
- [ ] Verify existing ungrouped Dependabot PRs get closed and reopened as grouped PRs

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)

## Review Guidance

Config-only change to `.github/dependabot.yml`. The `group-by: dependency-name` feature is [GA since Feb 2026](https://github.blog/changelog/2026-02-24-dependabot-can-group-updates-by-dependency-name-across-multiple-directories/).

## Related PRs

- #112 — gitleaks secret scanning (same ticket, merged)
- #115 — initial Dependabot setup (same ticket, merged)