### PR TITLE
feat: add integration deployment test for Google ADK agent (RHAIENG-4647)

### DIFF
--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -60,6 +60,7 @@ jobs:
           - { name: langgraph-react-agent, dir: agents/langgraph/react_agent }
           - { name: langgraph-hitl-agent, dir: agents/langgraph/human_in_the_loop }
           - { name: crewai-websearch-agent, dir: agents/crewai/websearch_agent }
+          - { name: google-adk-agent, dir: agents/google/adk }
     env:
       API_KEY: ${{ vars.API_KEY }}
       BASE_URL: ${{ vars.BASE_URL }}

--- a/agents/google/adk/Makefile
+++ b/agents/google/adk/Makefile
@@ -5,7 +5,7 @@ VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 MODEL          ?= llama3.1:8b
 
-.PHONY: init re-init env ollama llama-server run-app run-app-fresh run-cli build push build-openshift deploy undeploy test dry-run help
+.PHONY: init re-init env ollama llama-server run-app run-app-fresh run-cli build push build-openshift deploy undeploy test test-integration dry-run help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-12s %s\n", $$1, $$2}'
@@ -158,3 +158,8 @@ undeploy: ## Remove deployment from cluster
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)
+
+test-integration: ## Run integration deployment test
+	PYTHONPATH=$$(git rev-parse --show-toplevel)/tests \
+	  uv run --extra dev python -m pytest tests/integration/test_deployment.py \
+	    -v --tb=long --junitxml=results.xml

--- a/agents/google/adk/pyproject.toml
+++ b/agents/google/adk/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=9.0.2",
+    "httpx>=0.27",
 ]
 
 [tool.setuptools.packages.find]

--- a/agents/google/adk/tests/integration/conftest.py
+++ b/agents/google/adk/tests/integration/conftest.py
@@ -1,0 +1,2 @@
+# Re-export shared integration fixtures so pytest discovers them.
+from integration.conftest import cluster_auth, repo_root  # noqa: F401

--- a/agents/google/adk/tests/integration/test_deployment.py
+++ b/agents/google/adk/tests/integration/test_deployment.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+from integration.utils import (
+    MakeTargetError,
+    RouteNotFoundError,
+    get_route,
+    health_check,
+    load_agent_name,
+    run_make,
+)
+
+logger = logging.getLogger(__name__)
+
+INTERNAL_REGISTRY = "image-registry.openshift-image-registry.svc:5000"
+
+
+@pytest.fixture(scope="module")
+def agent_dir(repo_root):
+    return repo_root / "agents" / "google" / "adk"
+
+
+@pytest.fixture(scope="module")
+def agent_name(agent_dir):
+    return load_agent_name(agent_dir)
+
+
+def _write_env_file(agent_dir, container_image):
+    """Write a .env file so Makefile targets can source it."""
+    missing = [v for v in ("BASE_URL", "MODEL_ID") if v not in os.environ]
+    if missing:
+        pytest.fail(
+            f"Missing required env vars: {', '.join(missing)}. "
+            "Set them in the CI workflow or export locally."
+        )
+    env_path = agent_dir / ".env"
+    env_path.write_text(
+        f"API_KEY={os.environ.get('API_KEY', 'not-needed')}\n"
+        f"BASE_URL={os.environ['BASE_URL']}\n"
+        f"MODEL_ID={os.environ['MODEL_ID']}\n"
+        f"CONTAINER_IMAGE={container_image}\n"
+    )
+    return env_path
+
+
+@pytest.fixture(scope="module")
+def deployed_agent(cluster_auth, agent_dir, agent_name):
+    namespace = cluster_auth["namespace"]
+    container_image = f"{INTERNAL_REGISTRY}/{namespace}/{agent_name}:latest"
+    env_path = _write_env_file(agent_dir, container_image)
+
+    deployed = False
+    try:
+        logger.info("Building image on cluster via build-openshift...")
+        run_make("build-openshift", cwd=agent_dir, timeout=600)
+
+        logger.info("Deploying to cluster...")
+        run_make("deploy", cwd=agent_dir, timeout=300)
+        deployed = True
+
+        route_url = get_route(agent_name, namespace=namespace)
+        logger.info("Agent deployed at %s", route_url)
+
+        yield route_url
+
+    except (MakeTargetError, RouteNotFoundError) as exc:
+        pytest.fail(f"Deployment failed: {exc}")
+
+    finally:
+        if deployed:
+            logger.info("Tearing down deployment...")
+            try:
+                run_make("undeploy", cwd=agent_dir, timeout=120)
+            except MakeTargetError:
+                logger.warning(
+                    "Cleanup failed — manual undeploy may be needed", exc_info=True
+                )
+        env_path.unlink(missing_ok=True)
+
+
+@pytest.mark.integration
+def test_health_endpoint(deployed_agent):
+    route_url = deployed_agent
+    result = health_check(f"{route_url}/health", retries=12, backoff=5.0)
+
+    assert result["status"] == "healthy"
+    assert result["agent_initialized"] is True

--- a/agents/google/adk/uv.lock
+++ b/agents/google/adk/uv.lock
@@ -34,15 +34,17 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "pytest" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "chardet" },
-    { name = "fastapi", specifier = ">=0.129.0" },
+    { name = "fastapi", specifier = ">=0.135.1" },
     { name = "flask", specifier = ">=3.1.0" },
     { name = "google-adk", specifier = ">=2.0.0a1" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "litellm", specifier = ">=1.50.0,!=1.82.7,!=1.82.8" },
     { name = "milvus-lite", specifier = ">=2.5.1" },
     { name = "openai", specifier = ">=2.24.0" },
@@ -50,7 +52,7 @@ requires-dist = [
     { name = "pypdf" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
-    { name = "setuptools", specifier = ">=80.9.0,<82.0.0" },
+    { name = "setuptools", specifier = ">=80.9.0,<83.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
## Jira
[RHAIENG-4647](https://redhat.atlassian.net/browse/RHAIENG-4647)

## Summary
- Adds integration deployment test for the Google ADK agent (Tier 1 — simple pattern)
- Creates `tests/integration/` with conftest.py and test_deployment.py following the established pattern from react_agent, HITL, and CrewAI agents
- Adds `test-integration` Makefile target and CI workflow matrix entry

## Test plan
- [x] `pytest --collect-only` passes (1 test collected, no import errors)
- [x] CI run deploys to cluster and validates `/health` endpoint — [run 26587559130](https://github.com/red-hat-data-services/agentic-starter-kits/actions/runs/26587559130)
- [x] Cross-agent consistency verified against existing integration test PRs (#83, #90, #100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHAIENG-4647]: https://redhat.atlassian.net/browse/RHAIENG-4647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ