### PR TITLE
fix(deps): pin starlette>=1.0.1 in langgraph/agentic_rag (CVE-2026-48710)

### DIFF
--- a/agents/langgraph/agentic_rag/pyproject.toml
+++ b/agents/langgraph/agentic_rag/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "chardet==7.2.0",
     "pypdf==6.9.1",
     "flask>=3.1.0",
+    "starlette>=1.0.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Pin `starlette>=1.0.1` in `agents/langgraph/agentic_rag/pyproject.toml` to remediate **CVE-2026-48710** (CVSS 6.5, [GHSA-86qp-5c8j-p5mr](https://github.com/advisories/GHSA-86qp-5c8j-p5mr)) — Starlette Host-Header Authentication Bypass affecting versions 0.8.3–1.0.0
- `uv lock` regenerated (starlette 0.52.1 → 1.2.0); `uv.lock` is gitignored

Resolves [RHAIENG-5396](https://redhat.atlassian.net/browse/RHAIENG-5396)

## Test Steps Performed

### 1. Unit tests
```
make test  →  10/10 passed
```

### 2. Container build & push
```
make build  →  starlette==1.2.0 installed in image (verified via podman run)
make push   →  pushed to quay.io/adonheis/langgraph-agentic-rag:latest
```

### 3. Version verification inside container
```
podman run --rm quay.io/adonheis/langgraph-agentic-rag:latest \
  python -c "import starlette; print(starlette.__version__)"
→  1.2.0
```

### 4. Deploy to OpenShift
```
make deploy  →  Helm revision 12, deployment rolled out successfully
```

### 5. Health check
```
curl -sk https://langgraph-agentic-rag-adonheis-testing.apps.rosa.agen-e2e-rhoai2.p5ui.p3.openshiftapps.com/health
→  {"status":"healthy","agent_initialized":true}
```

### 6. MLflow tracing verification
Startup logs confirm tracing is operational:
```
[Tracing] MLflow server is reachable at https://rh-ai.apps.rosa.agen-e2e-rhoai2.p5ui.p3.openshiftapps.com/mlflow
[Tracing Enabled] MLflow -> ..., Experiment: adonheis-testing
```

### 7. Behavioral tests (16 tests)
```
16 passed in 245.64s
```

| Test Suite | Result |
|---|---|
| test_cost_latency | 1/1 passed |
| test_reliability | 2/2 passed |
| test_response_quality | 5/5 passed |
| test_tool_usage | 8/8 passed |

### 8. No direct starlette imports
Verified zero direct starlette imports across `main.py`, `src/agentic_rag/agent.py`, `src/agentic_rag/tools.py`, `src/agentic_rag/tracing.py` — all web framework usage goes through FastAPI abstractions.

## Regression Risk

Low — this agent uses only FastAPI abstractions (`main.py`). No direct Starlette imports. Confirmed by `grep -r starlette src/` returning no matches.

## Test plan
- [x] `make test` passes (10/10)
- [x] `make build` succeeds with starlette==1.2.0
- [x] `make push` to quay.io
- [x] `make deploy` to OpenShift
- [x] Health check passes
- [x] MLflow tracing confirmed
- [x] Behavioral tests pass (16/16)
- [x] No direct starlette imports in agent code
- [x] Pattern matches sibling PR #146 (crewai/websearch_agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHAIENG-5396]: https://redhat.atlassian.net/browse/RHAIENG-5396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ