### PR TITLE
fix(deps): pin starlette>=1.0.1 in llamaindex/websearch_agent (CVE-2026-48710)

### DIFF
--- a/agents/llamaindex/websearch_agent/pyproject.toml
+++ b/agents/llamaindex/websearch_agent/pyproject.toml
@@ -7,6 +7,7 @@ license = { text = "MIT" }
 requires-python = ">=3.12, <3.14"
 dependencies = [
     "fastapi>=0.135.1",
+    "starlette>=1.0.1",
     "uvicorn[standard]>=0.41.0",
     "llama-index>=0.14.15",
     "llama-index-llms-openai-like>=0.5.3",


### PR DESCRIPTION
## Summary

- Pin `starlette>=1.0.1` in `agents/llamaindex/websearch_agent/pyproject.toml` to remediate **CVE-2026-48710** (CVSS 6.5, [GHSA-86qp-5c8j-p5mr](https://github.com/advisories/GHSA-86qp-5c8j-p5mr)) — Starlette Host-Header Authentication Bypass affecting versions 0.8.3–1.0.0
- `uv lock` regenerated (starlette → 1.2.0); `uv.lock` is gitignored

Resolves [RHAIENG-5399](https://redhat.atlassian.net/browse/RHAIENG-5399)

## Test Steps Performed

### 1. Unit tests
```
make test  →  11/11 passed
```

### 2. Container build & push
```
make build  →  starlette==1.2.0 installed in image (verified via podman run)
make push   →  pushed to quay.io/adonheis/llamaindex-websearch-agent:latest
```

### 3. Version verification inside container
```
podman run --rm quay.io/adonheis/llamaindex-websearch-agent:latest \
  python -c "import starlette; print(starlette.__version__)"
→  1.2.0
```

### 4. Deploy to OpenShift
```
make deploy  →  Helm revision 4, deployment rolled out successfully
```

### 5. Health check
```
curl -sk https://llamaindex-websearch-agent-adonheis-testing.apps.rosa.agen-e2e-rhoai2.p5ui.p3.openshiftapps.com/health
→  {"status":"healthy","agent_initialized":true}
```

### 6. MLflow tracing verification
Startup logs confirm tracing is operational:
```
[Tracing] MLflow server is reachable at https://rh-ai.apps.rosa.agen-e2e-rhoai2.p5ui.p3.openshiftapps.com/mlflow
[Tracing Enabled] MLflow -> ..., Experiment: adonheis-testing
```

### 7. Behavioral tests (15 passed, 1 pre-existing failure)
```
15 passed, 1 failed in 218.76s
```

| Test Suite | Result |
|---|---|
| test_cost_latency | 1/1 passed |
| test_reliability | 2/2 passed |
| test_response_quality | 5/5 passed |
| test_tool_usage | 4/4 passed |
| test_streaming_parity | 1/1 failed (pre-existing — non-streaming path does not expose tool_calls in HTTP response body) |

### 8. No direct starlette imports
Verified zero direct starlette imports across `main.py`, `src/websearch_agent/workflow.py`, `src/websearch_agent/agent.py`, `src/websearch_agent/tools.py`, `src/websearch_agent/tracing.py`, `playground/app.py` — all web framework usage goes through FastAPI abstractions.

## Regression Risk

Low — this agent uses only FastAPI abstractions (`main.py`). No direct Starlette imports. Confirmed by `grep -r starlette src/ main.py playground/` returning no matches.

## Test plan
- [x] `make test` passes (11/11)
- [x] `make build` succeeds with starlette==1.2.0
- [x] `make push` to quay.io
- [x] `make deploy` to OpenShift
- [x] Health check passes
- [x] MLflow tracing confirmed
- [x] Behavioral tests pass (15/16 — 1 pre-existing failure)
- [x] No direct starlette imports in agent code
- [x] Pattern matches sibling PRs #146 (crewai/websearch_agent) and #147 (langgraph/agentic_rag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHAIENG-5399]: https://redhat.atlassian.net/browse/RHAIENG-5399