### PR TITLE
fix(deps): pin starlette>=1.0.1 in langgraph/human_in_the_loop (CVE-2026-48710)

### DIFF
--- a/agents/langgraph/human_in_the_loop/pyproject.toml
+++ b/agents/langgraph/human_in_the_loop/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "python-dotenv>=1.2.2",
     "setuptools>=80.9.0,<83.0.0",
     "flask>=3.1.0",
+    "starlette>=1.0.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Pin `starlette>=1.0.1` in `agents/langgraph/human_in_the_loop/pyproject.toml` to remediate **CVE-2026-48710** (CVSS 6.5, [GHSA-86qp-5c8j-p5mr](https://github.com/advisories/GHSA-86qp-5c8j-p5mr)) — Starlette Host-Header Authentication Bypass affecting versions 0.8.3–1.0.0
- `uv lock` regenerated; `uv.lock` is gitignored

Resolves [RHAIENG-5400](https://redhat.atlassian.net/browse/RHAIENG-5400)

## Test Steps Performed

### 1. Unit tests
```
make test  →  0 collected (agent has only integration tests, no unit tests — pre-existing)
```

### 2. Container build & push
```
make build  →  starlette==1.2.0 installed in image (verified via podman run)
make push   →  pushed to quay.io/adonheis/langgraph-hitl-agent:latest
```

### 3. Version verification inside container
```
podman run --rm quay.io/adonheis/langgraph-hitl-agent:latest \
  python -c "import starlette; print(starlette.__version__)"
→  1.2.0
```

### 4. Deploy to OpenShift
```
make deploy  →  Helm revision 2, deployment rolled out successfully
```

### 5. Health check
```
curl -sk https://langgraph-hitl-agent-adonheis-testing.apps.rosa.agen-e2e-rhoai2.p5ui.p3.openshiftapps.com/health
→  {"status":"healthy","agent_initialized":true}
```

### 6. MLflow tracing verification
Startup logs confirm tracing is operational:
```
[Tracing] MLflow server is reachable at https://rh-ai.apps.rosa.agen-e2e-rhoai2.p5ui.p3.openshiftapps.com/mlflow
[Tracing Enabled] MLflow -> ..., Experiment: adonheis-testing
```

### 7. Behavioral tests
No behavioral tests exist for this agent yet — pre-existing gap, not introduced by this PR.

### 8. No direct starlette imports
Verified zero direct starlette imports across `main.py`, `src/human_in_the_loop/`, `playground/` — all web framework usage goes through FastAPI abstractions.

## Regression Risk

Moderate — this agent uses interrupt/resume flow via `astream(stream_mode="updates")` which is sensitive to chunk boundaries. Starlette 1.0.x changes to `StreamingResponse` behavior could affect SSE chunk delivery. However, no direct starlette imports exist — all web framework usage goes through FastAPI abstractions. Smoke test confirmed the agent responds correctly to chat requests post-update.

## Test plan
- [x] `make test` (0 collected — agent has only integration tests, pre-existing)
- [x] `make build` succeeds with starlette==1.2.0
- [x] `make push` to quay.io
- [x] `make deploy` to OpenShift
- [x] Health check passes
- [x] MLflow tracing confirmed
- [x] Smoke test passes (greeting query returns correct response)
- [x] No behavioral tests (none exist for this agent yet)
- [x] No direct starlette imports in agent code
- [x] MLflow token refresh for all agents in namespace (7 secrets patched)
- [x] Pattern matches sibling PRs #146 and #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHAIENG-5400]: https://redhat.atlassian.net/browse/RHAIENG-5400