### PR TITLE
fix(deps): pin starlette>=1.0.1 in vanilla_python/openai_responses_agent

### DIFF
--- a/agents/vanilla_python/openai_responses_agent/pyproject.toml
+++ b/agents/vanilla_python/openai_responses_agent/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "setuptools>=80.9.0,<83.0.0",
     "flask>=3.1.0",
     "fastapi>=0.135.1",
+    "starlette>=1.0.1",
     "uvicorn[standard]>=0.41.0",
 ]
 


### PR DESCRIPTION
## Summary

- Pin `starlette>=1.0.1` in `agents/vanilla_python/openai_responses_agent/pyproject.toml` to remediate **CVE-2026-48710** ("BadHost", CVSS 6.5, [GHSA-86qp-5c8j-p5mr](https://github.com/encode/starlette/security/advisories/GHSA-86qp-5c8j-p5mr)) — a Starlette Host-Header authentication bypass affecting versions < 1.0.1
- No upstream dependency conflicts (unlike google-adk, this agent has no packages that pin `starlette<1`)
- No `[tool.uv]` override needed — clean resolution to starlette 1.2.0

Resolves: [RHAIENG-5398](https://redhat.atlassian.net/browse/RHAIENG-5398)
Epic: [RHAIENG-5393](https://redhat.atlassian.net/browse/RHAIENG-5393)

## Test plan

- [x] `make test` — 5/5 tests pass (including TestClient-based `test_health.py`)
- [x] `make run-app` — local server starts, `GET /health` returns healthy
- [x] `POST /chat/completions` (non-streaming) — agent responds correctly
- [x] `POST /chat/completions` (streaming) — SSE chunks stream correctly with `[DONE]` terminator
- [x] `make build-openshift` — in-cluster container build succeeds with starlette 1.2.0
- [x] `make deploy` — agent deploys and pod becomes ready
- [x] OpenShift health check + chat completion + streaming verified end-to-end
- [x] `oc exec` confirms `starlette==1.2.0` inside running pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHAIENG-5398]: https://redhat.atlassian.net/browse/RHAIENG-5398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-5393]: https://redhat.atlassian.net/browse/RHAIENG-5393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ