### PR TITLE
fix(deps): pin starlette>=1.0.1 in autogen/mcp_agent (CVE-2026-48710)

### DIFF
--- a/agents/autogen/mcp_agent/mcp_automl_template/pyproject.toml
+++ b/agents/autogen/mcp_agent/mcp_automl_template/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pandas>=2.0.0,<4.0.0",
     "pydantic>=2.0.0,<3.0.0",
     "uvicorn[standard]>=0.41.0,<1.0.0",
+    "starlette>=1.0.1",
 ]
 
 [project.optional-dependencies]

--- a/agents/autogen/mcp_agent/pyproject.toml
+++ b/agents/autogen/mcp_agent/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "python-dotenv>=1.2.0",
     "mcp",
     "setuptools>=80.9.0,<83.0.0",
+    "starlette>=1.0.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Pin `starlette>=1.0.1` in both `agents/autogen/mcp_agent/pyproject.toml` and `agents/autogen/mcp_agent/mcp_automl_template/pyproject.toml` to remediate **CVE-2026-48710** (CVSS 6.5, [GHSA-86qp-5c8j-p5mr](https://github.com/advisories/GHSA-86qp-5c8j-p5mr)) — Starlette Host-Header Authentication Bypass affecting versions 0.8.3–1.0.0
- `uv lock` regenerated (starlette → 1.2.0); `uv.lock` is gitignored

Resolves [RHAIENG-5402](https://redhat.atlassian.net/browse/RHAIENG-5402)

## Test Steps Performed

### 1. Unit tests
```
make test  →  0 collected (no unit tests exist for this agent, only behavioral)
```

### 2. Container build & push
```
make build  →  starlette==1.2.0 installed in image (verified via podman run)
make push   →  pushed to quay.io/adonheis/autogen-mcp-agent:latest
```

### 3. Version verification inside container
```
podman run --rm quay.io/adonheis/autogen-mcp-agent:latest \
  python -c "import starlette; print(starlette.__version__)"
→  1.2.0
```

### 4. Deploy to OpenShift
```
helm upgrade --install  →  Helm revision 6, deployment rolled out successfully
```

### 5. Health check
```
curl -sk https://autogen-mcp-agent-adonheis-testing.apps.rosa.agen-e2e-rhoai2.p5ui.p3.openshiftapps.com/health
→  {"status":"healthy","agent_initialized":true}
```

### 6. MLflow tracing verification
Startup logs confirm tracing is operational:
```
[Tracing] MLflow server is reachable at https://rh-ai.apps.rosa.agen-e2e-rhoai2.p5ui.p3.openshiftapps.com/mlflow
[Tracing Enabled] MLflow -> ..., Experiment: adonheis-testing
```

### 7. Smoke tests
Greeting test:
```
curl /chat/completions {"messages":[{"role":"user","content":"hello"}]} → 200 OK, assistant responded
```
Tool-triggering test:
```
curl /chat/completions {"messages":[{"role":"user","content":"Use the add tool to compute 3 + 5"}]}
→ 200 OK, tool_invocations: [{"name":"add","arguments":{"a":3,"b":5},"result":"8"}]
```

### 8. Behavioral tests (11 tests)
```
11 passed in 54.60s
```

| Test Suite | Result |
|---|---|
| test_cost_latency | 1/1 passed |
| test_reliability | 2/2 passed |
| test_response_quality | 1/1 passed |
| test_tool_usage | 7/7 passed |

### 9. Direct starlette imports
Verified direct starlette imports exist in `mcp_automl_template/mcp_server.py` (lines 8-9: `Request`, `JSONResponse`) — used in `@mcp.custom_route("/health")`. Both imports work correctly with starlette 1.2.0. No direct imports in main agent code (`main.py`, `src/`).

## Regression Risk

Medium — `mcp_automl_template/mcp_server.py` directly imports `starlette.requests.Request` and `starlette.responses.JSONResponse` (lines 8-9), used in the `@mcp.custom_route("/health")` handler. Verified both work correctly with starlette 1.2.0 via smoke tests and health checks on the deployed agent.

## Test plan
- [x] `make test` runs (0 unit tests exist — behavioral only)
- [x] `make build` succeeds with starlette==1.2.0
- [x] `make push` to quay.io
- [x] Deploy to OpenShift via Helm
- [x] Health check passes
- [x] MLflow tracing confirmed
- [x] Greeting smoke test passes
- [x] Tool-triggering smoke test passes (add tool invoked correctly)
- [x] Behavioral tests pass (11/11)
- [x] Direct starlette imports verified working (mcp_automl_template/mcp_server.py:8-9)
- [x] Pattern matches sibling PR #147 (langgraph/agentic_rag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHAIENG-5402]: https://redhat.atlassian.net/browse/RHAIENG-5402

## Verification Summary

| Step | Result |
|---|---|
| Container build | starlette==1.2.0 in image |
| Deploy to OpenShift | Helm rev 6, rollout successful |
| Health check | `{"status":"healthy","agent_initialized":true}` |
| MLflow tracing | `[Tracing Enabled]` confirmed in logs |
| Greeting smoke test | 200 OK |
| Tool smoke test | `add(3,5)=8` via MCP tools |
| Behavioral tests | **11/11 passed** (54.60s) |
| Direct starlette imports | `Request`, `JSONResponse` work with 1.2.0 |