### PR TITLE
fix(deps): pin starlette>=1.0.1 in a2a/langgraph_crewai_agent (CVE-2026-48710)

### DIFF
--- a/agents/a2a/langgraph_crewai_agent/pyproject.toml
+++ b/agents/a2a/langgraph_crewai_agent/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "langgraph-prebuilt>=1.0.8",
     "python-dotenv>=1.0.0",
     "uvicorn[standard]>=0.30.0",
+    "starlette>=1.0.1",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary

- Pin `starlette>=1.0.1` in `a2a/langgraph_crewai_agent` to remediate **CVE-2026-48710** (CVSS 6.5, GHSA-86qp-5c8j-p5mr) — Starlette Host-Header Authentication Bypass affecting versions 0.8.3–1.0.0

Follows the same pattern as PR #146 (crewai/websearch_agent) and PR #147 (langgraph/agentic_rag).

## Risk Analysis

### a2a-sdk compatibility: NO BLOCKER
- `a2a-sdk[http-server]>=0.3.25` has zero version constraint on starlette — accepts any version
- Dry-run dependency resolution: `a2a-sdk` + `starlette>=1.0.1` resolves to `starlette==1.2.0` cleanly

### Starlette 1.0 breaking changes vs. agent code: ALL CLEAR

| Breaking Change in 1.0 | Agent Uses It? | Evidence |
|------------------------|---------------|----------|
| `on_startup`/`on_shutdown` removed | No | `Starlette(routes=[...])` with no lifecycle params |
| `@app.route()` decorator removed | No | Uses `Route()` objects directly |
| `TemplateResponse` signature changed | No | Not imported |
| `FileResponse.method` param removed | No | Uses `FileResponse(path)` without `method` |
| Jinja2 import changes | No | Not used |

The 5 direct starlette import statements (7 names) in `langgraph_a2a_server.py:41-45` all use stable, unchanged APIs.

## Verification

| Step | Result |
|------|--------|
| `uv sync` resolves without conflicts | starlette 1.2.0 installed |
| All starlette imports verified (7 names from 5 statements) | Pass |
| `A2AStarletteApplication` from a2a-sdk imports OK | Pass |
| Container build (`make build`) | Built `:crew` + `:langgraph` tags |
| Container starlette version check | 1.2.0 confirmed |
| Deploy to OpenShift (`make deploy`) | Both `a2a-crew-agent` and `a2a-langgraph-agent` rolled out |
| Health checks | LangGraph: `{"status":"healthy"}`. Crew: agent-card OK (pure A2A server, no `/health` endpoint) |
| Crew agent-card (`A2AStarletteApplication`) | Pass |
| LangGraph `/chat/completions` (`Request`, `JSONResponse`) | Pass |
| LangGraph playground (`FileResponse`) | HTTP 200 |
| LangGraph agent-card (a2a-sdk Starlette routes) | Pass |

## Test plan

- [x] `uv sync` resolves without conflicts
- [x] All starlette imports verified (7 names from 5 statements)
- [x] `A2AStarletteApplication` from a2a-sdk imports successfully with starlette 1.2.0
- [x] Container build (`make build`) succeeds
- [x] Starlette 1.2.0 confirmed inside container
- [x] Deploy to OpenShift (`make deploy`) succeeds
- [x] Health checks pass for both `a2a-crew-agent` and `a2a-langgraph-agent`
- [x] A2A protocol smoke tests pass (agent-card, /chat/completions, playground)

🤖 Generated with [Claude Code](https://claude.com/claude-code)