### PR TITLE
feat(evals): add Langflow /api/v1/run adapter to eval harness and EvalHub

### DIFF
--- a/evals/evalhub_adapter/adapter.py
+++ b/evals/evalhub_adapter/adapter.py
@@ -54,6 +54,20 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+async def _get_langflow_token(base_url: str, client: httpx.AsyncClient) -> str:
+    """Obtain an auth token from Langflow's auto_login endpoint."""
+    url = f"{base_url.rstrip('/')}/api/v1/auto_login"
+    resp = await client.get(url, timeout=10.0)
+    resp.raise_for_status()
+    data = resp.json()
+    token = data.get("access_token")
+    if not token:
+        raise ValueError(
+            f"Langflow auto_login response missing 'access_token': {list(data.keys())}"
+        )
+    return token
+
+
 class AgenticEvalAdapter(FrameworkAdapter):
     """EvalHub adapter that runs our agentic eval harness."""
 
@@ -168,6 +182,12 @@ class AgenticEvalAdapter(FrameworkAdapter):
         async with httpx.AsyncClient(
             verify=params.verify_ssl, timeout=httpx.Timeout(params.timeout_seconds)
         ) as client:
+            langflow_headers: dict[str, str] = {}
+            if params.api_format == "langflow_run":
+                token = await _get_langflow_token(agent_url, client)
+                langflow_headers = {"Authorization": f"Bearer {token}"}
+                logger.info("Langflow auth token acquired for %s", agent_url)
+
             for i, query_spec in enumerate(queries):
                 progress = 30.0 + (50.0 * (i + 1) / len(queries))
                 try:
@@ -177,6 +197,7 @@ class AgenticEvalAdapter(FrameworkAdapter):
                         expected_tools=query_spec.expected_tools,
                         params=params,
                         model_name=config.model.name,
+                        extra_headers=langflow_headers or None,
                     )
                     request_start_ms = int(time.time() * 1000)
                     result = await run_task(task_config, client=client)

--- a/evals/evalhub_adapter/adapter.py
+++ b/evals/evalhub_adapter/adapter.py
@@ -63,7 +63,9 @@ async def _get_langflow_token(base_url: str, client: httpx.AsyncClient) -> str:
     token = data.get("access_token")
     if not token:
         raise ValueError(
-            f"Langflow auto_login response missing 'access_token': {list(data.keys())}"
+            "Langflow auto_login response missing 'access_token'. "
+            "Ensure the Langflow instance has LANGFLOW_AUTO_LOGIN=true. "
+            f"Response keys: {list(data.keys())}"
         )
     return token
 
@@ -186,7 +188,6 @@ class AgenticEvalAdapter(FrameworkAdapter):
             if params.api_format == "langflow_run":
                 token = await _get_langflow_token(agent_url, client)
                 langflow_headers = {"Authorization": f"Bearer {token}"}
-                logger.info("Langflow auth token acquired for %s", agent_url)
 
             for i, query_spec in enumerate(queries):
                 progress = 30.0 + (50.0 * (i + 1) / len(queries))

--- a/evals/evalhub_adapter/config.py
+++ b/evals/evalhub_adapter/config.py
@@ -6,12 +6,15 @@ import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, get_args
 from urllib.parse import urlparse
 
 from harness.runner import TaskConfig
 
 logger = logging.getLogger(__name__)
+
+ApiFormat = Literal["chat_completions", "langflow_run"]
+_VALID_API_FORMATS = get_args(ApiFormat)
 
 _ALLOWED_URL_SCHEMES = {"https", "http"}
 _BLOCKED_HOSTS = {
@@ -98,7 +101,7 @@ class AgenticEvalParams:
     verify_ssl: bool = True
     fixtures_path: str = "fixtures"
     stream: bool = False
-    api_format: Literal["chat_completions", "langflow_run"] = "chat_completions"
+    api_format: ApiFormat = "chat_completions"
     flow_id: str | None = None
 
     # MLflow trace enrichment (reads tool calls from agent-side traces)
@@ -109,9 +112,9 @@ class AgenticEvalParams:
 
     def __post_init__(self) -> None:
         """Validate fields and apply defaults after dataclass init."""
-        if self.api_format not in ("chat_completions", "langflow_run"):
+        if self.api_format not in _VALID_API_FORMATS:
             raise ValueError(
-                f"api_format must be 'chat_completions' or 'langflow_run', "
+                f"api_format must be one of {_VALID_API_FORMATS}, "
                 f"got '{self.api_format}'"
             )
         if self.api_format == "langflow_run" and not self.flow_id:

--- a/evals/evalhub_adapter/config.py
+++ b/evals/evalhub_adapter/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import urlparse
 
 from harness.runner import TaskConfig
@@ -97,6 +97,8 @@ class AgenticEvalParams:
     verify_ssl: bool = True
     fixtures_path: str = "fixtures"
     stream: bool = False
+    api_format: Literal["chat_completions", "langflow_run"] = "chat_completions"
+    flow_id: str | None = None
 
     # MLflow trace enrichment (reads tool calls from agent-side traces)
     mlflow_tracking_uri: str | None = None
@@ -106,6 +108,13 @@ class AgenticEvalParams:
 
     def __post_init__(self) -> None:
         """Validate fields and apply defaults after dataclass init."""
+        if self.api_format not in ("chat_completions", "langflow_run"):
+            raise ValueError(
+                f"api_format must be 'chat_completions' or 'langflow_run', "
+                f"got '{self.api_format}'"
+            )
+        if self.api_format == "langflow_run" and not self.flow_id:
+            raise ValueError("flow_id is required when api_format is 'langflow_run'")
         if not self.mlflow_trace_experiment_name:
             self.mlflow_trace_experiment_name = self.mlflow_experiment_name
         if not isinstance(self.timeout_seconds, (int, float)):
@@ -175,14 +184,19 @@ def job_spec_to_task_config(
     expected_tools: list[str] | None,
     params: AgenticEvalParams,
     model_name: str | None = None,
+    extra_headers: dict[str, str] | None = None,
 ) -> TaskConfig:
     """Translate EvalHub job parameters into our TaskConfig."""
     _validate_url(agent_url, "agent_url")
+    stream = False if params.api_format == "langflow_run" else params.stream
     return TaskConfig(
         agent_url=agent_url,
         query=query,
         expected_tools=expected_tools,
         timeout_seconds=params.timeout_seconds,
         model=model_name,
-        stream=params.stream,
+        stream=stream,
+        api_format=params.api_format,
+        flow_id=params.flow_id,
+        extra_headers=extra_headers or {},
     )

--- a/evals/evalhub_adapter/config.py
+++ b/evals/evalhub_adapter/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
@@ -115,6 +116,11 @@ class AgenticEvalParams:
             )
         if self.api_format == "langflow_run" and not self.flow_id:
             raise ValueError("flow_id is required when api_format is 'langflow_run'")
+        if self.flow_id and not re.fullmatch(r"[a-zA-Z0-9_-]+", self.flow_id):
+            raise ValueError(
+                f"flow_id must contain only alphanumeric characters, hyphens, "
+                f"and underscores — got '{self.flow_id}'"
+            )
         if not self.mlflow_trace_experiment_name:
             self.mlflow_trace_experiment_name = self.mlflow_experiment_name
         if not isinstance(self.timeout_seconds, (int, float)):

--- a/evals/evalhub_adapter/tests/test_config_and_evaluations.py
+++ b/evals/evalhub_adapter/tests/test_config_and_evaluations.py
@@ -277,6 +277,26 @@ class TestLangflowApiFormatValidation:
         with pytest.raises(ValueError, match="flow_id is required"):
             AgenticEvalParams.from_dict(raw)
 
+    def test_flow_id_with_path_traversal_raises(self):
+        """flow_id containing path-unsafe characters raises ValueError."""
+        with pytest.raises(ValueError, match="flow_id must contain only"):
+            AgenticEvalParams(
+                api_format="langflow_run",
+                flow_id="../../admin/delete",
+                mlflow_tracking_uri="http://mlflow:5000",
+                mlflow_experiment_name="test-exp",
+            )
+
+    def test_flow_id_with_slash_raises(self):
+        """flow_id containing slashes raises ValueError."""
+        with pytest.raises(ValueError, match="flow_id must contain only"):
+            AgenticEvalParams(
+                api_format="langflow_run",
+                flow_id="abc/def",
+                mlflow_tracking_uri="http://mlflow:5000",
+                mlflow_experiment_name="test-exp",
+            )
+
 
 class TestJobSpecToTaskConfig:
     """Tests for translating EvalHub job parameters into TaskConfig."""

--- a/evals/evalhub_adapter/tests/test_config_and_evaluations.py
+++ b/evals/evalhub_adapter/tests/test_config_and_evaluations.py
@@ -178,7 +178,7 @@ class TestAgenticEvalParamsFromDict:
         assert params.max_latency_seconds == 10.0
         assert params.timeout_seconds == 30.0
         assert params.verify_ssl is True
-        assert params.stream is True
+        assert params.stream is False
 
     def test_verify_ssl_false_without_env_raises(self, monkeypatch):
         """verify_ssl=False without EVALHUB_ALLOW_INSECURE_TLS raises ValueError."""
@@ -223,6 +223,61 @@ class TestAgenticEvalParamsFromDict:
             )
 
 
+class TestLangflowApiFormatValidation:
+    """Tests for api_format and flow_id validation in AgenticEvalParams."""
+
+    def test_langflow_run_with_flow_id(self):
+        """api_format='langflow_run' with a valid flow_id succeeds."""
+        params = AgenticEvalParams(
+            api_format="langflow_run",
+            flow_id="abc-123-def",
+            mlflow_tracking_uri="http://mlflow:5000",
+            mlflow_experiment_name="test-exp",
+        )
+        assert params.api_format == "langflow_run"
+        assert params.flow_id == "abc-123-def"
+
+    def test_langflow_run_missing_flow_id_raises(self):
+        """api_format='langflow_run' without flow_id raises ValueError."""
+        with pytest.raises(ValueError, match="flow_id is required"):
+            AgenticEvalParams(
+                api_format="langflow_run",
+                mlflow_tracking_uri="http://mlflow:5000",
+                mlflow_experiment_name="test-exp",
+            )
+
+    def test_invalid_api_format_raises(self):
+        """An unrecognized api_format raises ValueError."""
+        with pytest.raises(ValueError, match="api_format"):
+            AgenticEvalParams(
+                api_format="grpc",
+                mlflow_tracking_uri="http://mlflow:5000",
+                mlflow_experiment_name="test-exp",
+            )
+
+    def test_from_dict_langflow_run(self):
+        """from_dict correctly propagates api_format and flow_id."""
+        raw = {
+            "api_format": "langflow_run",
+            "flow_id": "uuid-here",
+            "mlflow_tracking_uri": "http://mlflow:5000",
+            "mlflow_experiment_name": "test-exp",
+        }
+        params = AgenticEvalParams.from_dict(raw)
+        assert params.api_format == "langflow_run"
+        assert params.flow_id == "uuid-here"
+
+    def test_from_dict_langflow_run_missing_flow_id_raises(self):
+        """from_dict with langflow_run and no flow_id raises ValueError."""
+        raw = {
+            "api_format": "langflow_run",
+            "mlflow_tracking_uri": "http://mlflow:5000",
+            "mlflow_experiment_name": "test-exp",
+        }
+        with pytest.raises(ValueError, match="flow_id is required"):
+            AgenticEvalParams.from_dict(raw)
+
+
 class TestJobSpecToTaskConfig:
     """Tests for translating EvalHub job parameters into TaskConfig."""
 
@@ -247,7 +302,41 @@ class TestJobSpecToTaskConfig:
         assert cfg.expected_tools == ["get_weather"]
         assert cfg.timeout_seconds == 45.0
         assert cfg.model == "gpt-4o"
-        assert cfg.stream is True
+        assert cfg.stream is False
+
+    def test_langflow_forces_stream_false(self):
+        """Langflow api_format forces stream=False in TaskConfig."""
+        params = AgenticEvalParams(
+            api_format="langflow_run",
+            flow_id="f-1",
+            stream=True,
+            mlflow_tracking_uri="http://mlflow:5000",
+            mlflow_experiment_name="test-exp",
+        )
+        cfg = job_spec_to_task_config(
+            agent_url="http://agent:8000",
+            query="test",
+            expected_tools=None,
+            params=params,
+        )
+        assert cfg.stream is False
+        assert cfg.api_format == "langflow_run"
+        assert cfg.flow_id == "f-1"
+
+    def test_extra_headers_propagated(self):
+        """extra_headers are passed through to TaskConfig."""
+        params = AgenticEvalParams(
+            mlflow_tracking_uri="http://mlflow:5000",
+            mlflow_experiment_name="test-exp",
+        )
+        cfg = job_spec_to_task_config(
+            agent_url="http://agent:8000",
+            query="test",
+            expected_tools=None,
+            params=params,
+            extra_headers={"Authorization": "Bearer tok123"},
+        )
+        assert cfg.extra_headers == {"Authorization": "Bearer tok123"}
 
 
 EXPECTED_BENCHMARK_IDS = [

--- a/evals/evalhub_adapter/tests/test_integration.py
+++ b/evals/evalhub_adapter/tests/test_integration.py
@@ -47,6 +47,7 @@ _DUMMY_JOB_SPEC = {
         "known_tools": ["search"],
         "timeout_seconds": 5.0,
         "verify_ssl": False,
+        "stream": True,
         "mlflow_tracking_uri": "http://mlflow:5000",
         "mlflow_experiment_name": "test-exp",
     },
@@ -86,6 +87,7 @@ def _make_job_spec(
         "known_tools": ["search"],
         "timeout_seconds": 5.0,
         "verify_ssl": False,
+        "stream": True,
         "fixtures_path": fixtures_path,
         "mlflow_tracking_uri": "http://mlflow:5000",
         "mlflow_experiment_name": "test-exp",
@@ -307,6 +309,7 @@ class TestRunAsyncHappyPath:
                 "known_tools": ["search"],
                 "timeout_seconds": 5.0,
                 "verify_ssl": False,
+                "stream": True,
                 "fixtures_path": str(fixtures_dir),
                 "mlflow_tracking_uri": "https://mlflow.example.com",
                 "mlflow_experiment_name": "agentic-evals",
@@ -507,6 +510,7 @@ class TestMLflowTraceEnrichment:
                 "known_tools": ["search"],
                 "timeout_seconds": 5.0,
                 "verify_ssl": False,
+                "stream": True,
                 "fixtures_path": str(fixtures_dir),
                 "mlflow_tracking_uri": "https://mlflow.example.com",
                 "mlflow_experiment_name": "test-exp",
@@ -532,6 +536,151 @@ class TestMLflowTraceEnrichment:
 
         assert results.num_examples_evaluated == 2
         assert mock_mlflow_client.enrich_eval_result.call_count == 2
+
+
+class TestLangflowProtocol:
+    """Integration tests for the Langflow /api/v1/run protocol."""
+
+    @pytest.fixture()
+    def adapter(self, tmp_path):
+        return _make_adapter(_write_job_spec(tmp_path))
+
+    @pytest.fixture()
+    def langflow_response(self):
+        return {
+            "session_id": "test-session",
+            "outputs": [
+                {
+                    "outputs": [
+                        {
+                            "results": {
+                                "message": {
+                                    "text": "The forecast is sunny.",
+                                    "content_blocks": [
+                                        {
+                                            "title": "get_forecast",
+                                            "contents": [
+                                                {
+                                                    "type": "tool_use",
+                                                    "name": "get_forecast",
+                                                    "tool_input": {"city": "Boston"},
+                                                }
+                                            ],
+                                        }
+                                    ],
+                                }
+                            },
+                            "artifacts": {"message": "The forecast is sunny."},
+                        }
+                    ]
+                }
+            ],
+        }
+
+    def test_langflow_full_pipeline(
+        self, adapter, fixtures_dir: Path, langflow_response
+    ):
+        """Full pipeline with api_format=langflow_run produces scored results."""
+        yaml_content = textwrap.dedent("""\
+            queries:
+              - query: "What is the weather in Boston?"
+                expected_tools: ["get_forecast"]
+        """)
+        (fixtures_dir / "tool_use.yaml").write_text(yaml_content)
+
+        job_spec = _make_job_spec(
+            fixtures_path=str(fixtures_dir),
+            parameters={
+                "known_tools": ["get_forecast"],
+                "timeout_seconds": 5.0,
+                "verify_ssl": False,
+                "fixtures_path": str(fixtures_dir),
+                "api_format": "langflow_run",
+                "flow_id": "test-flow-uuid",
+                "mlflow_tracking_uri": "http://mlflow:5000",
+                "mlflow_experiment_name": "test-exp",
+            },
+        )
+        callbacks = _make_callbacks()
+
+        auto_login_resp = MagicMock()
+        auto_login_resp.status_code = 200
+        auto_login_resp.raise_for_status = MagicMock()
+        auto_login_resp.json.return_value = {
+            "access_token": "test-jwt-token",
+            "token_type": "bearer",
+        }
+
+        run_resp = MagicMock()
+        run_resp.status_code = 200
+        run_resp.raise_for_status = MagicMock()
+        run_resp.json.return_value = langflow_response
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=auto_login_resp)
+        mock_client.post = AsyncMock(return_value=run_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "evalhub_adapter.adapter.httpx.AsyncClient", return_value=mock_client
+        ):
+            results = asyncio.run(adapter._run_async(job_spec, callbacks))
+
+        assert results.num_examples_evaluated == 1
+        assert results.overall_score > 0
+        assert callbacks.report_results.call_count == 1
+
+        mock_client.get.assert_called_once()
+        get_url = mock_client.get.call_args.args[0]
+        assert "/api/v1/auto_login" in get_url
+
+        post_call = mock_client.post.call_args
+        assert "/api/v1/run/test-flow-uuid" in post_call.args[0]
+
+        headers = post_call.kwargs.get("headers", {})
+        assert headers.get("Authorization") == "Bearer test-jwt-token"
+
+    def test_langflow_auth_failure_raises(self, adapter, fixtures_dir: Path):
+        """When auto_login returns non-200, the pipeline raises."""
+        yaml_content = textwrap.dedent("""\
+            queries:
+              - query: "test"
+                expected_tools: []
+        """)
+        (fixtures_dir / "tool_use.yaml").write_text(yaml_content)
+
+        job_spec = _make_job_spec(
+            fixtures_path=str(fixtures_dir),
+            parameters={
+                "known_tools": [],
+                "timeout_seconds": 5.0,
+                "verify_ssl": False,
+                "fixtures_path": str(fixtures_dir),
+                "api_format": "langflow_run",
+                "flow_id": "test-flow",
+                "mlflow_tracking_uri": "http://mlflow:5000",
+                "mlflow_experiment_name": "test-exp",
+            },
+        )
+        callbacks = _make_callbacks()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "Unauthorized",
+                request=httpx.Request("GET", "http://fake/api/v1/auto_login"),
+                response=httpx.Response(401),
+            )
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "evalhub_adapter.adapter.httpx.AsyncClient", return_value=mock_client
+        ):
+            with pytest.raises(httpx.HTTPStatusError):
+                asyncio.run(adapter._run_async(job_spec, callbacks))
 
 
 class TestMain:

--- a/evals/evalhub_adapter/tests/test_integration.py
+++ b/evals/evalhub_adapter/tests/test_integration.py
@@ -6,9 +6,8 @@ instance.
 
 Agents serve tool calls only via SSE streaming — their Pydantic
 response_model strips the extra ``context`` field that would otherwise
-carry tool-call history in non-streaming JSON.  The adapter therefore
-uses ``stream=True`` by default so the harness runner can accumulate
-``delta.tool_calls`` from the SSE event stream.
+carry tool-call history in non-streaming JSON.  Tests that need SSE
+streaming set ``stream=True`` explicitly (the default is ``False``).
 """
 
 from __future__ import annotations
@@ -680,6 +679,46 @@ class TestLangflowProtocol:
             "evalhub_adapter.adapter.httpx.AsyncClient", return_value=mock_client
         ):
             with pytest.raises(httpx.HTTPStatusError):
+                asyncio.run(adapter._run_async(job_spec, callbacks))
+
+    def test_langflow_missing_access_token_raises(self, adapter, fixtures_dir: Path):
+        """When auto_login returns 200 but no access_token, the pipeline raises."""
+        yaml_content = textwrap.dedent("""\
+            queries:
+              - query: "test"
+                expected_tools: []
+        """)
+        (fixtures_dir / "tool_use.yaml").write_text(yaml_content)
+
+        job_spec = _make_job_spec(
+            fixtures_path=str(fixtures_dir),
+            parameters={
+                "known_tools": [],
+                "timeout_seconds": 5.0,
+                "verify_ssl": False,
+                "fixtures_path": str(fixtures_dir),
+                "api_format": "langflow_run",
+                "flow_id": "test-flow",
+                "mlflow_tracking_uri": "http://mlflow:5000",
+                "mlflow_experiment_name": "test-exp",
+            },
+        )
+        callbacks = _make_callbacks()
+
+        auto_login_resp = MagicMock()
+        auto_login_resp.status_code = 200
+        auto_login_resp.raise_for_status = MagicMock()
+        auto_login_resp.json.return_value = {"token_type": "bearer"}
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=auto_login_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "evalhub_adapter.adapter.httpx.AsyncClient", return_value=mock_client
+        ):
+            with pytest.raises(ValueError, match="LANGFLOW_AUTO_LOGIN"):
                 asyncio.run(adapter._run_async(job_spec, callbacks))
 
 

--- a/evals/harness/runner.py
+++ b/evals/harness/runner.py
@@ -139,7 +139,8 @@ def _extract_token_usage(response_data: dict[str, Any]) -> int | None:
 def _get_langflow_output(response_data: dict[str, Any]) -> dict[str, Any] | None:
     """Navigate to the first output node from a Langflow /api/v1/run response."""
     try:
-        return response_data["outputs"][0]["outputs"][0]
+        output = response_data["outputs"][0]["outputs"][0]
+        return output if isinstance(output, dict) else None
     except (KeyError, IndexError, TypeError):
         return None
 

--- a/evals/harness/runner.py
+++ b/evals/harness/runner.py
@@ -172,7 +172,9 @@ def _extract_langflow_tool_calls(
                         }
                     )
     except (KeyError, IndexError, TypeError):
-        logger.debug("Failed to extract Langflow tool calls from response", exc_info=True)
+        logger.debug(
+            "Failed to extract Langflow tool calls from response", exc_info=True
+        )
     return tool_calls
 
 

--- a/evals/harness/runner.py
+++ b/evals/harness/runner.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import json
 import logging
 import time
-from dataclasses import dataclass
-from typing import Any
+from dataclasses import dataclass, field
+from typing import Any, Literal
 
 import httpx
 
@@ -25,6 +25,9 @@ class TaskConfig:
     model: str | None = None
     stream: bool = False
     thread_id: str | None = None
+    api_format: Literal["chat_completions", "langflow_run"] = "chat_completions"
+    flow_id: str | None = None
+    extra_headers: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -132,11 +135,53 @@ def _extract_token_usage(response_data: dict[str, Any]) -> int | None:
     return usage.get("total_tokens")
 
 
+def _extract_langflow_response_text(response_data: dict[str, Any]) -> str:
+    """Extract assistant message text from a Langflow /api/v1/run response."""
+    try:
+        output = response_data["outputs"][0]["outputs"][0]
+        text = output.get("results", {}).get("message", {}).get("text")
+        if text:
+            return text
+        return output.get("artifacts", {}).get("message", "") or ""
+    except (KeyError, IndexError, TypeError):
+        return ""
+
+
+def _extract_langflow_tool_calls(
+    response_data: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Extract tool calls from a Langflow /api/v1/run response.
+
+    Navigates outputs[0].outputs[0].results.message.content_blocks[*].contents[*]
+    and maps Langflow's ``tool_input`` field to ``arguments`` for scorer compatibility.
+    """
+    tool_calls: list[dict[str, Any]] = []
+    try:
+        message = (
+            response_data["outputs"][0]["outputs"][0]
+            .get("results", {})
+            .get("message", {})
+        )
+        for block in message.get("content_blocks", []):
+            for entry in block.get("contents", []):
+                if entry.get("type") == "tool_use":
+                    tool_calls.append(
+                        {
+                            "name": entry.get("name", ""),
+                            "arguments": entry.get("tool_input", {}),
+                        }
+                    )
+    except (KeyError, IndexError, TypeError):
+        pass
+    return tool_calls
+
+
 async def _run_streaming(
     client: httpx.AsyncClient,
     url: str,
     payload: dict[str, Any],
     timeout: float,
+    headers: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Handle a streaming chat completion request, accumulating the response."""
     collected_content = ""
@@ -146,7 +191,9 @@ async def _run_streaming(
     parsed_any_chunk = False
     malformed_count = 0
 
-    async with client.stream("POST", url, json=payload, timeout=timeout) as resp:
+    async with client.stream(
+        "POST", url, json=payload, headers=headers, timeout=timeout
+    ) as resp:
         resp.raise_for_status()
         async for line in resp.aiter_lines():
             if not line.startswith("data: "):
@@ -220,39 +267,61 @@ async def run_task(
 ) -> TaskResult:
     """Execute a single eval task against an agent endpoint.
 
-    Sends the query to the agent's /chat/completions endpoint,
-    measures latency, extracts tool calls and token usage.
+    Sends the query to the agent's endpoint (``/chat/completions`` or
+    Langflow ``/api/v1/run/<flow_id>``), measures latency, extracts
+    tool calls and token usage.
     """
     own_client = client is None
     if own_client:
         client = httpx.AsyncClient()
 
-    url = f"{config.agent_url.rstrip('/')}/chat/completions"
-    payload: dict[str, Any] = {
-        "messages": [{"role": "user", "content": config.query}],
-    }
-    if config.model:
-        payload["model"] = config.model
-    if config.stream:
-        payload["stream"] = True
-    if config.thread_id:
-        payload["thread_id"] = config.thread_id
+    is_langflow = config.api_format == "langflow_run"
 
+    if is_langflow:
+        if not config.flow_id:
+            raise ValueError("flow_id is required when api_format is 'langflow_run'")
+        url = f"{config.agent_url.rstrip('/')}/api/v1/run/{config.flow_id}"
+        payload: dict[str, Any] = {
+            "input_value": config.query,
+            "output_type": "chat",
+            "input_type": "chat",
+        }
+    else:
+        url = f"{config.agent_url.rstrip('/')}/chat/completions"
+        payload = {
+            "messages": [{"role": "user", "content": config.query}],
+        }
+        if config.model:
+            payload["model"] = config.model
+        if config.stream:
+            payload["stream"] = True
+        if config.thread_id:
+            payload["thread_id"] = config.thread_id
+
+    headers = config.extra_headers or None
     start = time.monotonic()
     try:
-        if config.stream:
+        if not is_langflow and config.stream:
             response_data = await _run_streaming(
-                client, url, payload, config.timeout_seconds
+                client, url, payload, config.timeout_seconds, headers=headers
             )
         else:
-            resp = await client.post(url, json=payload, timeout=config.timeout_seconds)
+            resp = await client.post(
+                url, json=payload, headers=headers, timeout=config.timeout_seconds
+            )
             resp.raise_for_status()
             response_data = resp.json()
 
         latency = time.monotonic() - start
-        tool_calls = _extract_tool_calls(response_data)
-        response_text = _extract_response_text(response_data)
-        tokens_used = _extract_token_usage(response_data)
+
+        if is_langflow:
+            tool_calls = _extract_langflow_tool_calls(response_data)
+            response_text = _extract_langflow_response_text(response_data)
+            tokens_used = None
+        else:
+            tool_calls = _extract_tool_calls(response_data)
+            response_text = _extract_response_text(response_data)
+            tokens_used = _extract_token_usage(response_data)
 
         return TaskResult(
             response=response_text,

--- a/evals/harness/runner.py
+++ b/evals/harness/runner.py
@@ -172,7 +172,7 @@ def _extract_langflow_tool_calls(
                         }
                     )
     except (KeyError, IndexError, TypeError):
-        pass
+        logger.debug("Failed to extract Langflow tool calls from response", exc_info=True)
     return tool_calls
 
 

--- a/evals/harness/runner.py
+++ b/evals/harness/runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 from dataclasses import dataclass, field
 from typing import Any, Literal
@@ -135,16 +136,23 @@ def _extract_token_usage(response_data: dict[str, Any]) -> int | None:
     return usage.get("total_tokens")
 
 
+def _get_langflow_output(response_data: dict[str, Any]) -> dict[str, Any] | None:
+    """Navigate to the first output node from a Langflow /api/v1/run response."""
+    try:
+        return response_data["outputs"][0]["outputs"][0]
+    except (KeyError, IndexError, TypeError):
+        return None
+
+
 def _extract_langflow_response_text(response_data: dict[str, Any]) -> str:
     """Extract assistant message text from a Langflow /api/v1/run response."""
-    try:
-        output = response_data["outputs"][0]["outputs"][0]
-        text = output.get("results", {}).get("message", {}).get("text")
-        if text:
-            return text
-        return output.get("artifacts", {}).get("message", "") or ""
-    except (KeyError, IndexError, TypeError):
+    output = _get_langflow_output(response_data)
+    if output is None:
         return ""
+    text = output.get("results", {}).get("message", {}).get("text")
+    if text:
+        return text
+    return output.get("artifacts", {}).get("message", "") or ""
 
 
 def _extract_langflow_tool_calls(
@@ -155,26 +163,20 @@ def _extract_langflow_tool_calls(
     Navigates outputs[0].outputs[0].results.message.content_blocks[*].contents[*]
     and maps Langflow's ``tool_input`` field to ``arguments`` for scorer compatibility.
     """
+    output = _get_langflow_output(response_data)
+    if output is None:
+        return []
     tool_calls: list[dict[str, Any]] = []
-    try:
-        message = (
-            response_data["outputs"][0]["outputs"][0]
-            .get("results", {})
-            .get("message", {})
-        )
-        for block in message.get("content_blocks", []):
-            for entry in block.get("contents", []):
-                if entry.get("type") == "tool_use":
-                    tool_calls.append(
-                        {
-                            "name": entry.get("name", ""),
-                            "arguments": entry.get("tool_input", {}),
-                        }
-                    )
-    except (KeyError, IndexError, TypeError):
-        logger.debug(
-            "Failed to extract Langflow tool calls from response", exc_info=True
-        )
+    message = output.get("results", {}).get("message", {})
+    for block in message.get("content_blocks", []):
+        for entry in block.get("contents", []):
+            if entry.get("type") == "tool_use":
+                tool_calls.append(
+                    {
+                        "name": entry.get("name", ""),
+                        "arguments": entry.get("tool_input", {}),
+                    }
+                )
     return tool_calls
 
 
@@ -282,6 +284,11 @@ async def run_task(
     if is_langflow:
         if not config.flow_id:
             raise ValueError("flow_id is required when api_format is 'langflow_run'")
+        if not re.fullmatch(r"[a-zA-Z0-9_-]+", config.flow_id):
+            raise ValueError(
+                f"flow_id must contain only alphanumeric characters, hyphens, "
+                f"and underscores — got '{config.flow_id}'"
+            )
         url = f"{config.agent_url.rstrip('/')}/api/v1/run/{config.flow_id}"
         payload: dict[str, Any] = {
             "input_value": config.query,

--- a/evals/harness/tests/conftest.py
+++ b/evals/harness/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Shared fixtures for harness tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def langflow_run_response() -> dict:
+    """Load the captured Langflow /api/v1/run response fixture."""
+    return json.loads((FIXTURES_DIR / "langflow_run_response.json").read_text())

--- a/evals/harness/tests/fixtures/langflow_run_response.json
+++ b/evals/harness/tests/fixtures/langflow_run_response.json
@@ -1,0 +1,52 @@
+{
+  "session_id": "ef9b8cc1-1b6a-4b72-91c9-abc123456789",
+  "outputs": [
+    {
+      "inputs": {
+        "input_value": "What is the weather forecast for Boston?"
+      },
+      "outputs": [
+        {
+          "results": {
+            "message": {
+              "text": "Based on the forecast data, Boston is expected to have partly cloudy skies with a high of 72°F and a low of 58°F.",
+              "sender": "Machine",
+              "sender_name": "AI",
+              "session_id": "ef9b8cc1-1b6a-4b72-91c9-abc123456789",
+              "content_blocks": [
+                {
+                  "title": "get_forecast",
+                  "contents": [
+                    {
+                      "type": "tool_use",
+                      "name": "get_forecast",
+                      "tool_input": {
+                        "city": "Boston",
+                        "days": 1
+                      },
+                      "duration": 1234
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "artifacts": {
+            "message": "Based on the forecast data, Boston is expected to have partly cloudy skies with a high of 72°F and a low of 58°F.",
+            "sender": "Machine",
+            "sender_name": "AI",
+            "type": "object"
+          },
+          "outputs": {
+            "message": {
+              "message": "Based on the forecast data, Boston is expected to have partly cloudy skies with a high of 72°F and a low of 58°F.",
+              "type": "text"
+            }
+          },
+          "logs": {},
+          "messages": []
+        }
+      ]
+    }
+  ]
+}

--- a/evals/harness/tests/test_runner_langflow.py
+++ b/evals/harness/tests/test_runner_langflow.py
@@ -1,0 +1,330 @@
+"""Unit tests for Langflow /api/v1/run protocol support in runner.py."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from harness.runner import (
+    TaskConfig,
+    _extract_langflow_response_text,
+    _extract_langflow_tool_calls,
+    run_task,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Extraction: response text
+# ---------------------------------------------------------------------------
+
+
+class TestExtractLangflowResponseText:
+    """Tests for _extract_langflow_response_text()."""
+
+    def test_primary_path(self, langflow_run_response):
+        """Extracts text from results.message.text."""
+        text = _extract_langflow_response_text(langflow_run_response)
+        assert "Boston" in text
+        assert "72°F" in text
+
+    def test_fallback_to_artifacts(self):
+        """Falls back to artifacts.message when results.message.text is missing."""
+        data = {
+            "outputs": [
+                {
+                    "outputs": [
+                        {
+                            "results": {"message": {}},
+                            "artifacts": {"message": "Fallback text here"},
+                        }
+                    ]
+                }
+            ]
+        }
+        assert _extract_langflow_response_text(data) == "Fallback text here"
+
+    def test_empty_response(self):
+        """Returns empty string for empty/malformed data."""
+        assert _extract_langflow_response_text({}) == ""
+        assert _extract_langflow_response_text({"outputs": []}) == ""
+
+    def test_none_text_uses_fallback(self):
+        """When text is None, falls back to artifacts.message."""
+        data = {
+            "outputs": [
+                {
+                    "outputs": [
+                        {
+                            "results": {"message": {"text": None}},
+                            "artifacts": {"message": "From artifacts"},
+                        }
+                    ]
+                }
+            ]
+        }
+        assert _extract_langflow_response_text(data) == "From artifacts"
+
+
+# ---------------------------------------------------------------------------
+# Extraction: tool calls
+# ---------------------------------------------------------------------------
+
+
+class TestExtractLangflowToolCalls:
+    """Tests for _extract_langflow_tool_calls()."""
+
+    def test_single_tool_call(self, langflow_run_response):
+        """Extracts a single tool call with tool_input mapped to arguments."""
+        calls = _extract_langflow_tool_calls(langflow_run_response)
+        assert len(calls) == 1
+        assert calls[0]["name"] == "get_forecast"
+        assert calls[0]["arguments"] == {"city": "Boston", "days": 1}
+
+    def test_multi_tool_calls(self):
+        """Extracts multiple tool calls from multiple content blocks."""
+        data = {
+            "outputs": [
+                {
+                    "outputs": [
+                        {
+                            "results": {
+                                "message": {
+                                    "content_blocks": [
+                                        {
+                                            "title": "search",
+                                            "contents": [
+                                                {
+                                                    "type": "tool_use",
+                                                    "name": "web_search",
+                                                    "tool_input": {"q": "test"},
+                                                }
+                                            ],
+                                        },
+                                        {
+                                            "title": "calc",
+                                            "contents": [
+                                                {
+                                                    "type": "tool_use",
+                                                    "name": "calculator",
+                                                    "tool_input": {"expr": "2+2"},
+                                                }
+                                            ],
+                                        },
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+        calls = _extract_langflow_tool_calls(data)
+        assert len(calls) == 2
+        assert calls[0]["name"] == "web_search"
+        assert calls[1]["name"] == "calculator"
+        assert calls[1]["arguments"] == {"expr": "2+2"}
+
+    def test_no_tool_calls(self):
+        """Returns empty list when no content_blocks or no tool_use entries."""
+        data = {
+            "outputs": [
+                {
+                    "outputs": [
+                        {
+                            "results": {
+                                "message": {
+                                    "text": "No tools used",
+                                    "content_blocks": [],
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+        assert _extract_langflow_tool_calls(data) == []
+
+    def test_skips_non_tool_use_entries(self):
+        """Entries with type != 'tool_use' are skipped."""
+        data = {
+            "outputs": [
+                {
+                    "outputs": [
+                        {
+                            "results": {
+                                "message": {
+                                    "content_blocks": [
+                                        {
+                                            "contents": [
+                                                {"type": "text", "text": "hello"},
+                                                {
+                                                    "type": "tool_use",
+                                                    "name": "search",
+                                                    "tool_input": {},
+                                                },
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+        calls = _extract_langflow_tool_calls(data)
+        assert len(calls) == 1
+        assert calls[0]["name"] == "search"
+
+    def test_empty_response(self):
+        """Returns empty list for empty/malformed data."""
+        assert _extract_langflow_tool_calls({}) == []
+        assert _extract_langflow_tool_calls({"outputs": []}) == []
+
+
+# ---------------------------------------------------------------------------
+# run_task() with langflow_run api_format
+# ---------------------------------------------------------------------------
+
+
+class TestRunTaskLangflow:
+    """Tests for run_task() with api_format='langflow_run'."""
+
+    def test_missing_flow_id_raises(self):
+        """run_task raises ValueError when flow_id is not set."""
+        config = TaskConfig(
+            agent_url="http://agent:8080",
+            query="hello",
+            api_format="langflow_run",
+            flow_id=None,
+        )
+        with pytest.raises(ValueError, match="flow_id is required"):
+            asyncio.run(run_task(config))
+
+    def test_url_construction(self, langflow_run_response):
+        """URL is built as /api/v1/run/<flow_id>."""
+        config = TaskConfig(
+            agent_url="http://agent:8080",
+            query="What is the weather?",
+            api_format="langflow_run",
+            flow_id="abc-123",
+            extra_headers={"Authorization": "Bearer tok"},
+        )
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = langflow_run_response
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        result = asyncio.run(run_task(config, client=mock_client))
+
+        call_args = mock_client.post.call_args
+        assert call_args.args[0] == "http://agent:8080/api/v1/run/abc-123"
+
+        payload = call_args.kwargs["json"]
+        assert payload == {
+            "input_value": "What is the weather?",
+            "output_type": "chat",
+            "input_type": "chat",
+        }
+
+        headers = call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer tok"
+
+        assert result.success is True
+        assert "Boston" in result.response
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "get_forecast"
+        assert result.tool_calls[0]["arguments"]["city"] == "Boston"
+
+    def test_langflow_does_not_stream(self, langflow_run_response):
+        """Langflow requests always use non-streaming POST, even if stream=True."""
+        config = TaskConfig(
+            agent_url="http://agent:8080",
+            query="test",
+            api_format="langflow_run",
+            flow_id="f-1",
+            stream=True,
+        )
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = langflow_run_response
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        result = asyncio.run(run_task(config, client=mock_client))
+
+        mock_client.post.assert_called_once()
+        assert not hasattr(mock_client, "stream") or not mock_client.stream.called
+        assert result.success is True
+
+    def test_http_error_returns_failed_result(self):
+        """HTTP errors return a failed TaskResult, not an exception."""
+        config = TaskConfig(
+            agent_url="http://agent:8080",
+            query="test",
+            api_format="langflow_run",
+            flow_id="f-1",
+        )
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "Server Error",
+                request=httpx.Request("POST", "http://agent:8080/api/v1/run/f-1"),
+                response=httpx.Response(500, text="Internal Server Error"),
+            )
+        )
+
+        result = asyncio.run(run_task(config, client=mock_client))
+
+        assert result.success is False
+        assert "500" in result.error
+
+
+# ---------------------------------------------------------------------------
+# Regression: chat_completions path unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestRunTaskChatCompletionsUnchanged:
+    """Verify the default chat_completions path still works."""
+
+    def test_default_api_format(self):
+        """TaskConfig defaults to chat_completions."""
+        config = TaskConfig(agent_url="http://a:8080", query="hi")
+        assert config.api_format == "chat_completions"
+        assert config.flow_id is None
+        assert config.extra_headers == {}
+
+    def test_chat_completions_url(self):
+        """chat_completions uses /chat/completions URL."""
+        config = TaskConfig(agent_url="http://agent:8080", query="hi")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "choices": [{"message": {"role": "assistant", "content": "hello"}}]
+        }
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        result = asyncio.run(run_task(config, client=mock_client))
+
+        call_args = mock_client.post.call_args
+        assert call_args.args[0] == "http://agent:8080/chat/completions"
+        assert result.success is True
+        assert result.response == "hello"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ evalhub = ["eval-hub-sdk[adapter]>=0.1.4", "httpx>=0.27", "pyyaml>=6.0"]
 # --------------------------------------------------------------------------
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-testpaths = ["tests/behavioral", "evals/evalhub_adapter/tests"]
+testpaths = ["tests/behavioral", "evals/evalhub_adapter/tests", "evals/harness/tests"]
 pythonpath = ["evals", "tests/behavioral"]
 python_files = "test_*.py"
 markers = [


### PR DESCRIPTION
## Summary
- Adds Langflow `/api/v1/run/<flow-id>` protocol support to the eval harness (`runner.py`) and EvalHub adapter, enabling behavioral testing and EvalHub jobs for Langflow agents
- Adds `api_format` and `flow_id` fields to `TaskConfig` and `AgenticEvalParams` with validation, Langflow response/tool-call extraction (`tool_input` → `arguments` mapping), and `auto_login` token acquisition
- Fixes pre-existing test regressions from the `stream` default change (6d74274) — SSE integration tests now explicitly set `stream=True`

## Test plan
- [x] All 104 unit + integration tests pass (`pytest evals/`)
- [x] Ruff lint + format clean
- [x] Live cluster behavioral tests against all 7 agents with test suites — no regressions from harness changes
- [x] E2E: run EvalHub job with `api_format: langflow_run` against the deployed Langflow agent (requires cluster access + EvalHub)

Closes RHAIENG-5389

🤖 Generated with [Claude Code](https://claude.com/claude-code)