### PR TITLE
docs: update MLflow tracing for 3.12+ plugin approach

### DIFF
--- a/agents/claude-code/mlflow-tracing.md
+++ b/agents/claude-code/mlflow-tracing.md
@@ -199,8 +199,12 @@ oc adm policy add-role-to-user edit -z default -n <your-namespace>
 #### 3. Add MLflow env vars to the [deployment](https://github.com/red-hat-data-services/agentic-starter-kits/blob/main/agents/claude-code/deployment/deployment.yaml)
 
 ```yaml
+# For MLflow 3.12+:
 - name: MLFLOW_TRACKING_URI
-  value: "https://mlflow.<your-rhoai-namespace>.svc:8443/mlflow"  # for 3.10.x remove /mlflow; namespace is commonly redhat-ods-applications
+  value: "https://mlflow.<your-rhoai-namespace>.svc:8443/mlflow"  # namespace is commonly redhat-ods-applications
+# For MLflow 3.10.x:
+# - name: MLFLOW_TRACKING_URI
+#   value: "https://mlflow.<your-rhoai-namespace>.svc:8443"
 - name: MLFLOW_TRACKING_AUTH
   value: "kubernetes-namespaced"
 - name: MLFLOW_WORKSPACE

--- a/agents/claude-code/mlflow-tracing.md
+++ b/agents/claude-code/mlflow-tracing.md
@@ -169,19 +169,24 @@ The following must already be running on the cluster:
 
 Add Python and the MLflow SDK to the [Containerfile](https://github.com/red-hat-data-services/agentic-starter-kits/blob/main/agents/claude-code/deployment/Containerfile).
 
-MLflow offers two ways to set up Claude Code tracing: a Claude Code plugin (npm) and the MLflow Python SDK. On RHOAI, use the **Python SDK** approach because the `kubernetes-namespaced` auth plugin is only available in the Python SDK — the npm plugin does not support Kubernetes service account authentication.
+MLflow 3.12+ uses a Claude Code plugin for tracing. This requires Python (for the MLflow CLI and `kubernetes-namespaced` auth) and Node.js/npm (for the plugin install). The `.npm` cache directory needs group-writable permissions for OpenShift's random UID.
 
 For MLflow 3.12+ (upstream):
 
 ```dockerfile
-RUN microdnf install -y --nodocs python3.12 python3.12-pip
+RUN microdnf install -y --nodocs python3.12 python3.12-pip nodejs npm
 RUN python3.12 -m pip install --no-cache-dir 'mlflow[kubernetes]>=3.12'
+
+# npm cache needs group-writable permissions for OpenShift random UID
+RUN mkdir -p /home/${USER_NAME}/.npm \
+    && chown -R ${USER_UID}:${USER_GID} /home/${USER_NAME}/.npm \
+    && chmod -R 775 /home/${USER_NAME}/.npm
 ```
 
 For MLflow 3.10.x (Red Hat fork required):
 
 ```dockerfile
-RUN microdnf install -y --nodocs python3.12 python3.12-pip
+RUN microdnf install -y --nodocs python3.12 python3.12-pip nodejs npm
 RUN python3.12 -m pip install --no-cache-dir \
   'mlflow[kubernetes] @ git+https://github.com/red-hat-data-services/mlflow.git@v3.10.1+rhaiv.3'
 ```
@@ -222,25 +227,13 @@ oc adm policy add-role-to-user edit -z default -n <your-namespace>
 
 #### 5. Wire up autolog in the [entrypoint](https://github.com/red-hat-data-services/agentic-starter-kits/blob/main/agents/claude-code/deployment/entrypoint.sh)
 
-The entrypoint exports `kubernetes-namespaced` auth, runs `mlflow autolog claude` to configure the Python hook, then injects auth settings into the generated `.claude/settings.json` so the hook can authenticate at session end.
+The entrypoint exports `kubernetes-namespaced` auth and runs `mlflow autolog claude` which installs the Claude Code plugin and configures tracing. The auth env vars must be exported before the command so it can authenticate with the MLflow server during setup.
 
 ```bash
 export MLFLOW_TRACKING_AUTH="kubernetes-namespaced"
 export MLFLOW_TRACKING_INSECURE_TLS="${MLFLOW_TRACKING_INSECURE_TLS:-false}"
 
 mlflow autolog claude -d /workspace -u "${MLFLOW_TRACKING_URI}" -n "${MLFLOW_EXPERIMENT_NAME}"
-
-# Inject auth into settings.json so the Python hook can authenticate
-python3.12 -c '
-import json, os
-sf = "/workspace/.claude/settings.json"
-with open(sf) as f: s = json.load(f)
-env = s.setdefault("env", {})
-env["MLFLOW_TRACKING_AUTH"] = "kubernetes-namespaced"
-env["MLFLOW_WORKSPACE"] = os.environ["MLFLOW_WORKSPACE"]
-env["MLFLOW_TRACKING_INSECURE_TLS"] = os.environ.get("MLFLOW_TRACKING_INSECURE_TLS", "false")
-with open(sf, "w") as f: json.dump(s, f, indent=2)
-'
 ```
 
 #### 6. Verify
@@ -264,4 +257,4 @@ oc exec deployment/<claude-deployment> -- bash -c '
 
 It works across all backends (Vertex AI, vLLM, OGX) with no changes to the tracing setup. It captures tool calls, token usage, latency, and session metadata out of the box. The only overhead is the stop-hook which runs after the session ends — zero impact on agent response times.
 
-For MLflow 3.12+, use upstream `mlflow[kubernetes]>=3.12` with the Python SDK approach — no Red Hat fork needed.
+For MLflow 3.12+, use upstream `mlflow[kubernetes]>=3.12` with the Claude Code plugin — no Red Hat fork needed.

--- a/agents/claude-code/mlflow-tracing.md
+++ b/agents/claude-code/mlflow-tracing.md
@@ -153,7 +153,7 @@ No measurable latency difference. OGX acts as a thin passthrough to vLLM's `/v1/
 
 ### Summary
 
-MLflow integration works. Follow this guide to hook Claude Code, OGX, and MLflow together on RHOAI — assuming all three are already deployed on the cluster. The setup requires the Red Hat MLflow fork for RHOAI 3.4, which will be replaced by upstream MLflow 3.11 in a future release.
+MLflow integration works. Follow this guide to hook Claude Code, OGX, and MLflow together on RHOAI — assuming all three are already deployed on the cluster.
 
 ### Prerequisites
 
@@ -167,15 +167,22 @@ The following must already be running on the cluster:
 
 #### 1. Add Python + MLflow to the Containerfile
 
-The ODH build of MLflow uses the Red Hat fork which includes the `kubernetes-namespaced` auth plugin not yet in upstream 3.10.x:
+Add Python and the MLflow SDK to the [Containerfile](https://github.com/red-hat-data-services/agentic-starter-kits/blob/main/agents/claude-code/deployment/Containerfile).
+
+For MLflow 3.10.x (Red Hat fork required):
 
 ```dockerfile
-RUN microdnf install -y python3.12 python3.12-pip
+RUN microdnf install -y --nodocs python3.12 python3.12-pip
 RUN python3.12 -m pip install --no-cache-dir \
   'mlflow[kubernetes] @ git+https://github.com/red-hat-data-services/mlflow.git@v3.10.1+rhaiv.3'
 ```
 
-> This fork requirement will go away when RHOAI ships MLflow 3.11, at which point replace with `mlflow[kubernetes]>=3.11`.
+For MLflow 3.12+ (upstream, no fork needed — requires npm for the Claude Code plugin):
+
+```dockerfile
+RUN microdnf install -y --nodocs python3.12 python3.12-pip nodejs npm
+RUN python3.12 -m pip install --no-cache-dir 'mlflow[kubernetes]>=3.12'
+```
 
 #### 2. Grant RBAC to the pod's service account
 
@@ -189,7 +196,7 @@ oc adm policy add-role-to-user edit -z default -n <your-namespace>
 
 ```yaml
 - name: MLFLOW_TRACKING_URI
-  value: "https://mlflow.<your-rhoai-namespace>.svc:8443"  # namespace where MLflow is deployed (commonly redhat-ods-applications)
+  value: "https://mlflow.<your-rhoai-namespace>.svc:8443/mlflow"  # for 3.10.x remove /mlflow; namespace is commonly redhat-ods-applications
 - name: MLFLOW_TRACKING_AUTH
   value: "kubernetes-namespaced"
 - name: MLFLOW_WORKSPACE
@@ -213,21 +220,13 @@ oc adm policy add-role-to-user edit -z default -n <your-namespace>
 
 #### 5. Wire up autolog in the [entrypoint](https://github.com/red-hat-data-services/agentic-starter-kits/blob/main/agents/claude-code/deployment/entrypoint.sh)
 
-The entrypoint runs `mlflow autolog claude` at startup and injects auth into the generated `.claude/settings.json`:
+The entrypoint sets the auth env vars and runs `mlflow autolog claude` at startup. The `kubernetes-namespaced` auth must be exported before the autolog command so it can authenticate with the MLflow server.
 
 ```bash
-mlflow autolog claude -u "${MLFLOW_TRACKING_URI}" -n "${MLFLOW_EXPERIMENT_NAME}" /workspace
+export MLFLOW_TRACKING_AUTH="kubernetes-namespaced"
+export MLFLOW_TRACKING_INSECURE_TLS="${MLFLOW_TRACKING_INSECURE_TLS:-false}"
 
-python3.12 -c '
-import json, os
-sf = "/workspace/.claude/settings.json"
-with open(sf) as f: s = json.load(f)
-env = s.setdefault("env", {})
-env["MLFLOW_TRACKING_AUTH"] = "kubernetes-namespaced"
-env["MLFLOW_WORKSPACE"] = os.environ["MLFLOW_WORKSPACE"]
-env["MLFLOW_TRACKING_INSECURE_TLS"] = "true"
-with open(sf, "w") as f: json.dump(s, f, indent=2)
-'
+mlflow autolog claude -d /workspace -u "${MLFLOW_TRACKING_URI}" -n "${MLFLOW_EXPERIMENT_NAME}"
 ```
 
 #### 6. Verify
@@ -251,4 +250,4 @@ oc exec deployment/<claude-deployment> -- bash -c '
 
 It works across all backends (Vertex AI, vLLM, OGX) with no changes to the tracing setup. It captures tool calls, token usage, latency, and session metadata out of the box. The only overhead is the stop-hook which runs after the session ends — zero impact on agent response times.
 
-When RHOAI ships MLflow 3.11, drop the Red Hat fork and use upstream `mlflow[kubernetes]>=3.11`.
+For MLflow 3.12+, use upstream `mlflow[kubernetes]>=3.12` — no Red Hat fork needed.

--- a/agents/claude-code/mlflow-tracing.md
+++ b/agents/claude-code/mlflow-tracing.md
@@ -198,13 +198,23 @@ oc adm policy add-role-to-user edit -z default -n <your-namespace>
 
 #### 3. Add MLflow env vars to the [deployment](https://github.com/red-hat-data-services/agentic-starter-kits/blob/main/agents/claude-code/deployment/deployment.yaml)
 
+For MLflow 3.12+:
+
 ```yaml
-# For MLflow 3.12+:
 - name: MLFLOW_TRACKING_URI
   value: "https://mlflow.<your-rhoai-namespace>.svc:8443/mlflow"  # namespace is commonly redhat-ods-applications
-# For MLflow 3.10.x:
-# - name: MLFLOW_TRACKING_URI
-#   value: "https://mlflow.<your-rhoai-namespace>.svc:8443"
+```
+
+For MLflow 3.10.x:
+
+```yaml
+- name: MLFLOW_TRACKING_URI
+  value: "https://mlflow.<your-rhoai-namespace>.svc:8443"  # namespace is commonly redhat-ods-applications
+```
+
+Common env vars (both versions):
+
+```yaml
 - name: MLFLOW_TRACKING_AUTH
   value: "kubernetes-namespaced"
 - name: MLFLOW_WORKSPACE
@@ -234,6 +244,7 @@ The entrypoint exports `kubernetes-namespaced` auth, runs `mlflow autolog claude
 export MLFLOW_TRACKING_AUTH="kubernetes-namespaced"
 export MLFLOW_TRACKING_INSECURE_TLS="${MLFLOW_TRACKING_INSECURE_TLS:-false}"
 
+# MLflow 3.12 uses -d flag; 3.10.x uses positional argument: mlflow autolog claude ... /workspace
 mlflow autolog claude -d /workspace -u "${MLFLOW_TRACKING_URI}" -n "${MLFLOW_EXPERIMENT_NAME}"
 
 # Inject auth into settings.json so the Python hook can authenticate

--- a/agents/claude-code/mlflow-tracing.md
+++ b/agents/claude-code/mlflow-tracing.md
@@ -169,19 +169,21 @@ The following must already be running on the cluster:
 
 Add Python and the MLflow SDK to the [Containerfile](https://github.com/red-hat-data-services/agentic-starter-kits/blob/main/agents/claude-code/deployment/Containerfile).
 
+MLflow offers two ways to set up Claude Code tracing: a Claude Code plugin (npm) and the MLflow Python SDK. On RHOAI, use the **Python SDK** approach because the `kubernetes-namespaced` auth plugin is only available in the Python SDK — the npm plugin does not support Kubernetes service account authentication.
+
+For MLflow 3.12+ (upstream):
+
+```dockerfile
+RUN microdnf install -y --nodocs python3.12 python3.12-pip
+RUN python3.12 -m pip install --no-cache-dir 'mlflow[kubernetes]>=3.12'
+```
+
 For MLflow 3.10.x (Red Hat fork required):
 
 ```dockerfile
 RUN microdnf install -y --nodocs python3.12 python3.12-pip
 RUN python3.12 -m pip install --no-cache-dir \
   'mlflow[kubernetes] @ git+https://github.com/red-hat-data-services/mlflow.git@v3.10.1+rhaiv.3'
-```
-
-For MLflow 3.12+ (upstream, no fork needed — requires npm for the Claude Code plugin):
-
-```dockerfile
-RUN microdnf install -y --nodocs python3.12 python3.12-pip nodejs npm
-RUN python3.12 -m pip install --no-cache-dir 'mlflow[kubernetes]>=3.12'
 ```
 
 #### 2. Grant RBAC to the pod's service account
@@ -220,13 +222,25 @@ oc adm policy add-role-to-user edit -z default -n <your-namespace>
 
 #### 5. Wire up autolog in the [entrypoint](https://github.com/red-hat-data-services/agentic-starter-kits/blob/main/agents/claude-code/deployment/entrypoint.sh)
 
-The entrypoint sets the auth env vars and runs `mlflow autolog claude` at startup. The `kubernetes-namespaced` auth must be exported before the autolog command so it can authenticate with the MLflow server.
+The entrypoint exports `kubernetes-namespaced` auth, runs `mlflow autolog claude` to configure the Python hook, then injects auth settings into the generated `.claude/settings.json` so the hook can authenticate at session end.
 
 ```bash
 export MLFLOW_TRACKING_AUTH="kubernetes-namespaced"
 export MLFLOW_TRACKING_INSECURE_TLS="${MLFLOW_TRACKING_INSECURE_TLS:-false}"
 
 mlflow autolog claude -d /workspace -u "${MLFLOW_TRACKING_URI}" -n "${MLFLOW_EXPERIMENT_NAME}"
+
+# Inject auth into settings.json so the Python hook can authenticate
+python3.12 -c '
+import json, os
+sf = "/workspace/.claude/settings.json"
+with open(sf) as f: s = json.load(f)
+env = s.setdefault("env", {})
+env["MLFLOW_TRACKING_AUTH"] = "kubernetes-namespaced"
+env["MLFLOW_WORKSPACE"] = os.environ["MLFLOW_WORKSPACE"]
+env["MLFLOW_TRACKING_INSECURE_TLS"] = os.environ.get("MLFLOW_TRACKING_INSECURE_TLS", "false")
+with open(sf, "w") as f: json.dump(s, f, indent=2)
+'
 ```
 
 #### 6. Verify
@@ -250,4 +264,4 @@ oc exec deployment/<claude-deployment> -- bash -c '
 
 It works across all backends (Vertex AI, vLLM, OGX) with no changes to the tracing setup. It captures tool calls, token usage, latency, and session metadata out of the box. The only overhead is the stop-hook which runs after the session ends — zero impact on agent response times.
 
-For MLflow 3.12+, use upstream `mlflow[kubernetes]>=3.12` — no Red Hat fork needed.
+For MLflow 3.12+, use upstream `mlflow[kubernetes]>=3.12` with the Python SDK approach — no Red Hat fork needed.

--- a/agents/claude-code/mlflow-tracing.md
+++ b/agents/claude-code/mlflow-tracing.md
@@ -169,27 +169,24 @@ The following must already be running on the cluster:
 
 Add Python and the MLflow SDK to the [Containerfile](https://github.com/red-hat-data-services/agentic-starter-kits/blob/main/agents/claude-code/deployment/Containerfile).
 
-MLflow 3.12+ uses a Claude Code plugin for tracing. This requires Python (for the MLflow CLI and `kubernetes-namespaced` auth) and Node.js/npm (for the plugin install). The `.npm` cache directory needs group-writable permissions for OpenShift's random UID.
+Use the MLflow Python SDK with the `kubernetes-namespaced` auth plugin. MLflow 3.12 is the recommended version — it uses the Python hook approach which handles kubernetes auth natively without requiring Node.js/npm.
 
-For MLflow 3.12+ (upstream):
+For MLflow 3.12 (upstream, recommended):
 
 ```dockerfile
-RUN microdnf install -y --nodocs python3.12 python3.12-pip nodejs npm
-RUN python3.12 -m pip install --no-cache-dir 'mlflow[kubernetes]>=3.12'
-
-# npm cache needs group-writable permissions for OpenShift random UID
-RUN mkdir -p /home/${USER_NAME}/.npm \
-    && chown -R ${USER_UID}:${USER_GID} /home/${USER_NAME}/.npm \
-    && chmod -R 775 /home/${USER_NAME}/.npm
+RUN microdnf install -y --nodocs python3.12 python3.12-pip
+RUN python3.12 -m pip install --no-cache-dir 'mlflow[kubernetes]==3.12.0'
 ```
 
 For MLflow 3.10.x (Red Hat fork required):
 
 ```dockerfile
-RUN microdnf install -y --nodocs python3.12 python3.12-pip nodejs npm
+RUN microdnf install -y --nodocs python3.12 python3.12-pip
 RUN python3.12 -m pip install --no-cache-dir \
   'mlflow[kubernetes] @ git+https://github.com/red-hat-data-services/mlflow.git@v3.10.1+rhaiv.3'
 ```
+
+> **Note:** MLflow 3.13+ switches to an npm plugin which does not yet support RHOAI's `kubernetes-namespaced` auth or `x-mlflow-workspace` header. Use 3.12 until upstream adds support.
 
 #### 2. Grant RBAC to the pod's service account
 
@@ -227,13 +224,25 @@ oc adm policy add-role-to-user edit -z default -n <your-namespace>
 
 #### 5. Wire up autolog in the [entrypoint](https://github.com/red-hat-data-services/agentic-starter-kits/blob/main/agents/claude-code/deployment/entrypoint.sh)
 
-The entrypoint exports `kubernetes-namespaced` auth and runs `mlflow autolog claude` which installs the Claude Code plugin and configures tracing. The auth env vars must be exported before the command so it can authenticate with the MLflow server during setup.
+The entrypoint exports `kubernetes-namespaced` auth, runs `mlflow autolog claude` to configure the Python hook, then injects auth settings into the generated `.claude/settings.json`.
 
 ```bash
 export MLFLOW_TRACKING_AUTH="kubernetes-namespaced"
 export MLFLOW_TRACKING_INSECURE_TLS="${MLFLOW_TRACKING_INSECURE_TLS:-false}"
 
 mlflow autolog claude -d /workspace -u "${MLFLOW_TRACKING_URI}" -n "${MLFLOW_EXPERIMENT_NAME}"
+
+# Inject auth into settings.json so the Python hook can authenticate
+python3.12 -c '
+import json, os
+sf = "/workspace/.claude/settings.json"
+with open(sf) as f: s = json.load(f)
+env = s.setdefault("env", {})
+env["MLFLOW_TRACKING_AUTH"] = "kubernetes-namespaced"
+env["MLFLOW_WORKSPACE"] = os.environ["MLFLOW_WORKSPACE"]
+env["MLFLOW_TRACKING_INSECURE_TLS"] = os.environ.get("MLFLOW_TRACKING_INSECURE_TLS", "false")
+with open(sf, "w") as f: json.dump(s, f, indent=2)
+'
 ```
 
 #### 6. Verify
@@ -257,4 +266,4 @@ oc exec deployment/<claude-deployment> -- bash -c '
 
 It works across all backends (Vertex AI, vLLM, OGX) with no changes to the tracing setup. It captures tool calls, token usage, latency, and session metadata out of the box. The only overhead is the stop-hook which runs after the session ends — zero impact on agent response times.
 
-For MLflow 3.12+, use upstream `mlflow[kubernetes]>=3.12` with the Claude Code plugin — no Red Hat fork needed.
+For MLflow 3.12, use upstream `mlflow[kubernetes]==3.12.0` with the Python hook — no Red Hat fork needed, no Node.js/npm required.


### PR DESCRIPTION
## Summary

Updates the MLflow tracing doc for upstream MLflow 3.12 using the Python SDK approach.

**Changes:**
- MLflow 3.12.0 upstream works with the Python hook — no Red Hat fork needed, no nodejs/npm required
- Both 3.10 (Red Hat fork) and 3.12 (upstream) install instructions included
- `MLFLOW_TRACKING_AUTH=kubernetes-namespaced` must be exported before `mlflow autolog claude`
- Auth settings injected into `.claude/settings.json` so the Python hook can authenticate
- Tracking URI updated to include `/mlflow` prefix for 3.12+ servers
- Note added: MLflow 3.13+ switches to an npm plugin which does not yet support RHOAI's kubernetes auth or workspace header — pin to 3.12.0