### PR TITLE
docs(openclaw): Add guide for OGX→vLLM inference path

### DIFF
--- a/agents/openclaw/deployment/README.md
+++ b/agents/openclaw/deployment/README.md
@@ -25,20 +25,7 @@ npm install && npm run build && npm run dev
 
 See [docs/installer-deployment.md](docs/installer-deployment.md) for the full walkthrough, validation, and rollback procedures.
 
-### Option B: Kustomize
-
-```bash
-oc new-project my-openclaw
-
-# Copy and customize the example overlay
-cp -r overlays/example overlays/my-env
-# Edit overlays/my-env/configmap-patch.yaml with your vLLM endpoint
-# Edit overlays/my-env/kustomization.yaml with your namespace and storage class
-
-oc apply -k overlays/my-env
-```
-
-### Option C: Direct YAML apply
+### Option B: Raw Manifests (Kustomize or direct apply)
 
 ```bash
 oc new-project my-openclaw
@@ -48,6 +35,8 @@ oc new-project my-openclaw
 
 oc apply -k manifests/
 ```
+
+See [docs/raw-deployment.md](docs/raw-deployment.md) for the full walkthrough, configuration details, and troubleshooting.
 
 ## Architecture
 
@@ -94,6 +83,7 @@ oc apply -k manifests/
 | Document | Description |
 |----------|-------------|
 | [docs/installer-deployment.md](docs/installer-deployment.md) | Full deployment guide: prerequisites, validation, rollback, appendix |
+| [docs/raw-deployment.md](docs/raw-deployment.md) | Step-by-step guide for deploying with raw Kustomize manifests |
 | [docs/troubleshooting.md](docs/troubleshooting.md) | Common issues and fixes (route 503, model override, heartbeat, config clobber) |
 | [docs/model-compatibility.md](docs/model-compatibility.md) | Model testing results for agentic tool-calling |
 

--- a/agents/openclaw/deployment/docs/installer-deployment.md
+++ b/agents/openclaw/deployment/docs/installer-deployment.md
@@ -121,7 +121,7 @@ Now using project "<your-name>-openclaw" on server "https://api.<your-cluster>:4
 
 ```bash
 git clone https://github.com/sallyom/claw-installer.git
-cd openclaw-installer
+cd claw-installer
 npm install && npm run build && npm run dev
 ```
 

--- a/agents/openclaw/deployment/docs/installer-deployment.md
+++ b/agents/openclaw/deployment/docs/installer-deployment.md
@@ -203,7 +203,13 @@ Expected output:
 
 ### Step 6: Approve device pairing
 
-After SSO login, the Control UI requires a one-time device pairing. Get the request ID from the UI prompt, then:
+After SSO login, the Control UI requires a one-time device pairing. To find the pending request ID, list devices inside the pod:
+
+```bash
+oc exec deployment/openclaw -n <namespace> -c gateway -- openclaw devices list
+```
+
+Look for the **Pending** section in the output — the request ID is in the first column. Then approve it:
 
 ```bash
 oc exec deployment/openclaw -n <namespace> -c gateway -- \

--- a/agents/openclaw/deployment/docs/raw-deployment.md
+++ b/agents/openclaw/deployment/docs/raw-deployment.md
@@ -65,7 +65,7 @@ Edit `manifests/02-configmap.yaml` and replace the placeholder values:
 - `YOUR-VLLM-OR-OGX-ENDPOINT` — your vLLM or OGX endpoint hostname
 - `YOUR-MODEL-ID` — the model ID from the `/v1/models` query above
 
-**Via OGX gateway** — OGX prefixes model IDs with `vllm/`, so use that full ID:
+**Via OGX gateway** — OGX prefixes model IDs with `vllm/`, so `agents.defaults.model` ends up as `vllm/vllm/<model>` (provider prefix + OGX model ID — the double `vllm/` is intentional):
 
 ```json
 "agents": {
@@ -173,7 +173,6 @@ oc port-forward deployment/openclaw 18789:18789 -n my-openclaw
 Open <http://localhost:18789> in your browser. Paste the gateway token from Step 2 when prompted.
 
 On first connect, device pairing is auto-approved for local connections. You should see the chat interface ready to use.
-
 
 ## References
 

--- a/agents/openclaw/deployment/docs/raw-deployment.md
+++ b/agents/openclaw/deployment/docs/raw-deployment.md
@@ -54,7 +54,7 @@ curl -s https://<your-endpoint>/v1/models | python3 -m json.tool
 }
 ```
 
-Use the **exact** `id` value from the response in your ConfigMap — both in `agents.defaults.model` and in `models.providers.vllm.models[].id`. Getting this wrong produces a `404 Model not found` error at runtime.
+Use the **exact** `id` value from the response as `models[].id` in your ConfigMap. For `agents.defaults.model`, prepend `vllm/` (the provider name) to the model ID.
 
 ## Configuration
 
@@ -111,15 +111,25 @@ Edit `manifests/02-configmap.yaml` and replace the placeholder values:
 
 Notice the `agents.defaults.model` field uses the format `<provider>/<model-id>`, while the `models[].id` is the raw ID sent to the endpoint in API requests.
 
-### Step 2: Set the gateway token
+### Step 2: Set secrets
 
-You might want to update `OPENCLAW_GATEWAY_TOKEN` in `manifests/01-secret.yaml` with a generated token.
+Edit `manifests/01-secret.yaml`:
 
-You will need this token to authenticate with the Control UI.
+- `OPENCLAW_GATEWAY_TOKEN` — replace `CHANGE-ME` with a token for the Control UI
+- `VLLM_API_KEY` — set to your vLLM/OGX API key, or leave as `not-needed` for unauthenticated endpoints
 
 ### Step 3: Check the storage class
 
-Edit `manifests/03-pvc.yaml` if your cluster uses a different block storage class than `gp3-csi`:
+Edit `manifests/03-pvc.yaml` if your cluster uses a different block storage class than `gp3-csi`.
+
+**Alternative: use an overlay** to keep the base manifests untouched:
+
+```bash
+cp -r overlays/example overlays/my-env
+# Edit overlays/my-env/configmap-patch.yaml with your endpoint + model
+# Edit overlays/my-env/kustomization.yaml with your namespace + storage class
+oc apply -k overlays/my-env
+```
 
 ## Deployment
 

--- a/agents/openclaw/deployment/docs/raw-deployment.md
+++ b/agents/openclaw/deployment/docs/raw-deployment.md
@@ -1,0 +1,174 @@
+# Deploying OpenClaw on OpenShift with Raw Manifests
+
+> Tested: 2026-06-10 on OpenShift 4.19 (ROSA) with OpenClaw 2026.6.5, vLLM via OGX 1.0.2
+
+Deploy [OpenClaw](https://github.com/openclaw/openclaw) on OpenShift using raw Kustomize manifests. This approach gives full control over the deployment configuration without the openclaw-installer abstraction. See [installer-deployment.md](installer-deployment.md).
+
+## Prerequisites
+
+- **OpenShift 4.17+** with namespace-scoped access (`oc login`)
+- **Block storage class** (gp3-csi, managed-csi, thin-csi) — not NFS (SQLite requires POSIX file locking)
+- **A vLLM-compatible model endpoint** — either:
+  - Direct vLLM server with `--enable-auto-tool-choice --tool-call-parser openai`
+  - OGX gateway proxying to vLLM (see [model-compatibility.md](model-compatibility.md) for tested models)
+
+### Verify prerequisites
+
+```bash
+oc version
+oc whoami
+oc get storageclass
+```
+
+### Find your model ID
+
+Query your model endpoint to discover the exact model ID. The ID format differs depending on whether you use vLLM directly or through OGX:
+
+```bash
+curl -s https://<your-endpoint>/v1/models | python3 -m json.tool
+```
+
+**Direct vLLM** returns the raw model name:
+
+```text
+{
+  "data": [
+    {
+      "id": "gpt-oss-120b",
+      "owned_by": "vllm"
+    }
+  ]
+}
+```
+
+**OGX gateway** prefixes the model with `vllm/`:
+
+```text
+{
+  "data": [
+    {
+      "id": "vllm/gpt-oss-120b",
+      "owned_by": "ogx"
+    }
+  ]
+}
+```
+
+Use the **exact** `id` value from the response in your ConfigMap — both in `agents.defaults.model` and in `models.providers.vllm.models[].id`. Getting this wrong produces a `404 Model not found` error at runtime.
+
+## Configuration
+
+### Step 1: Set the model endpoint
+
+Edit `manifests/02-configmap.yaml` and replace the placeholder values:
+
+- `YOUR-VLLM-OR-OGX-ENDPOINT` — your vLLM or OGX endpoint hostname
+- `YOUR-MODEL-ID` — the model ID from the `/v1/models` query above
+
+**Via OGX gateway** — OGX prefixes model IDs with `vllm/`, so use that full ID:
+
+```json
+"agents": {
+  "defaults": {
+    "model": "vllm/vllm/gpt-oss-120b"
+  }
+},
+"models": {
+  "providers": {
+    "vllm": {
+      "baseUrl": "https://ogx-my-namespace.apps.my-cluster.example.com/v1",
+      "apiKey": "not-needed",
+      "models": [{
+        "id": "vllm/gpt-oss-120b",
+        "name": "vllm/gpt-oss-120b"
+      }]
+    }
+  }
+}
+```
+
+**Direct vLLM**
+
+```json
+"agents": {
+  "defaults": {
+    "model": "vllm/gpt-oss-120b"
+  }
+},
+"models": {
+  "providers": {
+    "vllm": {
+      "baseUrl": "https://vllm-my-model.apps.my-cluster.example.com/v1",
+      "apiKey": "not-needed",
+      "models": [{
+        "id": "gpt-oss-120b",
+        "name": "gpt-oss-120b"
+      }]
+    }
+  }
+}
+```
+
+Notice the `agents.defaults.model` field uses the format `<provider>/<model-id>`, while the `models[].id` is the raw ID sent to the endpoint in API requests.
+
+### Step 2: Set the gateway token
+
+You might want to update `OPENCLAW_GATEWAY_TOKEN` in `manifests/01-secret.yaml` with a generated token.
+
+You will need this token to authenticate with the Control UI.
+
+### Step 3: Check the storage class
+
+Edit `manifests/03-pvc.yaml` if your cluster uses a different block storage class than `gp3-csi`:
+
+## Deployment
+
+```bash
+oc new-project my-openclaw
+
+oc apply -k manifests/ -n my-openclaw
+```
+
+### Verify startup
+
+```bash
+oc get pods -n my-openclaw
+```
+
+Expected: `1/1 Running` (init container completes, gateway starts).
+
+```bash
+oc logs deployment/openclaw -c gateway -n my-openclaw --tail=20
+```
+
+Expected output:
+
+```text
+[gateway] loading configuration…
+[gateway] resolving authentication…
+[gateway] starting...
+[gateway] agent model: vllm/<your-model> (thinking=off, fast=off)
+[gateway] http server listening (... plugins; ...s)
+[gateway] ready
+```
+
+### Access the Control UI
+
+Port-forward to access locally:
+
+```bash
+oc port-forward deployment/openclaw 18789:18789 -n my-openclaw
+```
+
+Open <http://localhost:18789> in your browser. Paste the gateway token from Step 2 when prompted.
+
+On first connect, device pairing is auto-approved for local connections. You should see the chat interface ready to use.
+
+
+## References
+
+| Resource | URL |
+|----------|-----|
+| OpenClaw vLLM Provider Docs | <https://docs.openclaw.ai/providers/vllm> |
+| OpenClaw K8s Deployment Scripts | <https://github.com/openclaw/openclaw/tree/main/scripts/k8s> |
+| OpenClaw Upstream | <https://github.com/openclaw/openclaw> |

--- a/agents/openclaw/deployment/manifests/02-configmap.yaml
+++ b/agents/openclaw/deployment/manifests/02-configmap.yaml
@@ -5,11 +5,15 @@ metadata:
   labels:
     app: openclaw
 data:
+  # YOUR-MODEL-ID: use the exact "id" from your endpoint's /v1/models response.
+  #   Direct vLLM returns e.g. "gpt-oss-120b"
+  #   OGX returns e.g. "vllm/gpt-oss-120b" (includes vllm/ prefix)
+  # See docs/raw-deployment.md for details.
   openclaw.json: |
     {
       "gateway": {
         "port": 18789,
-        "bind": "0.0.0.0",
+        "bind": "lan",
         "mode": "local",
         "auth": {
           "mode": "token"
@@ -18,8 +22,7 @@ data:
       "channels": {},
       "agents": {
         "defaults": {
-          "heartbeat": {},
-          "model": "openai-compat/gpt-oss-20b",
+          "model": "vllm/YOUR-MODEL-ID",
           "sandbox": {
             "mode": "off"
           }
@@ -28,14 +31,14 @@ data:
       "models": {
         "mode": "replace",
         "providers": {
-          "openai-compat": {
-            "baseUrl": "https://YOUR-VLLM-ENDPOINT/v1",
+          "vllm": {
+            "baseUrl": "https://YOUR-VLLM-OR-OGX-ENDPOINT/v1",
             "api": "openai-completions",
             "apiKey": "not-needed",
             "models": [
               {
-                "id": "gpt-oss-20b",
-                "name": "gpt-oss-20b",
+                "id": "YOUR-MODEL-ID",
+                "name": "YOUR-MODEL-ID",
                 "reasoning": false,
                 "input": ["text"],
                 "contextWindow": 32768,

--- a/agents/openclaw/deployment/manifests/04-deployment.yaml
+++ b/agents/openclaw/deployment/manifests/04-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsNonRoot: true
       initContainers:
         - name: init-config
-          image: ghcr.io/openclaw/openclaw:latest
+          image: ghcr.io/openclaw/openclaw@sha256:037f49ba1595be9502fb345138d727cd0cfaecf1392cbe0cfe053fb4681386cd
           command:
             - sh
             - -c
@@ -44,7 +44,8 @@ spec:
                 - ALL
       containers:
         - name: gateway
-          image: ghcr.io/openclaw/openclaw:latest
+          image: ghcr.io/openclaw/openclaw@sha256:037f49ba1595be9502fb345138d727cd0cfaecf1392cbe0cfe053fb4681386cd
+          # Explicit entrypoint required — the image default doesn't start the gateway on OpenShift
           command:
             - node
             - /app/dist/index.js

--- a/agents/openclaw/deployment/manifests/04-deployment.yaml
+++ b/agents/openclaw/deployment/manifests/04-deployment.yaml
@@ -25,15 +25,14 @@ spec:
             - sh
             - -c
             - |
-              cp /config/openclaw.json /data/.openclaw/openclaw.json
-              chgrp -R 0 /data/.openclaw
-              chmod -R g=u /data/.openclaw
+              mkdir -p /home/node/.openclaw/workspace
+              cp /config/openclaw.json /home/node/.openclaw/openclaw.json
               echo "Config initialized"
           volumeMounts:
             - name: config
               mountPath: /config
             - name: data
-              mountPath: /data/.openclaw
+              mountPath: /home/node/.openclaw
           resources:
             limits:
               memory: 128Mi
@@ -46,20 +45,34 @@ spec:
       containers:
         - name: gateway
           image: ghcr.io/openclaw/openclaw:latest
+          command:
+            - node
+            - /app/dist/index.js
+            - gateway
+            - run
           ports:
             - containerPort: 18789
               protocol: TCP
           env:
+            - name: HOME
+              value: /home/node
+            - name: OPENCLAW_CONFIG_DIR
+              value: /home/node/.openclaw
+            - name: NODE_ENV
+              value: production
             - name: OPENCLAW_GATEWAY_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: openclaw-secrets
                   key: OPENCLAW_GATEWAY_TOKEN
-            - name: OPENCLAW_HOME
-              value: /data/.openclaw
+            - name: VLLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw-secrets
+                  key: VLLM_API_KEY
           volumeMounts:
             - name: data
-              mountPath: /data/.openclaw
+              mountPath: /home/node/.openclaw
           resources:
             requests:
               memory: 256Mi

--- a/agents/openclaw/deployment/overlays/example/configmap-patch.yaml
+++ b/agents/openclaw/deployment/overlays/example/configmap-patch.yaml
@@ -31,8 +31,8 @@ data:
             "apiKey": "not-needed",
             "models": [
               {
-                "id": "vllm/my-model",
-                "name": "vllm/my-model",
+                "id": "my-model",
+                "name": "my-model",
                 "reasoning": false,
                 "input": ["text"],
                 "contextWindow": 32768,

--- a/agents/openclaw/deployment/overlays/example/configmap-patch.yaml
+++ b/agents/openclaw/deployment/overlays/example/configmap-patch.yaml
@@ -7,7 +7,7 @@ data:
     {
       "gateway": {
         "port": 18789,
-        "bind": "0.0.0.0",
+        "bind": "lan",
         "mode": "local",
         "auth": {
           "mode": "token"
@@ -16,8 +16,7 @@ data:
       "channels": {},
       "agents": {
         "defaults": {
-          "heartbeat": {},
-          "model": "openai-compat/my-model",
+          "model": "vllm/my-model",
           "sandbox": {
             "mode": "off"
           }
@@ -26,14 +25,14 @@ data:
       "models": {
         "mode": "replace",
         "providers": {
-          "openai-compat": {
+          "vllm": {
             "baseUrl": "https://my-vllm-endpoint.apps.my-cluster.example.com/v1",
             "api": "openai-completions",
             "apiKey": "not-needed",
             "models": [
               {
-                "id": "my-model",
-                "name": "my-model",
+                "id": "vllm/my-model",
+                "name": "vllm/my-model",
                 "reasoning": false,
                 "input": ["text"],
                 "contextWindow": 32768,


### PR DESCRIPTION
## Summary
- **Add deployment guide** (`docs/raw-deployment.md`) for the OpenClaw → OGX → vLLM path, tested end-to-end with port-forwarding and interacting through OpenClaw Chat UI.
- **Update Raw manifest deployment** for OpenClaw on OpenShift — Openclaw installed through Raw manifests resulted in a crashing `openclaw gateway` pod. Updated them in reference to [official upstream k8s scripts](https://github.com/openclaw/openclaw/tree/main/scripts/k8s) and [OpenClaw VLLM setup](https://docs.openclaw.ai/providers/vllm)

## Test plan

- [x] Deployed openclaw in OpenShift 4.19 (ROSA) with existing ogx and vllm setup 
       (
- openclaw image : `ghcr.io/openclaw/openclaw@sha256:037f49ba1595be9502fb345138d727cd0cfaecf1392cbe0cfe053fb4681386cd`, 
- ogx image : `quay.io/rhoai/odh-ogx-core-rhel9:rhoai-3.5-ea.1`, 
- vllm image : `registry.redhat.io/rhaii/vllm-cuda-rhel9:3.4.0-1777444689`) 
- [x] Port-forwarded and accessed Control UI at `http://localhost:18789`
- [x] Tested tool calling capacity of OpenClaw → OGX → vLLM through the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)