### PR TITLE
docs: improve Claude Code deployment from end-to-end vLLM walkthrough

### DIFF
--- a/agents/claude-code/deployment/Containerfile
+++ b/agents/claude-code/deployment/Containerfile
@@ -58,10 +58,10 @@ RUN microdnf install -y --nodocs \
     && microdnf clean all \
     && rm -rf /var/cache/yum
 
-# Install MLflow with Kubernetes auth plugin (Red Hat fork for RHOAI 3.4)
-# Replace with mlflow[kubernetes]>=3.11 when RHOAI ships upstream MLflow 3.11
-RUN python3.12 -m pip install --no-cache-dir \
-  'mlflow[kubernetes] @ git+https://github.com/red-hat-data-services/mlflow.git@v3.10.1+rhaiv.3'
+# Install MLflow with Kubernetes auth plugin for RHOAI tracing (optional)
+# Note: MLflow 3.13+ switches to an npm plugin that does not yet support
+# RHOAI's kubernetes-namespaced auth. Pin to 3.12 until upstream adds support.
+RUN python3.12 -m pip install --no-cache-dir 'mlflow[kubernetes]==3.12.0'
 
 # =============================================================================
 # Create Non-Root User

--- a/agents/claude-code/deployment/Containerfile
+++ b/agents/claude-code/deployment/Containerfile
@@ -51,8 +51,17 @@ RUN microdnf install -y --nodocs \
         git \
         curl \
         jq \
+        python3.12 \
+        python3.12-pip \
+    && ln -sf /usr/bin/python3.12 /usr/bin/python3 \
+    && ln -sf /usr/bin/python3.12 /usr/bin/python \
     && microdnf clean all \
     && rm -rf /var/cache/yum
+
+# Install MLflow with Kubernetes auth plugin (Red Hat fork for RHOAI 3.4)
+# Replace with mlflow[kubernetes]>=3.11 when RHOAI ships upstream MLflow 3.11
+RUN python3.12 -m pip install --no-cache-dir \
+  'mlflow[kubernetes] @ git+https://github.com/red-hat-data-services/mlflow.git@v3.10.1+rhaiv.3'
 
 # =============================================================================
 # Create Non-Root User

--- a/agents/claude-code/deployment/README.md
+++ b/agents/claude-code/deployment/README.md
@@ -10,7 +10,7 @@ A step-by-step guide to build, test, and deploy the Claude Code container image.
 
 - `podman` installed locally (on macOS, you also need to run `podman machine init` and `podman machine start` before building)
 - `oc` CLI installed and logged into your OpenShift cluster
-- An Anthropic API key OR a GCP service account key for Vertex AI
+- An Anthropic API key, a GCP service account key for Vertex AI, or a vLLM/OGX endpoint (no Anthropic credentials needed)
 - The Containerfile and entrypoint.sh files
 
 ---
@@ -66,6 +66,13 @@ oc apply -f deployment.yaml
 
 ```bash
 oc start-build claude-code --from-dir=. --follow
+```
+
+**Rebuilding:** If you rebuild the image after the initial deployment (e.g., after modifying the Containerfile), the running pod will not pick up the new image automatically. Re-apply the deployment manifest and restart:
+
+```bash
+oc apply -f deployment.yaml
+oc rollout restart deployment/claude-code
 ```
 
 ### 6. Wait for deployment and test
@@ -242,6 +249,13 @@ oc rollout restart deployment/claude-code-vertex
 oc start-build claude-code --from-dir=. --follow
 ```
 
+**Rebuilding:** If you rebuild the image after the initial deployment (e.g., after modifying the Containerfile), the running pod will not pick up the new image automatically. Re-apply the deployment manifest and restart:
+
+```bash
+oc apply -f deployment-vertex.yaml
+oc rollout restart deployment/claude-code-vertex
+```
+
 ### 6. Wait for deployment and test
 
 ```bash
@@ -339,10 +353,24 @@ This option connects Claude Code directly to a vLLM server that supports the Ant
 ### Prerequisites
 
 - A vLLM server with `/v1/messages` endpoint support
-- The vLLM model must have a **context window of at least 32K tokens** (Claude Code's system prompt is ~23K tokens)
+- The vLLM model must have a **context window of at least 32K tokens** (Claude Code's system prompt is ~23K tokens). However, for realistic coding work, **128K+ tokens is strongly recommended** since CLAUDE.md, skills, file listings, and conversation easily push input past 100K tokens
 - Network connectivity from your OpenShift cluster to the vLLM server
 
 **Important**: Claude Code internally uses model aliases (haiku, sonnet, opus) for certain operations. When using vLLM, you must override these aliases using environment variables (see step 3 below), otherwise Claude Code will attempt to use Anthropic model names which will result in 404 errors.
+
+**Network connectivity**: If the vLLM server is outside the cluster (e.g., on EC2 or another cloud), verify that the pod can reach it. Common causes of connection failure include security group rules, network policies, and firewalls. To test connectivity from inside the pod:
+
+```bash
+# Find the cluster's egress IP
+oc exec deployment/claude-code-vllm -- curl -s ifconfig.me
+
+# Test connectivity to the vLLM server
+oc exec deployment/claude-code-vllm -- curl -s -o /dev/null -w "%{http_code}" http://YOUR_VLLM_HOST:8000/v1/models
+```
+
+If the vLLM server uses IP-based access rules, add the cluster egress IP to the allow list (e.g., AWS security group inbound rule on TCP port 8000).
+
+**Note:** Claude Code is designed and tested for use with Anthropic's Claude models. Open source models may produce lower quality results, particularly for complex multi-step tasks. Including language runtimes in the container (see [Extending the Container Image](#extending-the-container-image)) helps because the agent can run tests and catch its own mistakes.
 
 ### 1. Build and test locally
 
@@ -379,6 +407,24 @@ Edit `deployment-vllm.yaml` and update:
   - `ANTHROPIC_DEFAULT_OPUS_MODEL`: Set to your vLLM model ID
 - `claude-vllm-settings` ConfigMap: Set the `model` field to your model ID
 
+**Context window configuration**: Claude Code defaults to a 180K context window, which causes failures on models with smaller windows (e.g., 131K). Configure these three env vars in the `claude-vllm-settings` ConfigMap or the Deployment env section:
+
+- `CLAUDE_CODE_AUTO_COMPACT_WINDOW`: Set to your model's actual context window in tokens (e.g., `131072` for a 131K model). Do not pre-subtract output tokens.
+- `CLAUDE_CODE_MAX_OUTPUT_TOKENS`: Set to your desired output budget (e.g., `28000`).
+- `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`: Controls when autocompaction triggers. Set so that the remaining headroom exceeds the output budget. Formula: `percentage <= (context_window - max_output_tokens) / context_window * 100`
+
+Example values:
+
+| Model | Context | AUTO_COMPACT_WINDOW | MAX_OUTPUT_TOKENS | AUTOCOMPACT_PCT |
+|-------|---------|--------------------|--------------------|-----------------|
+| RedHatAI/Qwen3.6-35B-A3B-NVFP4 | 131K | 131072 | 28000 | 75 |
+| Qwen/Qwen3-235B-A22B | 131K | 131072 | 28000 | 75 |
+| openai/gpt-oss-120b | 131K | 131072 | 28000 | 75 |
+| ibm-granite/granite-4.1-8b-instruct | 524K | 524288 | 64000 | 83 |
+| meta-llama/Llama-4-Maverick-17B-128E | 1,048K | 1048576 | 64000 | 83 |
+
+Models with 500K+ context can use the default 83% threshold. Models with smaller context windows need a lower percentage to leave sufficient headroom for output tokens.
+
 ### 4. Apply the deployment manifest
 
 ```bash
@@ -389,6 +435,13 @@ oc apply -f deployment-vllm.yaml
 
 ```bash
 oc start-build claude-code --from-dir=. --follow
+```
+
+**Rebuilding:** If you rebuild the image after the initial deployment (e.g., after modifying the Containerfile), the running pod will not pick up the new image automatically. Re-apply the deployment manifest and restart:
+
+```bash
+oc apply -f deployment-vllm.yaml
+oc rollout restart deployment/claude-code-vllm
 ```
 
 ### 6. Wait for deployment and test
@@ -505,9 +558,11 @@ This option uses OGX (from RHOAI) as an API gateway between Claude Code and vLLM
 
 - **OGX with PostgreSQL**: Some versions of OGX require PostgreSQL as the storage backend. Check your OGX version's requirements and deploy accordingly before proceeding.
 - A vLLM server accessible from OGX
-- The vLLM model must have a **context window of at least 32K tokens** (Claude Code's system prompt is ~23K tokens)
+- The vLLM model must have a **context window of at least 32K tokens** (Claude Code's system prompt is ~23K tokens). However, for realistic coding work, **128K+ tokens is strongly recommended** since CLAUDE.md, skills, file listings, and conversation easily push input past 100K tokens
 
 **Important**: Claude Code internally uses model aliases (haiku, sonnet, opus) for certain operations. When using OGX with vLLM, you must override these aliases using environment variables (see step 1 below), otherwise Claude Code will attempt to use Anthropic model names which will result in 404 errors.
+
+**Note:** Claude Code is designed and tested for use with Anthropic's Claude models. Open source models may produce lower quality results, particularly for complex multi-step tasks. Including language runtimes in the container (see [Extending the Container Image](#extending-the-container-image)) helps because the agent can run tests and catch its own mistakes.
 
 ### 1. Update the Claude Code deployment manifest
 
@@ -533,6 +588,13 @@ oc apply -f deployment-ogx-vllm.yaml
 
 ```bash
 oc start-build claude-code --from-dir=. --follow
+```
+
+**Rebuilding:** If you rebuild the image after the initial deployment (e.g., after modifying the Containerfile), the running pod will not pick up the new image automatically. Re-apply the deployment manifest and restart:
+
+```bash
+oc apply -f deployment-ogx-vllm.yaml
+oc rollout restart deployment/claude-code-ogx-vllm
 ```
 
 ### 4. Wait for deployment and test
@@ -661,21 +723,33 @@ oc logs deployment/ogx --tail=50
 
 ### SKIP_PERMISSIONS
 
-The deployment manifests set `SKIP_PERMISSIONS=true` by default, which passes `--dangerously-skip-permissions` to Claude Code. This disables all file-system write permission prompts.
+The deployment manifests set `SKIP_PERMISSIONS=true` by default, which passes `--dangerously-skip-permissions` to Claude Code. This disables all permission prompts, including file-system write confirmations and confirmation of potentially destructive operations (e.g., `git push --force`).
 
 **Why it's enabled by default:**
 
 - The container runs as non-root with dropped capabilities and seccomp profiles
 - Claude only has access to the isolated `/workspace` PVC, not host filesystems
 - Permission prompts don't work well in non-interactive `oc exec` scenarios
+- One of the main advantages of running Claude Code in an isolated container is enabling less-interrupted workflows
 
-**When to disable:**
+**Tradeoffs to consider:**
 
-- If you mount sensitive host directories into the container
-- If you're running in a less isolated environment
-- If you want Claude to prompt before file operations
+Running in an isolated container removes much of the reason you would normally keep permission checks in place: the container cannot access data that is not explicitly mounted into it. However, skipping permissions also disables guardrails against destructive operations on external services the agent can reach, such as force-pushing to a Git remote or making unintended API calls via MCP servers. If you are running interactively and want an extra layer of confirmation, you can disable `SKIP_PERMISSIONS`. But for headless or automated usage, permission prompts are not practical, and you should rely on the repository safeguards described below instead.
 
 To disable, set `SKIP_PERMISSIONS=false` in the deployment manifest or remove the environment variable entirely.
+
+### Repository Safeguards
+
+When an AI agent has push access to a Git repository, you should ensure the repository itself has protections against mistakes. This is especially important when permission checks are disabled (`SKIP_PERMISSIONS=true`) and when using less capable models that are more likely to make errors such as committing directly to main, force-pushing, or merging their own PRs.
+
+**Recommended protections:**
+
+- **Branch protection rules**: Protect your main/default branch so that direct pushes are blocked. This forces all changes through pull requests. On GitHub, configure this under Settings > Branches > Branch protection rules.
+- **Required pull request reviews**: Require at least one approval from someone other than the PR author before merging. This prevents the agent (or anyone) from opening and immediately merging a PR without human review.
+- **Limit PAT scope**: When creating the GitHub Personal Access Token used by the agent, grant only the minimum permissions needed. For example, if the agent only needs to open PRs but not merge them, do not grant the PAT merge permissions. See [GitHub's documentation on token scopes](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) for fine-grained token options.
+- **Status checks**: Require CI checks (tests, linting) to pass before a PR can be merged, so that broken code cannot be merged even if a review is approved.
+
+These protections apply regardless of whether you are using Claude Code or any other AI coding tool. They are standard best practices for collaborative development, but become critical when an automated agent has commit and push access.
 
 ---
 
@@ -737,6 +811,24 @@ MCP (Model Context Protocol) servers extend Claude Code with additional tools. M
 }
 ```
 
+**Common MCP server examples:**
+
+GitHub (official remote MCP server, requires a [Personal Access Token](https://github.com/settings/tokens)):
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_PAT}"
+      }
+    }
+  }
+}
+```
+
 **Injecting secrets:** Environment variables like `${API_TOKEN}` can be injected via Kubernetes Secrets in the Deployment env section:
 
 ```yaml
@@ -758,7 +850,7 @@ Avoid hardcoding credentials directly in the ConfigMap JSON.
 | `sse` | Legacy remote servers | Network access to endpoint |
 | `command` | Local process-based servers | Executable must exist in container |
 
-**Note**: The lean UBI base image only includes `git`, `curl`, `jq`, and `bash`. Command-based MCP servers requiring `npx`, `python`, or other runtimes will not work unless you extend the image.
+**Note**: The base image includes `git`, `curl`, `jq`, `bash`, and `python3`. Command-based MCP servers requiring `npx` or other runtimes will not work unless you extend the image (see [Extending the Container Image](#extending-the-container-image)).
 
 **Option 1: Mounted config file**
 
@@ -838,6 +930,51 @@ data:
     {
       "model": "your-model-id"
     }
+```
+
+### Extending the Container Image
+
+The base image includes `git`, `curl`, `jq`, `bash`, and `python3`, which is sufficient for basic tasks. For real coding workflows, you will likely need additional language runtimes and tools so the agent can run tests, lint code, and build projects. Including the runtimes your project uses significantly improves agent output quality since the agent can run tests and catch its own mistakes.
+
+The following example adds common development tools. Remove any you don't need:
+
+```dockerfile
+# In the "Install System Dependencies" section of the Containerfile
+RUN microdnf install -y --nodocs \
+        git \
+        curl \
+        jq \
+        python3.12 \
+        python3.12-pip \
+        # Build tools
+        make \
+        gcc \
+        tar \
+        unzip \
+        patch \
+        diffutils \
+        which \
+        # Node.js (includes npm)
+        nodejs \
+        # Go
+        golang \
+        # Java
+        java-21-openjdk-devel \
+        maven \
+        # Rust
+        rust \
+        cargo \
+    && microdnf clean all \
+    && rm -rf /var/cache/yum
+```
+
+The GitHub CLI (`gh`) is not available in UBI repos and must be installed separately:
+
+```dockerfile
+# Install GitHub CLI
+ARG GH_VERSION=2.74.1
+RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz -C /usr/local/bin --strip-components=2 "gh_${GH_VERSION}_linux_amd64/bin/gh"
 ```
 
 ---

--- a/agents/claude-code/deployment/README.md
+++ b/agents/claude-code/deployment/README.md
@@ -68,7 +68,7 @@ oc apply -f deployment.yaml
 oc start-build claude-code --from-dir=. --follow
 ```
 
-**Rebuilding:** If you rebuild the image after the initial deployment (e.g., after modifying the Containerfile), the running pod will not pick up the new image automatically. Re-apply the deployment manifest and restart:
+**Rebuilding:** After running `oc start-build` to rebuild the image (e.g., after modifying the Containerfile), the running pod will not pick up the new image automatically. Re-apply the deployment manifest and restart:
 
 ```bash
 oc apply -f deployment.yaml
@@ -249,7 +249,7 @@ oc rollout restart deployment/claude-code-vertex
 oc start-build claude-code --from-dir=. --follow
 ```
 
-**Rebuilding:** If you rebuild the image after the initial deployment (e.g., after modifying the Containerfile), the running pod will not pick up the new image automatically. Re-apply the deployment manifest and restart:
+**Rebuilding:** After running `oc start-build` to rebuild the image (e.g., after modifying the Containerfile), the running pod will not pick up the new image automatically. Re-apply the deployment manifest and restart:
 
 ```bash
 oc apply -f deployment-vertex.yaml
@@ -437,7 +437,7 @@ oc apply -f deployment-vllm.yaml
 oc start-build claude-code --from-dir=. --follow
 ```
 
-**Rebuilding:** If you rebuild the image after the initial deployment (e.g., after modifying the Containerfile), the running pod will not pick up the new image automatically. Re-apply the deployment manifest and restart:
+**Rebuilding:** After running `oc start-build` to rebuild the image (e.g., after modifying the Containerfile), the running pod will not pick up the new image automatically. Re-apply the deployment manifest and restart:
 
 ```bash
 oc apply -f deployment-vllm.yaml
@@ -590,7 +590,7 @@ oc apply -f deployment-ogx-vllm.yaml
 oc start-build claude-code --from-dir=. --follow
 ```
 
-**Rebuilding:** If you rebuild the image after the initial deployment (e.g., after modifying the Containerfile), the running pod will not pick up the new image automatically. Re-apply the deployment manifest and restart:
+**Rebuilding:** After running `oc start-build` to rebuild the image (e.g., after modifying the Containerfile), the running pod will not pick up the new image automatically. Re-apply the deployment manifest and restart:
 
 ```bash
 oc apply -f deployment-ogx-vllm.yaml
@@ -751,6 +751,14 @@ When an AI agent has push access to a Git repository, you should ensure the repo
 
 These protections apply regardless of whether you are using Claude Code or any other AI coding tool. They are standard best practices for collaborative development, but become critical when an automated agent has commit and push access.
 
+### Credential Isolation
+
+When credentials such as GitHub PATs or API tokens are passed as environment variables or written to files inside the container, the agent can read them directly. This means the agent could inadvertently expose credentials in conversation output, commit messages, or through MCP server calls. This is a known limitation of the approach described in this guide.
+
+For many use cases, this risk is acceptable when combined with the safeguards above: limiting PAT scope to the minimum required permissions, protecting branches, and requiring PR reviews. However, for environments with strict security requirements, the ideal approach is to isolate the agent from the credentials it depends on, so that it can use tools (like git push or GitHub APIs) without being able to see or exfiltrate the underlying secrets.
+
+Container isolation solutions are actively exploring ways to provide this kind of separation. If credential isolation is a requirement for your deployment, consider evaluating such solutions as they mature.
+
 ---
 
 ## Customization
@@ -813,7 +821,7 @@ MCP (Model Context Protocol) servers extend Claude Code with additional tools. M
 
 **Common MCP server examples:**
 
-GitHub (official remote MCP server, requires a [Personal Access Token](https://github.com/settings/tokens)):
+GitHub (official remote MCP server, requires a [Personal Access Token](https://github.com/settings/tokens)). The `${GITHUB_PAT}` variable is expanded at runtime from the container's environment; inject it via a Kubernetes Secret (see "Injecting secrets" below):
 
 ```json
 {

--- a/agents/claude-code/deployment/deployment-vllm.yaml
+++ b/agents/claude-code/deployment/deployment-vllm.yaml
@@ -144,7 +144,7 @@ spec:
             # For internal service: http://vllm-service.namespace.svc.cluster.local
             # For external route: https://vllm-route.apps.cluster.domain
             - name: ANTHROPIC_BASE_URL
-              value: YOUR_VLLM_URL  # e.g., http://1.2.3.4:8000
+              value: YOUR_VLLM_URL
             # vLLM doesn't validate API keys, but Claude Code requires one
             - name: ANTHROPIC_API_KEY
               value: "fake"

--- a/agents/claude-code/deployment/deployment-vllm.yaml
+++ b/agents/claude-code/deployment/deployment-vllm.yaml
@@ -144,7 +144,7 @@ spec:
             # For internal service: http://vllm-service.namespace.svc.cluster.local
             # For external route: https://vllm-route.apps.cluster.domain
             - name: ANTHROPIC_BASE_URL
-              value: "https://YOUR_VLLM_ENDPOINT"
+              value: YOUR_VLLM_URL  # e.g., http://1.2.3.4:8000
             # vLLM doesn't validate API keys, but Claude Code requires one
             - name: ANTHROPIC_API_KEY
               value: "fake"

--- a/agents/claude-code/deployment/entrypoint.sh
+++ b/agents/claude-code/deployment/entrypoint.sh
@@ -60,6 +60,18 @@ log_error() {
 }
 
 # -----------------------------------------------------------------------------
+# Onboarding
+# -----------------------------------------------------------------------------
+
+setup_onboarding() {
+    local claude_json="${HOME}/.claude.json"
+    log_info "Marking onboarding as complete (skips interactive login wizard)"
+    rm -f "${claude_json}" 2>/dev/null || true
+    echo '{"hasCompletedOnboarding": true}' > "${claude_json}"
+    chmod 664 "${claude_json}"
+}
+
+# -----------------------------------------------------------------------------
 # Validation
 # -----------------------------------------------------------------------------
 
@@ -96,6 +108,22 @@ validate_environment() {
 }
 
 # -----------------------------------------------------------------------------
+# Git Credentials
+# -----------------------------------------------------------------------------
+
+setup_git_credentials() {
+    if [[ -n "${GITHUB_PAT:-}" ]]; then
+        log_info "Configuring git credentials for github.com"
+        git config --global credential.helper store
+        local cred_file="${HOME}/.git-credentials"
+        echo "https://x-access-token:${GITHUB_PAT}@github.com" > "${cred_file}"
+        chmod 600 "${cred_file}"
+        git config --global user.name "${GIT_USER_NAME:-claude-agent}"
+        git config --global user.email "${GIT_USER_EMAIL:-claude-agent@noreply.github.com}"
+    fi
+}
+
+# -----------------------------------------------------------------------------
 # MCP Configuration
 # -----------------------------------------------------------------------------
 
@@ -125,6 +153,48 @@ setup_mcp() {
 
     # Export for use in command building
     export MCP_ARGS="${mcp_args[*]:-}"
+}
+
+# -----------------------------------------------------------------------------
+# MLflow Tracing
+# -----------------------------------------------------------------------------
+
+setup_mlflow() {
+    if [[ -z "${MLFLOW_TRACKING_URI:-}" ]]; then
+        return
+    fi
+
+    if ! command -v mlflow >/dev/null 2>&1; then
+        log_warn "MLFLOW_TRACKING_URI is set but mlflow is not installed"
+        return
+    fi
+
+    log_info "Configuring MLflow tracing"
+    mlflow autolog claude \
+        -u "${MLFLOW_TRACKING_URI}" \
+        -n "${MLFLOW_EXPERIMENT_NAME:-claude-code-traces}" \
+        /workspace
+
+    # Inject MLflow auth env vars into the generated settings
+    python3 -c '
+import json, os
+sf = "/workspace/.claude/settings.json"
+if not os.path.exists(sf):
+    print(f"[entrypoint] WARN: {sf} not found, skipping MLflow settings injection")
+    raise SystemExit(0)
+with open(sf) as f:
+    s = json.load(f)
+env = s.setdefault("env", {})
+if os.environ.get("MLFLOW_TRACKING_AUTH"):
+    env["MLFLOW_TRACKING_AUTH"] = os.environ["MLFLOW_TRACKING_AUTH"]
+if os.environ.get("MLFLOW_WORKSPACE"):
+    env["MLFLOW_WORKSPACE"] = os.environ["MLFLOW_WORKSPACE"]
+if os.environ.get("MLFLOW_TRACKING_INSECURE_TLS"):
+    env["MLFLOW_TRACKING_INSECURE_TLS"] = os.environ["MLFLOW_TRACKING_INSECURE_TLS"]
+with open(sf, "w") as f:
+    json.dump(s, f, indent=2)
+print("[entrypoint] INFO: MLflow settings injected into " + sf)
+'
 }
 
 # -----------------------------------------------------------------------------
@@ -223,8 +293,11 @@ main() {
     log_info "Claude Code version: $(claude --version 2>/dev/null || echo 'unknown')"
 
     # Run setup functions
+    setup_onboarding
     validate_environment
+    setup_git_credentials
     setup_mcp
+    setup_mlflow
     setup_skills
     build_claude_args
 

--- a/agents/claude-code/deployment/entrypoint.sh
+++ b/agents/claude-code/deployment/entrypoint.sh
@@ -26,6 +26,18 @@
 #     MCP_CONFIG_FILE          - Path to MCP configuration JSON file
 #     MCP_CONFIG_JSON          - MCP configuration as inline JSON string
 #
+#   Git Credentials:
+#     GITHUB_PAT               - GitHub Personal Access Token for push access
+#     GIT_USER_NAME            - Git commit author name (default: claude-agent)
+#     GIT_USER_EMAIL           - Git commit author email (default: claude-agent@noreply.github.com)
+#
+#   MLflow Tracing (optional):
+#     MLFLOW_TRACKING_URI      - MLflow server URI (enables tracing when set)
+#     MLFLOW_EXPERIMENT_NAME   - Experiment name (default: claude-code-traces)
+#     MLFLOW_TRACKING_AUTH     - Auth plugin name (default: kubernetes-namespaced)
+#     MLFLOW_WORKSPACE         - MLflow workspace (typically the namespace)
+#     MLFLOW_TRACKING_INSECURE_TLS - Set to "true" to skip TLS cert verification
+#
 #   Permissions:
 #     SKIP_PERMISSIONS         - Set to "true" to bypass permission checks (sandboxed environments only)
 #
@@ -66,9 +78,16 @@ log_error() {
 setup_onboarding() {
     local claude_json="${HOME}/.claude.json"
     log_info "Marking onboarding as complete (skips interactive login wizard)"
-    rm -f "${claude_json}" 2>/dev/null || true
+    if [[ -f "${claude_json}" ]]; then
+        local merged
+        merged=$(jq '.hasCompletedOnboarding = true' "${claude_json}" 2>/dev/null) \
+            && echo "${merged}" > "${claude_json}" \
+            && return
+        # jq failed (malformed JSON or permissions), fall through to overwrite
+        rm -f "${claude_json}" 2>/dev/null || true
+    fi
     echo '{"hasCompletedOnboarding": true}' > "${claude_json}"
-    chmod 664 "${claude_json}"
+    chmod 660 "${claude_json}"
 }
 
 # -----------------------------------------------------------------------------
@@ -170,31 +189,45 @@ setup_mlflow() {
     fi
 
     log_info "Configuring MLflow tracing"
-    mlflow autolog claude \
+
+    export MLFLOW_TRACKING_AUTH="${MLFLOW_TRACKING_AUTH:-kubernetes-namespaced}"
+    export MLFLOW_TRACKING_INSECURE_TLS="${MLFLOW_TRACKING_INSECURE_TLS:-false}"
+
+    if [[ "${MLFLOW_TRACKING_INSECURE_TLS}" == "true" ]]; then
+        log_warn "MLflow TLS certificate verification is disabled (MLFLOW_TRACKING_INSECURE_TLS=true)"
+    fi
+
+    if ! mlflow autolog claude \
+        -d /workspace \
         -u "${MLFLOW_TRACKING_URI}" \
-        -n "${MLFLOW_EXPERIMENT_NAME:-claude-code-traces}" \
-        /workspace
+        -n "${MLFLOW_EXPERIMENT_NAME:-claude-code-traces}"; then
+        log_warn "mlflow autolog failed. Tracing will not be available, but Claude Code will still work."
+        return
+    fi
 
     # Inject MLflow auth env vars into the generated settings
-    python3 -c '
-import json, os
+    if ! python3 -c '
+import json, os, sys
 sf = "/workspace/.claude/settings.json"
 if not os.path.exists(sf):
     print(f"[entrypoint] WARN: {sf} not found, skipping MLflow settings injection")
-    raise SystemExit(0)
-with open(sf) as f:
-    s = json.load(f)
+    sys.exit(0)
+try:
+    with open(sf) as f:
+        s = json.load(f)
+except json.JSONDecodeError:
+    print(f"[entrypoint] WARN: {sf} contains invalid JSON, skipping MLflow settings injection")
+    sys.exit(0)
 env = s.setdefault("env", {})
-if os.environ.get("MLFLOW_TRACKING_AUTH"):
-    env["MLFLOW_TRACKING_AUTH"] = os.environ["MLFLOW_TRACKING_AUTH"]
-if os.environ.get("MLFLOW_WORKSPACE"):
-    env["MLFLOW_WORKSPACE"] = os.environ["MLFLOW_WORKSPACE"]
-if os.environ.get("MLFLOW_TRACKING_INSECURE_TLS"):
-    env["MLFLOW_TRACKING_INSECURE_TLS"] = os.environ["MLFLOW_TRACKING_INSECURE_TLS"]
+env["MLFLOW_TRACKING_AUTH"] = os.environ.get("MLFLOW_TRACKING_AUTH", "kubernetes-namespaced")
+env["MLFLOW_WORKSPACE"] = os.environ.get("MLFLOW_WORKSPACE", "")
+env["MLFLOW_TRACKING_INSECURE_TLS"] = os.environ.get("MLFLOW_TRACKING_INSECURE_TLS", "false")
 with open(sf, "w") as f:
     json.dump(s, f, indent=2)
 print("[entrypoint] INFO: MLflow settings injected into " + sf)
-'
+'; then
+        log_warn "MLflow settings injection failed. Tracing may not authenticate correctly."
+    fi
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to PR #116, based on an end-to-end deployment of Claude Code with a vLLM backend (RedHatAI/Qwen3.6-35B-A3B-NVFP4) on OpenShift, including real coding tasks and GitHub integration.

- **README**: Add vLLM prerequisites, GitHub MCP example, context window configuration (env vars + model table), network connectivity troubleshooting, "Extending the Container Image" section with comprehensive dev tools example, "Repository Safeguards" section (branch protection, PR reviews, PAT scope), expanded SKIP_PERMISSIONS tradeoff discussion, rebuild instructions for all deployment options, and model capability note for vLLM/OGX
- **Containerfile**: Add python3.12/pip and MLflow with RHOAI Kubernetes auth plugin
- **entrypoint.sh**: Add onboarding bypass (login wizard), git credential setup (GitHub PAT), and MLflow tracing configuration
- **deployment-vllm.yaml**: Fix ANTHROPIC_BASE_URL placeholder to not assume HTTPS

## Test plan

- [x] Deployed on OpenShift with vLLM backend and verified all entrypoint functions (onboarding, git credentials, MLflow tracing)
- [x] Verified comprehensive dev tools example builds successfully on OpenShift (all packages install on UBI 10 minimal)
- [x] Tested GitHub MCP server integration with PAT auth
- [x] Verified MLflow traces recorded and visible in RHOAI MLflow UI
- [x] Tested interactive and headless modes with vLLM backend

Comment from Bill Murdock with assistance from Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)