### PR TITLE
feat: Persist stateful data in the Claude Code container across pod restarts

### DIFF
--- a/agents/claude-code/deployment/Containerfile
+++ b/agents/claude-code/deployment/Containerfile
@@ -77,28 +77,30 @@ RUN useradd -u ${USER_UID} -g ${USER_GID} -d /home/${USER_NAME} -m -s /bin/bash 
 # Create Directory Structure
 # =============================================================================
 
-# Skills directory - empty, mountable via ConfigMap/PVC
-# Claude Code auto-discovers skills from ~/.claude/skills/
-# Each skill is a subdirectory containing a SKILL.md file
-# Structure: ~/.claude/skills/<skill-name>/SKILL.md
+# Temporary ~/.claude directory for Claude Code installer
+# The installer writes to ~/.claude/local/ during installation
+# This directory is removed after installation and replaced with a symlink at runtime
+# (see entrypoint.sh for symlink creation to /workspace/.claude)
+#
+# Skills are mounted at runtime to /workspace/.claude/skills/ via ConfigMap/PVC
+# and accessible via ~/.claude/skills/ through the symlink.
+# Each skill is a subdirectory containing a SKILL.md file.
+# Structure: /workspace/.claude/skills/<skill-name>/SKILL.md
 #
 # Mount at runtime:
-#   podman run -v /path/to/skills:/home/claude-agent/.claude/skills:ro,z ...
-#   Or in OpenShift, mount a ConfigMap or PVC to /home/claude-agent/.claude/skills
-RUN mkdir -p /home/${USER_NAME}/.claude/skills \
-    && chown -R ${USER_UID}:${USER_GID} /home/${USER_NAME}/.claude/skills \
-    && chmod -R 775 /home/${USER_NAME}/.claude/skills
-
-# Workspace directory - for agent working files
-# Can be mounted with PVC for persistence
-RUN mkdir -p /workspace \
-    && chown -R ${USER_UID}:${USER_GID} /workspace \
-    && chmod -R 775 /workspace
-
-# Claude config directory
+#   podman run -v /path/to/skills:/workspace/.claude/skills:ro,z ...
+#   Or in OpenShift, mount a ConfigMap or PVC to /workspace/.claude/skills
 RUN mkdir -p /home/${USER_NAME}/.claude \
     && chown -R ${USER_UID}:${USER_GID} /home/${USER_NAME}/.claude \
     && chmod -R 775 /home/${USER_NAME}/.claude
+
+# Workspace directory - for agent working files
+# Can be mounted with PVC for persistence
+# /workspace/.claude holds global config (CLAUDE_CONFIG_DIR)
+# /workspace/projects is the working directory (WORKDIR)
+RUN mkdir -p /workspace/projects \
+    && chown -R ${USER_UID}:${USER_GID} /workspace \
+    && chmod -R 775 /workspace
 
 # Ensure home directory has correct permissions for OpenShift random UID
 RUN chown -R ${USER_UID}:${USER_GID} /home/${USER_NAME} \
@@ -125,6 +127,10 @@ RUN claude --version
 # Switch back to root for remaining setup
 USER 0
 
+# Remove ~/.claude created by installer - entrypoint will create a symlink to /workspace/.claude
+# This prevents overlay filesystem issues when trying to remove/move the directory at runtime
+RUN rm -rf /home/${USER_NAME}/.claude
+
 # =============================================================================
 # Copy Entrypoint
 # =============================================================================
@@ -139,7 +145,9 @@ COPY --chmod=755 entrypoint.sh /usr/local/bin/entrypoint.sh
 ENV DISABLE_AUTOUPDATER=1
 
 # Default working directory
-WORKDIR /workspace
+# Set to /workspace/projects to separate from global config at /workspace/.claude
+# This prevents overlap between CLAUDE_CONFIG_DIR and local auto-memory
+WORKDIR /workspace/projects
 
 # =============================================================================
 # Runtime Configuration

--- a/agents/claude-code/deployment/README.md
+++ b/agents/claude-code/deployment/README.md
@@ -113,7 +113,6 @@ podman run -it --rm \
 # OpenShift interactive mode (uses claude-run for proper config)
 oc exec -it deployment/claude-code -- bash -c '
   export HOME=/home/claude-agent
-  cd /workspace
   ~/.claude/claude-run
 '
 ```
@@ -128,14 +127,12 @@ To see detailed logging of Claude Code activity, use the `--debug` flag:
 # Enable full debug logging
 oc exec -it deployment/claude-code -- bash -c '
   export HOME=/home/claude-agent
-  cd /workspace
   claude --debug
 '
 
 # Enable debug logging for API calls only
 oc exec -it deployment/claude-code -- bash -c '
   export HOME=/home/claude-agent
-  cd /workspace
   claude --debug api
 '
 ```
@@ -303,14 +300,12 @@ podman run -it --rm \
 # OpenShift interactive mode (uses claude-run for proper config)
 oc exec -it deployment/claude-code-vertex -- bash -c '
   export HOME=/home/claude-agent
-  cd /workspace
   ~/.claude/claude-run
 '
 
 # Alternative: source env.sh directly
 oc exec -it deployment/claude-code-vertex -- bash -c '
   export HOME=/home/claude-agent
-  cd /workspace
   source ~/.claude/env.sh
   claude $CLAUDE_EXTRA_ARGS
 '
@@ -326,14 +321,12 @@ To see detailed logging of Claude Code activity, use the `--debug` flag:
 # Enable full debug logging
 oc exec -it deployment/claude-code-vertex -- bash -c '
   export HOME=/home/claude-agent
-  cd /workspace
   claude --debug
 '
 
 # Enable debug logging for API calls only
 oc exec -it deployment/claude-code-vertex -- bash -c '
   export HOME=/home/claude-agent
-  cd /workspace
   claude --debug api
 '
 ```
@@ -515,7 +508,6 @@ podman run -it --rm \
 # OpenShift interactive mode
 oc exec -it deployment/claude-code-vllm -- bash -c '
   export HOME=/home/claude-agent
-  cd /workspace
   ~/.claude/claude-run
 '
 ```
@@ -526,14 +518,12 @@ oc exec -it deployment/claude-code-vllm -- bash -c '
 # Enable full debug logging
 oc exec -it deployment/claude-code-vllm -- bash -c '
   export HOME=/home/claude-agent
-  cd /workspace
   claude --debug
 '
 
 # Enable debug logging for API calls only
 oc exec -it deployment/claude-code-vllm -- bash -c '
   export HOME=/home/claude-agent
-  cd /workspace
   claude --debug api
 '
 ```
@@ -682,7 +672,6 @@ The 404s are caused by Claude Code's HTTP client probing behavior and do not ind
 # OpenShift interactive mode
 oc exec -it deployment/claude-code-ogx-vllm -- bash -c '
   export HOME=/home/claude-agent
-  cd /workspace
   ~/.claude/claude-run
 '
 ```
@@ -693,14 +682,12 @@ oc exec -it deployment/claude-code-ogx-vllm -- bash -c '
 # Enable full debug logging
 oc exec -it deployment/claude-code-ogx-vllm -- bash -c '
   export HOME=/home/claude-agent
-  cd /workspace
   claude --debug
 '
 
 # Enable debug logging for API calls only
 oc exec -it deployment/claude-code-ogx-vllm -- bash -c '
   export HOME=/home/claude-agent
-  cd /workspace
   claude --debug api
 '
 ```
@@ -763,6 +750,69 @@ Container isolation solutions are actively exploring ways to provide this kind o
 
 ## Customization
 
+### Session Persistence
+
+By default, Claude Code session history and memory persist across pod restarts. This is enabled via the `CLAUDE_CONFIG_DIR` environment variable, which points to `/workspace/.claude/` (inside the workspace PVC).
+
+**Directory structure:**
+
+```text
+/workspace/                      ← PVC mount (persistent)
+├── .claude/                     ← Global config (CLAUDE_CONFIG_DIR)
+│   ├── settings.json            ← ConfigMap mount
+│   ├── skills/                  ← ConfigMap mount
+│   ├── memory/                  ← Persisted (global memory)
+│   └── projects/                ← Persisted (session history)
+└── projects/                    ← WORKDIR (where users run Claude)
+    └── .claude/                 ← Local auto-memory (separate from global)
+```
+
+This structure separates global config (`/workspace/.claude/`) from local auto-memory (`/workspace/projects/.claude/`), mirroring the experience of running Claude Code locally on a laptop.
+
+**What persists:**
+
+| Data | Location | Persisted? |
+|------|----------|------------|
+| Session history | `/workspace/.claude/projects/` | ✅ Yes |
+| Global memory | `/workspace/.claude/memory/` | ✅ Yes |
+| Local auto-memory | `/workspace/projects/.claude/` | ✅ Yes |
+| Project files | `/workspace/projects/` | ✅ Yes |
+| Skills | `/workspace/.claude/skills/` | ConfigMap (re-mounted each restart) |
+| Settings | `/workspace/.claude/settings.json` | ConfigMap (re-mounted each restart) |
+
+**How it works:**
+
+1. The `CLAUDE_CONFIG_DIR` environment variable tells Claude Code to store global state in `/workspace/.claude/`
+2. The entrypoint creates a symlink: `~/.claude` → `/workspace/.claude/`
+3. The `WORKDIR` is `/workspace/projects/`, so local auto-memory goes to `/workspace/projects/.claude/`
+4. The `/workspace` directory is backed by a PVC, so all session data persists
+5. Skills and settings are ConfigMap mounts that overlay specific paths within the PVC
+
+**User experience:**
+
+```bash
+# Session 1: Have a conversation
+oc exec -it deployment/claude-code -- bash
+~/.claude/claude-run
+# ... conversation with Claude ...
+# Exit and pod restarts
+
+# Session 2: Claude remembers the previous conversation
+oc exec -it deployment/claude-code -- bash
+~/.claude/claude-run
+# Claude can reference prior context
+```
+
+**Disabling persistence:**
+
+To disable session persistence (ephemeral sessions only), set `CLAUDE_CONFIG_DIR` to a non-PVC path:
+
+```yaml
+env:
+  - name: CLAUDE_CONFIG_DIR
+    value: "/tmp/.claude"
+```
+
 ### Injecting Skills
 
 Skills allow you to extend Claude Code with custom instructions and capabilities. Skills are injected at deploy time via ConfigMap or PVC mount.
@@ -777,7 +827,7 @@ Skills allow you to extend Claude Code with custom instructions and capabilities
     └── SKILL.md
 ```
 
-**Mount path:** `/home/claude-agent/.claude/skills`
+**Mount path:** `/workspace/.claude/skills` (accessible via `~/.claude/skills/` symlink)
 
 Claude Code auto-discovers skills from `~/.claude/skills/`. Each skill is a subdirectory containing a `SKILL.md` file that defines the skill's behavior.
 
@@ -912,7 +962,7 @@ Claude Code automatically reads CLAUDE.md from the working directory and applies
 
 ### Overriding settings.json
 
-All deployment manifests include a settings ConfigMap that mounts to `~/.claude/settings.json`. The ConfigMap name varies by deployment option (`claude-settings`, `claude-vertex-settings`, `claude-vllm-settings`, or `claude-ogx-vllm-settings`). The default is empty (`{}`), which you can customize at deploy time:
+All deployment manifests include a settings ConfigMap that mounts to `/workspace/.claude/settings.json` (accessible via `~/.claude/settings.json` symlink). The ConfigMap name varies by deployment option (`claude-settings`, `claude-vertex-settings`, `claude-vllm-settings`, or `claude-ogx-vllm-settings`). The default is empty (`{}`), which you can customize at deploy time:
 
 ```bash
 # Update the settings ConfigMap (use the appropriate name for your deployment)

--- a/agents/claude-code/deployment/deployment-ogx-vllm.yaml
+++ b/agents/claude-code/deployment/deployment-ogx-vllm.yaml
@@ -6,6 +6,12 @@
 # Architecture:
 #   Claude Code → OGX (API Gateway) → vLLM (Model Server)
 #
+# Directory Structure:
+#   /workspace/                - PVC mount (persistent)
+#   /workspace/.claude/        - Global config (CLAUDE_CONFIG_DIR) - settings, skills, memory
+#   /workspace/projects/       - Working directory (WORKDIR) - where users run Claude
+#   /workspace/projects/.claude/ - Local auto-memory (separate from global config)
+#
 # OGX Requirements:
 # - PostgreSQL database (check your OGX version's requirements)
 #
@@ -145,6 +151,10 @@ spec:
             # ===========================================
             - name: HOME
               value: "/home/claude-agent"
+            # CLAUDE_CONFIG_DIR enables session persistence across pod restarts
+            # The entrypoint creates a symlink: ~/.claude -> /workspace/.claude
+            - name: CLAUDE_CONFIG_DIR
+              value: "/workspace/.claude"
             # ===========================================
             # OGX Gateway Connection
             # ===========================================
@@ -184,15 +194,17 @@ spec:
           volumeMounts:
             - name: workspace
               mountPath: /workspace
+            # Skills and settings are mounted inside /workspace/.claude/ (the CLAUDE_CONFIG_DIR)
+            # This enables session persistence while keeping ConfigMap-based injection
             - name: skills
-              mountPath: /home/claude-agent/.claude/skills
+              mountPath: /workspace/.claude/skills
               readOnly: true
             - name: mcp-config
               mountPath: /etc/mcp
               readOnly: true
             # Mount settings.json to set default model
             - name: claude-settings
-              mountPath: /home/claude-agent/.claude/settings.json
+              mountPath: /workspace/.claude/settings.json
               subPath: settings.json
           resources:
             requests:

--- a/agents/claude-code/deployment/deployment-vertex.yaml
+++ b/agents/claude-code/deployment/deployment-vertex.yaml
@@ -3,6 +3,12 @@
 # This deployment uses Google Vertex AI for Claude API access instead of
 # direct Anthropic API keys. It requires GCP credentials to be mounted.
 #
+# Directory Structure:
+#   /workspace/                - PVC mount (persistent)
+#   /workspace/.claude/        - Global config (CLAUDE_CONFIG_DIR) - settings, skills, memory
+#   /workspace/projects/       - Working directory (WORKDIR) - where users run Claude
+#   /workspace/projects/.claude/ - Local auto-memory (separate from global config)
+#
 # Prerequisites:
 # 1. A GCP service account with Vertex AI access
 # 2. Vertex AI API enabled in your GCP project
@@ -166,9 +172,13 @@ spec:
             # ===========================================
             # Runtime Environment
             # ===========================================
-            # HOME must be set for the entrypoint to create ~/.claude/
+            # HOME must be set for the entrypoint to create ~/.claude/ symlink
             - name: HOME
               value: "/home/claude-agent"
+            # CLAUDE_CONFIG_DIR enables session persistence across pod restarts
+            # The entrypoint creates a symlink: ~/.claude -> /workspace/.claude
+            - name: CLAUDE_CONFIG_DIR
+              value: "/workspace/.claude"
             # ===========================================
             # Vertex AI Authentication
             # ===========================================
@@ -203,8 +213,10 @@ spec:
           volumeMounts:
             - name: workspace
               mountPath: /workspace
+            # Skills and settings are mounted inside /workspace/.claude/ (the CLAUDE_CONFIG_DIR)
+            # This enables session persistence while keeping ConfigMap-based injection
             - name: skills
-              mountPath: /home/claude-agent/.claude/skills
+              mountPath: /workspace/.claude/skills
               readOnly: true
             - name: mcp-config
               mountPath: /etc/mcp
@@ -214,7 +226,7 @@ spec:
               mountPath: /var/secrets/google
               readOnly: true
             - name: claude-settings
-              mountPath: /home/claude-agent/.claude/settings.json
+              mountPath: /workspace/.claude/settings.json
               subPath: settings.json
           resources:
             requests:

--- a/agents/claude-code/deployment/deployment-vllm.yaml
+++ b/agents/claude-code/deployment/deployment-vllm.yaml
@@ -3,6 +3,12 @@
 # This deployment connects Claude Code directly to a vLLM server that supports
 # the Anthropic Messages API (/v1/messages endpoint).
 #
+# Directory Structure:
+#   /workspace/                - PVC mount (persistent)
+#   /workspace/.claude/        - Global config (CLAUDE_CONFIG_DIR) - settings, skills, memory
+#   /workspace/projects/       - Working directory (WORKDIR) - where users run Claude
+#   /workspace/projects/.claude/ - Local auto-memory (separate from global config)
+#
 # Prerequisites:
 # 1. A vLLM server with /v1/messages endpoint support
 # 2. The vLLM model must have a context window >= 32K tokens
@@ -137,6 +143,10 @@ spec:
             # ===========================================
             - name: HOME
               value: "/home/claude-agent"
+            # CLAUDE_CONFIG_DIR enables session persistence across pod restarts
+            # The entrypoint creates a symlink: ~/.claude -> /workspace/.claude
+            - name: CLAUDE_CONFIG_DIR
+              value: "/workspace/.claude"
             # ===========================================
             # vLLM Connection
             # ===========================================
@@ -176,15 +186,17 @@ spec:
           volumeMounts:
             - name: workspace
               mountPath: /workspace
+            # Skills and settings are mounted inside /workspace/.claude/ (the CLAUDE_CONFIG_DIR)
+            # This enables session persistence while keeping ConfigMap-based injection
             - name: skills
-              mountPath: /home/claude-agent/.claude/skills
+              mountPath: /workspace/.claude/skills
               readOnly: true
             - name: mcp-config
               mountPath: /etc/mcp
               readOnly: true
             # Mount settings.json to set default model
             - name: claude-settings
-              mountPath: /home/claude-agent/.claude/settings.json
+              mountPath: /workspace/.claude/settings.json
               subPath: settings.json
           resources:
             requests:

--- a/agents/claude-code/deployment/deployment.yaml
+++ b/agents/claude-code/deployment/deployment.yaml
@@ -2,6 +2,12 @@
 #
 # This file contains all resources needed to deploy Claude Code on OpenShift.
 #
+# Directory Structure:
+#   /workspace/                - PVC mount (persistent)
+#   /workspace/.claude/        - Global config (CLAUDE_CONFIG_DIR) - settings, skills, memory
+#   /workspace/projects/       - Working directory (WORKDIR) - where users run Claude
+#   /workspace/projects/.claude/ - Local auto-memory (separate from global config)
+#
 # Before applying this manifest, create the credentials secret:
 #   oc create secret generic claude-credentials \
 #     --from-literal=ANTHROPIC_API_KEY="sk-ant-api03-YOUR_KEY_HERE"
@@ -143,9 +149,13 @@ spec:
           command: ["entrypoint.sh"]
           args: ["sleep", "infinity"]  # Keep container running for exec access
           env:
-            # HOME must be set for the entrypoint to create ~/.claude/
+            # HOME must be set for the entrypoint to create ~/.claude/ symlink
             - name: HOME
               value: "/home/claude-agent"
+            # CLAUDE_CONFIG_DIR enables session persistence across pod restarts
+            # The entrypoint creates a symlink: ~/.claude -> /workspace/.claude
+            - name: CLAUDE_CONFIG_DIR
+              value: "/workspace/.claude"
             - name: ANTHROPIC_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -166,14 +176,16 @@ spec:
           volumeMounts:
             - name: workspace
               mountPath: /workspace
+            # Skills and settings are mounted inside /workspace/.claude/ (the CLAUDE_CONFIG_DIR)
+            # This enables session persistence while keeping ConfigMap-based injection
             - name: skills
-              mountPath: /home/claude-agent/.claude/skills
+              mountPath: /workspace/.claude/skills
               readOnly: true
             - name: mcp-config
               mountPath: /etc/mcp
               readOnly: true
             - name: claude-settings
-              mountPath: /home/claude-agent/.claude/settings.json
+              mountPath: /workspace/.claude/settings.json
               subPath: settings.json
           resources:
             requests:

--- a/agents/claude-code/deployment/entrypoint.sh
+++ b/agents/claude-code/deployment/entrypoint.sh
@@ -41,6 +41,11 @@
 #   Permissions:
 #     SKIP_PERMISSIONS         - Set to "true" to bypass permission checks (sandboxed environments only)
 #
+#   Session Persistence:
+#     CLAUDE_CONFIG_DIR        - Directory for Claude Code state (default: /workspace/.claude)
+#                                Session history and memory persist here across pod restarts.
+#                                A symlink is created from ~/.claude to this directory.
+#
 # =============================================================================
 
 set -euo pipefail
@@ -143,6 +148,39 @@ setup_git_credentials() {
 }
 
 # -----------------------------------------------------------------------------
+# Config Directory Setup (Session Persistence)
+# -----------------------------------------------------------------------------
+
+setup_config_dir() {
+    # Use CLAUDE_CONFIG_DIR for Claude Code state, defaulting to /workspace/.claude
+    # This enables session persistence since /workspace is backed by a PVC
+    export CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-/workspace/.claude}"
+
+    # Ensure the config directory exists
+    mkdir -p "${CLAUDE_CONFIG_DIR}"
+
+    # Ensure the projects directory exists (WORKDIR is /workspace/projects)
+    # This separates global config (/workspace/.claude) from local auto-memory (/workspace/projects/.claude)
+    mkdir -p /workspace/projects
+
+    # Create symlink from ~/.claude to the config dir for user convenience
+    # Users expect to find settings/skills at ~/.claude/
+    # The image doesn't include ~/.claude (removed at build time), so we just create the symlink
+    local home_claude_dir="${HOME}/.claude"
+    if [[ ! -L "${home_claude_dir}" ]]; then
+        # Remove any existing directory (shouldn't exist in normal operation, but handles edge cases)
+        if [[ -d "${home_claude_dir}" ]]; then
+            log_info "Removing existing ${home_claude_dir} directory"
+            rm -rf "${home_claude_dir}" 2>/dev/null || mv -f "${home_claude_dir}" "${home_claude_dir}.old" 2>/dev/null || true
+        fi
+        ln -sfn "${CLAUDE_CONFIG_DIR}" "${home_claude_dir}"
+    fi
+
+    log_info "Claude config directory: ${CLAUDE_CONFIG_DIR}"
+    log_info "Symlink: ${home_claude_dir} -> ${CLAUDE_CONFIG_DIR}"
+}
+
+# -----------------------------------------------------------------------------
 # MCP Configuration
 # -----------------------------------------------------------------------------
 
@@ -235,9 +273,10 @@ print("[entrypoint] INFO: MLflow settings injected into " + sf)
 # -----------------------------------------------------------------------------
 
 setup_skills() {
-    # Claude Code auto-discovers skills from ~/.claude/skills/
-    # Structure: ~/.claude/skills/<skill-name>/SKILL.md
-    local skills_dir="${HOME}/.claude/skills"
+    # Claude Code auto-discovers skills from $CLAUDE_CONFIG_DIR/skills/
+    # Structure: $CLAUDE_CONFIG_DIR/skills/<skill-name>/SKILL.md
+    # (Also accessible via ~/.claude/skills/ symlink)
+    local skills_dir="${CLAUDE_CONFIG_DIR}/skills"
 
     if [[ -d "${skills_dir}" ]]; then
         local skill_count
@@ -329,6 +368,7 @@ main() {
     setup_onboarding
     validate_environment
     setup_git_credentials
+    setup_config_dir
     setup_mcp
     setup_mlflow
     setup_skills

--- a/agents/claude-code/deployment/entrypoint.sh
+++ b/agents/claude-code/deployment/entrypoint.sh
@@ -167,8 +167,16 @@ setup_config_dir() {
     # Users expect to find settings/skills at ~/.claude/
     # The image doesn't include ~/.claude (removed at build time), so we just create the symlink
     local home_claude_dir="${HOME}/.claude"
-    if [[ ! -L "${home_claude_dir}" ]]; then
-        # Remove any existing directory (shouldn't exist in normal operation, but handles edge cases)
+    if [[ -L "${home_claude_dir}" ]]; then
+        # Symlink exists - verify it points to the correct location
+        local current_target
+        current_target=$(readlink "${home_claude_dir}")
+        if [[ "${current_target}" != "${CLAUDE_CONFIG_DIR}" ]]; then
+            ln -sfn "${CLAUDE_CONFIG_DIR}" "${home_claude_dir}"
+            log_info "Updated symlink: ${home_claude_dir} -> ${CLAUDE_CONFIG_DIR}"
+        fi
+    else
+        # No symlink - remove any existing directory and create the symlink
         if [[ -d "${home_claude_dir}" ]]; then
             log_info "Removing existing ${home_claude_dir} directory"
             rm -rf "${home_claude_dir}" 2>/dev/null || mv -f "${home_claude_dir}" "${home_claude_dir}.old" 2>/dev/null || true

--- a/agents/claude-code/deployment/entrypoint.sh
+++ b/agents/claude-code/deployment/entrypoint.sh
@@ -246,7 +246,8 @@ setup_mlflow() {
     # Inject MLflow auth env vars into the generated settings
     if ! python3 -c '
 import json, os, sys
-sf = "/workspace/.claude/settings.json"
+config_dir = os.environ.get("CLAUDE_CONFIG_DIR", "/workspace/.claude")
+sf = os.path.join(config_dir, "settings.json")
 if not os.path.exists(sf):
     print(f"[entrypoint] WARN: {sf} not found, skipping MLflow settings injection")
     sys.exit(0)


### PR DESCRIPTION

## Description

- Enable session persistence by storing Claude Code state in `/workspace/.claude/` (PVC-backed)
- Change WORKDIR from `/workspace` to `/workspace/projects` to separate global config from local auto-memory
- Create `~/.claude` → `/workspace/.claude` symlink at runtime for user convenience
- Session history, memory, and settings now persist across pod restarts
- Skills and settings remain injectable via ConfigMap mounts to `/workspace/.claude/`

## Jira Ticket

RHAIENG-5282

## Testing

- [ ] Run Claude session, delete pod, verify session files persist in `/workspace/.claude/projects/`
- [ ] Verify `~/.claude` symlink points to `/workspace/.claude`
- [ ] Verify skills mount at `/workspace/.claude/skills/` and are accessible via `~/.claude/skills/`
