### PR TITLE
chore: drop maxdepth from CI lockfile check and add mcp_automl_template hook

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -80,7 +80,7 @@ jobs:
               echo "::error file=$dir/uv.lock::Lock file is stale — run 'uv lock' in $dir"
               failed=1
             fi
-          done < <(find . -maxdepth 5 -name pyproject.toml ! -path '*/.venv/*' ! -path '*/egg-info/*')
+          done < <(find . -name pyproject.toml ! -path '*/.venv/*' ! -path '*/egg-info/*')
           exit $failed
 
   secret-scanning:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,6 +85,10 @@ repos:
         files: ^agents/autogen/templates/mcp_agent/pyproject\.toml$
         args: [--project, agents/autogen/templates/mcp_agent]
       - id: uv-lock
+        name: uv-lock (autogen/mcp_automl_template)
+        files: ^agents/autogen/templates/mcp_agent/mcp_automl_template/pyproject\.toml$
+        args: [--project, agents/autogen/templates/mcp_agent/mcp_automl_template]
+      - id: uv-lock
         name: uv-lock (crewai/websearch_agent)
         files: ^agents/crewai/templates/websearch_agent/pyproject\.toml$
         args: [--project, agents/crewai/templates/websearch_agent]


### PR DESCRIPTION
## Description

Two fixes from review feedback on #179:

- **Drop `maxdepth 5`** from CI lockfile-check `find` command. The `templates/` restructure pushed `mcp_automl_template` to depth 6, causing CI to silently skip it. Removing maxdepth makes the check future-proof — path exclusions (`.venv`, `egg-info`) already filter noise.
- **Add missing pre-commit hook** for `agents/autogen/templates/mcp_agent/mcp_automl_template/` — the only `pyproject.toml` without a `uv-lock` pre-commit entry.

## Jira Ticket

RHAIENG-4059

## Testing

- [ ] `make test` passes (run from the affected agent directory)
- [x] Manual testing performed (describe steps below)
- [ ] No testing required (documentation/config change only)

`pre-commit run uv-lock --all-files` — all 13 entries pass (including new mcp_automl_template).

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)

## Related PRs

- #175 (lock file generation)
- #179 (CI check + pre-commit hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)