### PR TITLE
chore: enforce squash merge policy and PR title linting (RHAIENG-4375)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- PR title must follow Conventional Commits (e.g. feat: add health check endpoint). It becomes the commit message on main. -->
+
 ## Description
 
 <!-- Summarize your changes and the motivation behind them -->

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         with:
@@ -27,7 +28,7 @@ jobs:
             revert
           subjectPatternError: >
             PR title must follow Conventional Commits: `<type>(optional scope): <description>`.
-            The description must be at least 10 characters.
-          subjectPattern: ^.{10,}$
+            The description must be between 10 and 72 characters.
+          subjectPattern: ^.{10,72}$
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,33 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            test
+            perf
+            refactor
+            ci
+            build
+            style
+            revert
+          subjectPatternError: >
+            PR title must follow Conventional Commits: `<type>(optional scope): <description>`.
+            The description must be at least 10 characters.
+          subjectPattern: ^.{10,}$
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ Configuration files: [`ruff.toml`](ruff.toml) (Python rules), [`.markdownlint.js
 
 ## Commit message conventions
 
-This repository enforces the [Conventional Commits](https://www.conventionalcommits.org/) specification via a pre-commit hook. Commits that don't follow this format will be blocked locally by the pre-commit hook.
+This repository enforces the [Conventional Commits](https://www.conventionalcommits.org/) specification via a pre-commit hook. Commits that don't follow this format will be blocked locally by the pre-commit hook. All PRs are squash-merged, so the **PR title** becomes the commit message on `main` — make sure it follows Conventional Commits format.
 
 > **Tip:** To bypass the hook in rare cases (e.g., merge commits, emergency hotfixes): `git commit --no-verify`
 


### PR DESCRIPTION
## Summary

- Add CI workflow to lint PR titles against Conventional Commits format (`amannn/action-semantic-pull-request`)
- Document squash merge policy in CONTRIBUTING.md (PR title = commit message on `main`)
- Add PR template reminder about Conventional Commits title format

## Jira Ticket

RHAIENG-4375

## Test plan

- [x] Open a test PR with a non-conventional title — verify the `PR Title` check fails
- [x] Edit the PR title to a valid format — verify the check re-runs and passes
- [x] Confirm only "Squash and merge" button is available on PRs

Tested on fork: created [PR #26](https://github.com/tarun-etikala/agentic-starter-kits/pull/26) with bad title → `lint` failed. Edited title to `test: verify PR title lint workflow` → `lint` passed. PR closed and branch cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)