### PR TITLE
fix: resolve integration test agent paths from test files

### DIFF
--- a/agents/crewai/templates/websearch_agent/tests/integration/test_deployment.py
+++ b/agents/crewai/templates/websearch_agent/tests/integration/test_deployment.py
@@ -10,6 +10,7 @@ from integration.utils import (
     get_route,
     health_check,
     load_agent_name,
+    resolve_agent_dir,
     run_make,
 )
 
@@ -19,8 +20,8 @@ INTERNAL_REGISTRY = "image-registry.openshift-image-registry.svc:5000"
 
 
 @pytest.fixture(scope="module")
-def agent_dir(repo_root):
-    return repo_root / "agents" / "crewai" / "websearch_agent"
+def agent_dir():
+    return resolve_agent_dir(__file__)
 
 
 @pytest.fixture(scope="module")

--- a/agents/google/templates/adk/tests/integration/test_deployment.py
+++ b/agents/google/templates/adk/tests/integration/test_deployment.py
@@ -10,6 +10,7 @@ from integration.utils import (
     get_route,
     health_check,
     load_agent_name,
+    resolve_agent_dir,
     run_make,
 )
 
@@ -19,8 +20,8 @@ INTERNAL_REGISTRY = "image-registry.openshift-image-registry.svc:5000"
 
 
 @pytest.fixture(scope="module")
-def agent_dir(repo_root):
-    return repo_root / "agents" / "google" / "adk"
+def agent_dir():
+    return resolve_agent_dir(__file__)
 
 
 @pytest.fixture(scope="module")

--- a/agents/langgraph/templates/agentic_rag/tests/integration/conftest.py
+++ b/agents/langgraph/templates/agentic_rag/tests/integration/conftest.py
@@ -10,6 +10,7 @@ from integration.utils import (
     RouteNotFoundError,
     get_route,
     load_agent_name,
+    resolve_agent_dir,
     run_make,
 )
 
@@ -22,8 +23,8 @@ _REQUIRED_ENV = ("BASE_URL", "MODEL_ID", "EMBEDDING_MODEL", "VECTOR_STORE_ID")
 
 
 @pytest.fixture(scope="module")
-def agent_dir(repo_root):
-    return repo_root / "agents" / "langgraph" / "agentic_rag"
+def agent_dir():
+    return resolve_agent_dir(__file__)
 
 
 @pytest.fixture(scope="module")

--- a/agents/langgraph/templates/human_in_the_loop/tests/integration/test_deployment.py
+++ b/agents/langgraph/templates/human_in_the_loop/tests/integration/test_deployment.py
@@ -10,6 +10,7 @@ from integration.utils import (
     get_route,
     health_check,
     load_agent_name,
+    resolve_agent_dir,
     run_make,
 )
 
@@ -19,8 +20,8 @@ INTERNAL_REGISTRY = "image-registry.openshift-image-registry.svc:5000"
 
 
 @pytest.fixture(scope="module")
-def agent_dir(repo_root):
-    return repo_root / "agents" / "langgraph" / "human_in_the_loop"
+def agent_dir():
+    return resolve_agent_dir(__file__)
 
 
 @pytest.fixture(scope="module")

--- a/agents/langgraph/templates/react_agent/tests/integration/test_auth.py
+++ b/agents/langgraph/templates/react_agent/tests/integration/test_auth.py
@@ -14,6 +14,7 @@ from integration.utils import (
     get_route,
     health_check,
     load_agent_name,
+    resolve_agent_dir,
     run_make,
 )
 
@@ -27,8 +28,8 @@ WRONG_AUDIENCE = "langgraph-react-agent-wrong"
 
 
 @pytest.fixture(scope="module")
-def agent_dir(repo_root):
-    return repo_root / "agents" / "langgraph" / "react_agent"
+def agent_dir():
+    return resolve_agent_dir(__file__)
 
 
 @pytest.fixture(scope="module")

--- a/agents/langgraph/templates/react_agent/tests/integration/test_deployment.py
+++ b/agents/langgraph/templates/react_agent/tests/integration/test_deployment.py
@@ -10,6 +10,7 @@ from integration.utils import (
     get_route,
     health_check,
     load_agent_name,
+    resolve_agent_dir,
     run_make,
 )
 
@@ -19,8 +20,8 @@ INTERNAL_REGISTRY = "image-registry.openshift-image-registry.svc:5000"
 
 
 @pytest.fixture(scope="module")
-def agent_dir(repo_root):
-    return repo_root / "agents" / "langgraph" / "react_agent"
+def agent_dir():
+    return resolve_agent_dir(__file__)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from integration import utils as integration_utils
 
+from integration import utils as integration_utils
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from integration import utils as integration_utils
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.parametrize(
+    ("test_file", "expected_agent_dir"),
+    [
+        (
+            "agents/langgraph/templates/react_agent/tests/integration/test_deployment.py",
+            "agents/langgraph/templates/react_agent",
+        ),
+        (
+            "agents/langgraph/templates/react_agent/tests/integration/test_auth.py",
+            "agents/langgraph/templates/react_agent",
+        ),
+        (
+            "agents/langgraph/templates/human_in_the_loop/tests/integration/test_deployment.py",
+            "agents/langgraph/templates/human_in_the_loop",
+        ),
+        (
+            "agents/langgraph/templates/agentic_rag/tests/integration/conftest.py",
+            "agents/langgraph/templates/agentic_rag",
+        ),
+        (
+            "agents/google/templates/adk/tests/integration/test_deployment.py",
+            "agents/google/templates/adk",
+        ),
+        (
+            "agents/crewai/templates/websearch_agent/tests/integration/test_deployment.py",
+            "agents/crewai/templates/websearch_agent",
+        ),
+    ],
+)
+def test_resolve_agent_dir_returns_agent_root(test_file: str, expected_agent_dir: str):
+    resolved = integration_utils.resolve_agent_dir(REPO_ROOT / test_file)
+
+    assert resolved == REPO_ROOT / expected_agent_dir
+
+
+def test_resolve_agent_dir_rejects_non_agent_paths():
+    with pytest.raises(FileNotFoundError, match="agent.yaml"):
+        integration_utils.resolve_agent_dir(REPO_ROOT / "tests/integration/conftest.py")

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -13,6 +13,18 @@ import yaml
 logger = logging.getLogger(__name__)
 
 
+def resolve_agent_dir(test_file: str | Path) -> Path:
+    test_path = Path(test_file).resolve()
+    agent_dir = test_path.parents[2]
+    agent_config = agent_dir / "agent.yaml"
+    if not agent_config.is_file():
+        raise FileNotFoundError(
+            f"Could not find agent.yaml from test file {test_path}; "
+            f"expected {agent_config}"
+        )
+    return agent_dir
+
+
 def load_agent_name(agent_dir: str | Path) -> str:
     data = yaml.safe_load((Path(agent_dir) / "agent.yaml").read_text())
     if not isinstance(data, dict) or "name" not in data:


### PR DESCRIPTION
Avoid stale pre-templates fixture paths by deriving each agent root from the current test file location and cover the shared resolver with a regression test.

Fixes #188 

## Testing

- [x] `make test` passes (run from the affected agent directory)
- [x] Manual testing performed (describe steps below)
- [ ] No testing required (documentation/config change only)