### PR TITLE
fix: propagate backend errors in openai_responses_agent (RHAIENG-5285)

### DIFF
--- a/agents/vanilla_python/templates/openai_responses_agent/main.py
+++ b/agents/vanilla_python/templates/openai_responses_agent/main.py
@@ -14,6 +14,7 @@ from fastapi.responses import (
     JSONResponse,
     StreamingResponse,
 )
+from openai import APIStatusError
 from openai_responses_agent.agent import AIAgent, get_agent_closure
 from openai_responses_agent.tracing import enable_tracing, wrap_func_with_mlflow_trace
 from pydantic import BaseModel, Field
@@ -229,6 +230,8 @@ async def _handle_chat(user_message: str, model_id: str):
             "usage": None,
         }
 
+    except APIStatusError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e.message))
     except Exception as e:
         raise HTTPException(
             status_code=500, detail=f"Error processing request: {str(e)}"

--- a/agents/vanilla_python/templates/openai_responses_agent/src/openai_responses_agent/agent.py
+++ b/agents/vanilla_python/templates/openai_responses_agent/src/openai_responses_agent/agent.py
@@ -9,13 +9,16 @@ Compatible with OpenAI API and any OpenAI-compatible endpoint (e.g. base_url ove
 import asyncio
 import csv
 import inspect
+import logging
 import re
 from io import StringIO
 from os import getenv
 from typing import Any, Callable, Dict, List, Optional
 
 from dotenv import load_dotenv
-from openai import OpenAI
+from openai import APIStatusError, OpenAI
+
+logger = logging.getLogger(__name__)
 
 from openai_responses_agent.tools import search_price, search_reviews
 from openai_responses_agent.tracing import wrap_func_with_mlflow_trace
@@ -291,9 +294,11 @@ class AIAgent:
                     # No Action: line – treat the whole response as the final answer
                     return result.strip() if result else None
 
+        except APIStatusError:
+            raise
         except Exception as e:
-            print(f"Agent error: {e}")
-            return None
+            logger.exception("Agent error during query execution")
+            raise RuntimeError(f"Agent error: {e}") from e
 
         return None
 

--- a/agents/vanilla_python/templates/openai_responses_agent/src/openai_responses_agent/agent.py
+++ b/agents/vanilla_python/templates/openai_responses_agent/src/openai_responses_agent/agent.py
@@ -18,10 +18,10 @@ from typing import Any, Callable, Dict, List, Optional
 from dotenv import load_dotenv
 from openai import APIStatusError, OpenAI
 
-logger = logging.getLogger(__name__)
-
 from openai_responses_agent.tools import search_price, search_reviews
 from openai_responses_agent.tracing import wrap_func_with_mlflow_trace
+
+logger = logging.getLogger(__name__)
 
 
 def get_agent_closure(


### PR DESCRIPTION
## Summary
- Stop silently swallowing `APIStatusError` exceptions (e.g. 400 from vLLM) in `AIAgent.query()`
- Re-raise HTTP errors from the inference backend so `main.py` returns a meaningful error response instead of empty content
- Replace `print()` error logging with `logger.exception()` and wrap non-HTTP errors in `RuntimeError`

## Root cause
The agent uses the OpenAI Responses API format internally. When vLLM rejects the `output_text` content blocks with a 400, the broad `except Exception` at line 294 caught it, printed to stdout, and returned `None` — which the adapter converted to an empty string `""`.

## Test plan
- [ ] Deploy agent against vLLM qwen2-5-7b-instruct backend
- [ ] Send a tool-requiring query and verify a proper error response is returned (not empty content)
- [ ] Verify agent still works correctly with OpenAI-native backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)