### PR TITLE
fix: validate empty messages and populate usage in agents

### DIFF
--- a/agents/autogen/templates/mcp_agent/main.py
+++ b/agents/autogen/templates/mcp_agent/main.py
@@ -114,6 +114,9 @@ class ChatResponse(BaseModel):
             "`is_error` if applicable."
         ),
     )
+    usage: dict | None = Field(
+        None, description="Usage statistics for the completion request."
+    )
 
 
 class HealthResponse(BaseModel):

--- a/agents/crewai/templates/websearch_agent/main.py
+++ b/agents/crewai/templates/websearch_agent/main.py
@@ -46,7 +46,9 @@ class ChatCompletionRequest(BaseModel):
     """
 
     messages: list[ChatMessage] = Field(
-        ..., description="A list of messages comprising the conversation so far."
+        ...,
+        min_length=1,
+        description="A list of messages comprising the conversation so far.",
     )
     model: str | None = Field(
         None,
@@ -223,6 +225,15 @@ async def _handle_chat(user_message: str, model_id: str):
 
         assistant_content = _clean_content(str(result))
 
+        usage = None
+        token_usage = getattr(result, "token_usage", None)
+        if token_usage:
+            usage = {
+                "prompt_tokens": getattr(token_usage, "prompt_tokens", 0) or 0,
+                "completion_tokens": getattr(token_usage, "completion_tokens", 0) or 0,
+                "total_tokens": getattr(token_usage, "total_tokens", 0) or 0,
+            }
+
         return {
             "id": _make_completion_id(),
             "object": "chat.completion",
@@ -238,7 +249,7 @@ async def _handle_chat(user_message: str, model_id: str):
                     "finish_reason": "stop",
                 }
             ],
-            "usage": None,
+            "usage": usage,
         }
 
     except Exception as e:

--- a/agents/crewai/templates/websearch_agent/tests/test_api_contract.py
+++ b/agents/crewai/templates/websearch_agent/tests/test_api_contract.py
@@ -1,0 +1,101 @@
+"""Regression tests for API-contract changes (RHAIENG-5747, RHAIENG-5748).
+
+Covers:
+- Empty messages validation returns 422 (not 500)
+- Usage populated when CrewAI result.token_usage is present
+- Usage stays None when token_usage is absent
+"""
+
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from main import ChatCompletionRequest
+
+
+class TestEmptyMessagesValidation:
+    def test_empty_messages_rejected(self):
+        with pytest.raises(ValidationError) as exc_info:
+            ChatCompletionRequest(messages=[])
+        assert "messages" in str(exc_info.value)
+
+    def test_single_message_accepted(self):
+        req = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hello"}]
+        )
+        assert len(req.messages) == 1
+
+
+class TestCrewaiUsageExtraction:
+    """Test the inline usage extraction logic from _handle_chat."""
+
+    @staticmethod
+    def _extract_usage_from_result(result):
+        """Mirror the usage extraction logic from main._handle_chat."""
+        usage = None
+        token_usage = getattr(result, "token_usage", None)
+        if token_usage:
+            usage = {
+                "prompt_tokens": getattr(token_usage, "prompt_tokens", 0) or 0,
+                "completion_tokens": getattr(token_usage, "completion_tokens", 0) or 0,
+                "total_tokens": getattr(token_usage, "total_tokens", 0) or 0,
+            }
+        return usage
+
+    def test_returns_none_when_no_token_usage(self):
+        result = SimpleNamespace()
+        assert self._extract_usage_from_result(result) is None
+
+    def test_returns_none_when_token_usage_is_none(self):
+        result = SimpleNamespace(token_usage=None)
+        assert self._extract_usage_from_result(result) is None
+
+    def test_returns_usage_when_present(self):
+        result = SimpleNamespace(
+            token_usage=SimpleNamespace(
+                prompt_tokens=15,
+                completion_tokens=25,
+                total_tokens=40,
+            )
+        )
+        usage = self._extract_usage_from_result(result)
+        assert usage == {
+            "prompt_tokens": 15,
+            "completion_tokens": 25,
+            "total_tokens": 40,
+        }
+
+    def test_handles_zero_values(self):
+        result = SimpleNamespace(
+            token_usage=SimpleNamespace(
+                prompt_tokens=0,
+                completion_tokens=0,
+                total_tokens=0,
+            )
+        )
+        usage = self._extract_usage_from_result(result)
+        assert usage == {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+        }
+
+    def test_handles_none_fields(self):
+        result = SimpleNamespace(
+            token_usage=SimpleNamespace(
+                prompt_tokens=None,
+                completion_tokens=10,
+                total_tokens=10,
+            )
+        )
+        usage = self._extract_usage_from_result(result)
+        assert usage == {
+            "prompt_tokens": 0,
+            "completion_tokens": 10,
+            "total_tokens": 10,
+        }

--- a/agents/crewai/templates/websearch_agent/tests/test_api_contract.py
+++ b/agents/crewai/templates/websearch_agent/tests/test_api_contract.py
@@ -25,9 +25,7 @@ class TestEmptyMessagesValidation:
         assert "messages" in str(exc_info.value)
 
     def test_single_message_accepted(self):
-        req = ChatCompletionRequest(
-            messages=[{"role": "user", "content": "hello"}]
-        )
+        req = ChatCompletionRequest(messages=[{"role": "user", "content": "hello"}])
         assert len(req.messages) == 1
 
 

--- a/agents/google/templates/adk/main.py
+++ b/agents/google/templates/adk/main.py
@@ -44,7 +44,9 @@ class ChatCompletionRequest(BaseModel):
     """
 
     messages: list[ChatMessage] = Field(
-        ..., description="A list of messages comprising the conversation so far."
+        ...,
+        min_length=1,
+        description="A list of messages comprising the conversation so far.",
     )
     model: str | None = Field(
         None,

--- a/agents/langgraph/templates/agentic_rag/main.py
+++ b/agents/langgraph/templates/agentic_rag/main.py
@@ -44,7 +44,9 @@ class ChatCompletionRequest(BaseModel):
     """
 
     messages: list[ChatMessage] = Field(
-        ..., description="A list of messages comprising the conversation so far."
+        ...,
+        min_length=1,
+        description="A list of messages comprising the conversation so far.",
     )
     model: str | None = Field(
         None,
@@ -160,6 +162,28 @@ def _build_langchain_messages(messages: list[ChatMessage]) -> list[HumanMessage]
     raise ValueError("No user message found in messages list")
 
 
+def _extract_usage(messages) -> dict | None:
+    """Sum token usage from AIMessage.usage_metadata across all LLM calls."""
+    prompt_tokens = 0
+    completion_tokens = 0
+    total_tokens = 0
+    found = False
+    for message in messages:
+        if isinstance(message, AIMessage) and getattr(message, "usage_metadata", None):
+            meta = message.usage_metadata
+            prompt_tokens += meta.get("input_tokens", 0) or 0
+            completion_tokens += meta.get("output_tokens", 0) or 0
+            total_tokens += meta.get("total_tokens", 0) or 0
+            found = True
+    if not found:
+        return None
+    return {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": total_tokens,
+    }
+
+
 def _make_completion_id() -> str:
     return f"chatcmpl-{uuid.uuid4().hex[:12]}"
 
@@ -252,7 +276,7 @@ async def _handle_chat(messages: list[HumanMessage], model_id: str):
                 }
             ],
             "context": context_messages,
-            "usage": None,
+            "usage": _extract_usage(result.get("messages", [])),
         }
 
     except Exception as e:

--- a/agents/langgraph/templates/agentic_rag/main.py
+++ b/agents/langgraph/templates/agentic_rag/main.py
@@ -162,7 +162,7 @@ def _build_langchain_messages(messages: list[ChatMessage]) -> list[HumanMessage]
     raise ValueError("No user message found in messages list")
 
 
-def _extract_usage(messages) -> dict | None:
+def _extract_usage(messages: list) -> dict | None:
     """Sum token usage from AIMessage.usage_metadata across all LLM calls."""
     prompt_tokens = 0
     completion_tokens = 0

--- a/agents/langgraph/templates/agentic_rag/tests/test_api_contract.py
+++ b/agents/langgraph/templates/agentic_rag/tests/test_api_contract.py
@@ -1,0 +1,106 @@
+"""Regression tests for API-contract changes (RHAIENG-5747, RHAIENG-5748).
+
+Covers:
+- Empty messages validation returns 422 (not 500)
+- _extract_usage populates usage when AIMessage.usage_metadata is present
+- _extract_usage returns None when no metadata is available
+"""
+
+import os
+import sys
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from pydantic import ValidationError
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from main import ChatCompletionRequest, _extract_usage
+
+
+class TestEmptyMessagesValidation:
+    def test_empty_messages_rejected(self):
+        with pytest.raises(ValidationError) as exc_info:
+            ChatCompletionRequest(messages=[])
+        assert "messages" in str(exc_info.value)
+
+    def test_single_message_accepted(self):
+        req = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hello"}]
+        )
+        assert len(req.messages) == 1
+
+
+class TestExtractUsage:
+    def test_returns_none_when_no_ai_messages(self):
+        messages = [HumanMessage(content="hi")]
+        assert _extract_usage(messages) is None
+
+    def test_returns_none_when_ai_has_no_metadata(self):
+        messages = [AIMessage(content="response")]
+        assert _extract_usage(messages) is None
+
+    def test_returns_usage_when_metadata_present(self):
+        msg = AIMessage(
+            content="response",
+            usage_metadata={
+                "input_tokens": 10,
+                "output_tokens": 20,
+                "total_tokens": 30,
+            },
+        )
+        result = _extract_usage([msg])
+        assert result == {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+        }
+
+    def test_sums_across_multiple_ai_messages(self):
+        messages = [
+            AIMessage(
+                content="thought",
+                usage_metadata={
+                    "input_tokens": 5,
+                    "output_tokens": 10,
+                    "total_tokens": 15,
+                },
+            ),
+            ToolMessage(content="result", tool_call_id="tc1"),
+            AIMessage(
+                content="final",
+                usage_metadata={
+                    "input_tokens": 8,
+                    "output_tokens": 12,
+                    "total_tokens": 20,
+                },
+            ),
+        ]
+        result = _extract_usage(messages)
+        assert result == {
+            "prompt_tokens": 13,
+            "completion_tokens": 22,
+            "total_tokens": 35,
+        }
+
+    def test_skips_messages_without_metadata(self):
+        messages = [
+            AIMessage(content="no metadata"),
+            AIMessage(
+                content="has metadata",
+                usage_metadata={
+                    "input_tokens": 7,
+                    "output_tokens": 3,
+                    "total_tokens": 10,
+                },
+            ),
+        ]
+        result = _extract_usage(messages)
+        assert result == {
+            "prompt_tokens": 7,
+            "completion_tokens": 3,
+            "total_tokens": 10,
+        }
+
+    def test_returns_none_for_empty_list(self):
+        assert _extract_usage([]) is None

--- a/agents/langgraph/templates/agentic_rag/tests/test_api_contract.py
+++ b/agents/langgraph/templates/agentic_rag/tests/test_api_contract.py
@@ -25,9 +25,7 @@ class TestEmptyMessagesValidation:
         assert "messages" in str(exc_info.value)
 
     def test_single_message_accepted(self):
-        req = ChatCompletionRequest(
-            messages=[{"role": "user", "content": "hello"}]
-        )
+        req = ChatCompletionRequest(messages=[{"role": "user", "content": "hello"}])
         assert len(req.messages) == 1
 
 

--- a/agents/langgraph/templates/human_in_the_loop/main.py
+++ b/agents/langgraph/templates/human_in_the_loop/main.py
@@ -46,7 +46,9 @@ class ChatCompletionRequest(BaseModel):
     """
 
     messages: list[ChatMessage] = Field(
-        ..., description="A list of messages comprising the conversation so far."
+        ...,
+        min_length=1,
+        description="A list of messages comprising the conversation so far.",
     )
     model: str | None = Field(
         None,
@@ -172,6 +174,28 @@ def _build_langchain_messages(messages: list[ChatMessage]) -> list[HumanMessage]
         if msg.role == "user":
             return [HumanMessage(content=msg.content)]
     raise ValueError("No user message found in messages list")
+
+
+def _extract_usage(messages) -> dict | None:
+    """Sum token usage from AIMessage.usage_metadata across all LLM calls."""
+    prompt_tokens = 0
+    completion_tokens = 0
+    total_tokens = 0
+    found = False
+    for message in messages:
+        if isinstance(message, AIMessage) and getattr(message, "usage_metadata", None):
+            meta = message.usage_metadata
+            prompt_tokens += meta.get("input_tokens", 0) or 0
+            completion_tokens += meta.get("output_tokens", 0) or 0
+            total_tokens += meta.get("total_tokens", 0) or 0
+            found = True
+    if not found:
+        return None
+    return {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": total_tokens,
+    }
 
 
 def _make_completion_id() -> str:
@@ -327,7 +351,7 @@ async def _handle_chat(
             ],
             "context": context_messages,
             "thread_id": thread_id,
-            "usage": None,
+            "usage": _extract_usage(all_messages),
         }
 
     except Exception:

--- a/agents/langgraph/templates/human_in_the_loop/main.py
+++ b/agents/langgraph/templates/human_in_the_loop/main.py
@@ -276,6 +276,13 @@ async def _handle_chat(
     try:
         agent = agent_graph_closure(checkpointer)
 
+        prior_count = 0
+        prior = checkpointer.get_tuple(config)
+        if prior and prior.checkpoint:
+            prior_count = len(
+                prior.checkpoint.get("channel_values", {}).get("messages", [])
+            )
+
         if request.approval:
             # Resume from interrupt with human decision
             if request.approval.lower() in ("yes", "y", "approve"):
@@ -324,10 +331,11 @@ async def _handle_chat(
             }
 
         all_messages = result.value.get("messages", [])
+        new_messages = all_messages[prior_count:]
 
         # Extract the final assistant content
         assistant_content = ""
-        for message in reversed(all_messages):
+        for message in reversed(new_messages):
             if isinstance(message, AIMessage) and message.content:
                 assistant_content = message.content
                 break
@@ -351,7 +359,7 @@ async def _handle_chat(
             ],
             "context": context_messages,
             "thread_id": thread_id,
-            "usage": _extract_usage(all_messages),
+            "usage": _extract_usage(new_messages),
         }
 
     except Exception:

--- a/agents/langgraph/templates/human_in_the_loop/main.py
+++ b/agents/langgraph/templates/human_in_the_loop/main.py
@@ -176,7 +176,7 @@ def _build_langchain_messages(messages: list[ChatMessage]) -> list[HumanMessage]
     raise ValueError("No user message found in messages list")
 
 
-def _extract_usage(messages) -> dict | None:
+def _extract_usage(messages: list) -> dict | None:
     """Sum token usage from AIMessage.usage_metadata across all LLM calls."""
     prompt_tokens = 0
     completion_tokens = 0
@@ -340,7 +340,7 @@ async def _handle_chat(
                 assistant_content = message.content
                 break
 
-        context_messages = _format_context_messages(all_messages)
+        context_messages = _format_context_messages(new_messages)
 
         return {
             "id": _make_completion_id(),

--- a/agents/langgraph/templates/human_in_the_loop/tests/test_api_contract.py
+++ b/agents/langgraph/templates/human_in_the_loop/tests/test_api_contract.py
@@ -26,9 +26,7 @@ class TestEmptyMessagesValidation:
         assert "messages" in str(exc_info.value)
 
     def test_single_message_accepted(self):
-        req = ChatCompletionRequest(
-            messages=[{"role": "user", "content": "hello"}]
-        )
+        req = ChatCompletionRequest(messages=[{"role": "user", "content": "hello"}])
         assert len(req.messages) == 1
 
 

--- a/agents/langgraph/templates/human_in_the_loop/tests/test_api_contract.py
+++ b/agents/langgraph/templates/human_in_the_loop/tests/test_api_contract.py
@@ -1,0 +1,178 @@
+"""Regression tests for API-contract changes (RHAIENG-5747, RHAIENG-5748).
+
+Covers:
+- Empty messages validation returns 422 (not 500)
+- _extract_usage populates usage when AIMessage.usage_metadata is present
+- _extract_usage returns None when no metadata is available
+- HITL turn scoping: resumed-thread responses include only current-turn messages
+"""
+
+import os
+import sys
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from pydantic import ValidationError
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from main import ChatCompletionRequest, _extract_usage, _format_context_messages
+
+
+class TestEmptyMessagesValidation:
+    def test_empty_messages_rejected(self):
+        with pytest.raises(ValidationError) as exc_info:
+            ChatCompletionRequest(messages=[])
+        assert "messages" in str(exc_info.value)
+
+    def test_single_message_accepted(self):
+        req = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hello"}]
+        )
+        assert len(req.messages) == 1
+
+
+class TestExtractUsage:
+    def test_returns_none_when_no_ai_messages(self):
+        messages = [HumanMessage(content="hi")]
+        assert _extract_usage(messages) is None
+
+    def test_returns_none_when_ai_has_no_metadata(self):
+        messages = [AIMessage(content="response")]
+        assert _extract_usage(messages) is None
+
+    def test_returns_usage_when_metadata_present(self):
+        msg = AIMessage(
+            content="response",
+            usage_metadata={
+                "input_tokens": 10,
+                "output_tokens": 20,
+                "total_tokens": 30,
+            },
+        )
+        result = _extract_usage([msg])
+        assert result == {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+        }
+
+    def test_sums_across_multiple_ai_messages(self):
+        messages = [
+            AIMessage(
+                content="thought",
+                usage_metadata={
+                    "input_tokens": 5,
+                    "output_tokens": 10,
+                    "total_tokens": 15,
+                },
+            ),
+            ToolMessage(content="result", tool_call_id="tc1"),
+            AIMessage(
+                content="final",
+                usage_metadata={
+                    "input_tokens": 8,
+                    "output_tokens": 12,
+                    "total_tokens": 20,
+                },
+            ),
+        ]
+        result = _extract_usage(messages)
+        assert result == {
+            "prompt_tokens": 13,
+            "completion_tokens": 22,
+            "total_tokens": 35,
+        }
+
+    def test_skips_messages_without_metadata(self):
+        messages = [
+            AIMessage(content="no metadata"),
+            AIMessage(
+                content="has metadata",
+                usage_metadata={
+                    "input_tokens": 7,
+                    "output_tokens": 3,
+                    "total_tokens": 10,
+                },
+            ),
+        ]
+        result = _extract_usage(messages)
+        assert result == {
+            "prompt_tokens": 7,
+            "completion_tokens": 3,
+            "total_tokens": 10,
+        }
+
+    def test_returns_none_for_empty_list(self):
+        assert _extract_usage([]) is None
+
+
+class TestHitlTurnScoping:
+    """Verify that slicing all_messages[prior_count:] correctly isolates
+    only the current turn's messages for usage and context."""
+
+    def _make_prior_turn(self):
+        return [
+            HumanMessage(content="turn-1 question"),
+            AIMessage(
+                content="turn-1 answer",
+                usage_metadata={
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "total_tokens": 150,
+                },
+            ),
+        ]
+
+    def _make_current_turn(self):
+        return [
+            HumanMessage(content="turn-2 question"),
+            AIMessage(
+                content="turn-2 answer",
+                usage_metadata={
+                    "input_tokens": 20,
+                    "output_tokens": 10,
+                    "total_tokens": 30,
+                },
+            ),
+        ]
+
+    def test_usage_scoped_to_current_turn(self):
+        prior = self._make_prior_turn()
+        current = self._make_current_turn()
+        all_messages = prior + current
+        prior_count = len(prior)
+
+        new_messages = all_messages[prior_count:]
+        usage = _extract_usage(new_messages)
+
+        assert usage == {
+            "prompt_tokens": 20,
+            "completion_tokens": 10,
+            "total_tokens": 30,
+        }
+
+    def test_context_scoped_to_current_turn(self):
+        prior = self._make_prior_turn()
+        current = self._make_current_turn()
+        all_messages = prior + current
+        prior_count = len(prior)
+
+        new_messages = all_messages[prior_count:]
+        context = _format_context_messages(new_messages)
+
+        roles = [m["role"] for m in context]
+        assert roles == ["user", "assistant"]
+        assert context[0]["content"] == "turn-2 question"
+        assert context[1]["content"] == "turn-2 answer"
+
+    def test_prior_count_zero_includes_all(self):
+        all_messages = self._make_prior_turn() + self._make_current_turn()
+        new_messages = all_messages[0:]
+        usage = _extract_usage(new_messages)
+
+        assert usage == {
+            "prompt_tokens": 120,
+            "completion_tokens": 60,
+            "total_tokens": 180,
+        }

--- a/agents/langgraph/templates/react_agent/main.py
+++ b/agents/langgraph/templates/react_agent/main.py
@@ -181,7 +181,7 @@ def _build_langchain_messages(messages: list[ChatMessage]) -> list[HumanMessage]
     raise ValueError("No user message found in messages list")
 
 
-def _extract_usage(messages) -> dict | None:
+def _extract_usage(messages: list) -> dict | None:
     """Sum token usage from AIMessage.usage_metadata across all LLM calls."""
     prompt_tokens = 0
     completion_tokens = 0

--- a/agents/langgraph/templates/react_agent/main.py
+++ b/agents/langgraph/templates/react_agent/main.py
@@ -44,7 +44,9 @@ class ChatCompletionRequest(BaseModel):
     """
 
     messages: list[ChatMessage] = Field(
-        ..., description="A list of messages comprising the conversation so far."
+        ...,
+        min_length=1,
+        description="A list of messages comprising the conversation so far.",
     )
     model: str | None = Field(
         None,
@@ -179,6 +181,28 @@ def _build_langchain_messages(messages: list[ChatMessage]) -> list[HumanMessage]
     raise ValueError("No user message found in messages list")
 
 
+def _extract_usage(messages) -> dict | None:
+    """Sum token usage from AIMessage.usage_metadata across all LLM calls."""
+    prompt_tokens = 0
+    completion_tokens = 0
+    total_tokens = 0
+    found = False
+    for message in messages:
+        if isinstance(message, AIMessage) and getattr(message, "usage_metadata", None):
+            meta = message.usage_metadata
+            prompt_tokens += meta.get("input_tokens", 0) or 0
+            completion_tokens += meta.get("output_tokens", 0) or 0
+            total_tokens += meta.get("total_tokens", 0) or 0
+            found = True
+    if not found:
+        return None
+    return {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": total_tokens,
+    }
+
+
 def _make_completion_id() -> str:
     return f"chatcmpl-{uuid.uuid4().hex[:12]}"
 
@@ -271,7 +295,7 @@ async def _handle_chat(messages: list[HumanMessage], model_id: str):
                 }
             ],
             "context": context_messages,
-            "usage": None,
+            "usage": _extract_usage(result.get("messages", [])),
         }
 
     except Exception as e:

--- a/agents/langgraph/templates/react_agent/tests/test_api_contract.py
+++ b/agents/langgraph/templates/react_agent/tests/test_api_contract.py
@@ -1,0 +1,106 @@
+"""Regression tests for API-contract changes (RHAIENG-5747, RHAIENG-5748).
+
+Covers:
+- Empty messages validation returns 422 (not 500)
+- _extract_usage populates usage when AIMessage.usage_metadata is present
+- _extract_usage returns None when no metadata is available
+"""
+
+import os
+import sys
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from pydantic import ValidationError
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from main import ChatCompletionRequest, _extract_usage
+
+
+class TestEmptyMessagesValidation:
+    def test_empty_messages_rejected(self):
+        with pytest.raises(ValidationError) as exc_info:
+            ChatCompletionRequest(messages=[])
+        assert "messages" in str(exc_info.value)
+
+    def test_single_message_accepted(self):
+        req = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hello"}]
+        )
+        assert len(req.messages) == 1
+
+
+class TestExtractUsage:
+    def test_returns_none_when_no_ai_messages(self):
+        messages = [HumanMessage(content="hi")]
+        assert _extract_usage(messages) is None
+
+    def test_returns_none_when_ai_has_no_metadata(self):
+        messages = [AIMessage(content="response")]
+        assert _extract_usage(messages) is None
+
+    def test_returns_usage_when_metadata_present(self):
+        msg = AIMessage(
+            content="response",
+            usage_metadata={
+                "input_tokens": 10,
+                "output_tokens": 20,
+                "total_tokens": 30,
+            },
+        )
+        result = _extract_usage([msg])
+        assert result == {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+        }
+
+    def test_sums_across_multiple_ai_messages(self):
+        messages = [
+            AIMessage(
+                content="thought",
+                usage_metadata={
+                    "input_tokens": 5,
+                    "output_tokens": 10,
+                    "total_tokens": 15,
+                },
+            ),
+            ToolMessage(content="result", tool_call_id="tc1"),
+            AIMessage(
+                content="final",
+                usage_metadata={
+                    "input_tokens": 8,
+                    "output_tokens": 12,
+                    "total_tokens": 20,
+                },
+            ),
+        ]
+        result = _extract_usage(messages)
+        assert result == {
+            "prompt_tokens": 13,
+            "completion_tokens": 22,
+            "total_tokens": 35,
+        }
+
+    def test_skips_messages_without_metadata(self):
+        messages = [
+            AIMessage(content="no metadata"),
+            AIMessage(
+                content="has metadata",
+                usage_metadata={
+                    "input_tokens": 7,
+                    "output_tokens": 3,
+                    "total_tokens": 10,
+                },
+            ),
+        ]
+        result = _extract_usage(messages)
+        assert result == {
+            "prompt_tokens": 7,
+            "completion_tokens": 3,
+            "total_tokens": 10,
+        }
+
+    def test_returns_none_for_empty_list(self):
+        assert _extract_usage([]) is None

--- a/agents/langgraph/templates/react_agent/tests/test_api_contract.py
+++ b/agents/langgraph/templates/react_agent/tests/test_api_contract.py
@@ -25,9 +25,7 @@ class TestEmptyMessagesValidation:
         assert "messages" in str(exc_info.value)
 
     def test_single_message_accepted(self):
-        req = ChatCompletionRequest(
-            messages=[{"role": "user", "content": "hello"}]
-        )
+        req = ChatCompletionRequest(messages=[{"role": "user", "content": "hello"}])
         assert len(req.messages) == 1
 
 

--- a/agents/langgraph/templates/react_with_database_memory/main.py
+++ b/agents/langgraph/templates/react_with_database_memory/main.py
@@ -181,7 +181,7 @@ def _convert_dict_to_message(msg: ChatMessage):
         return HumanMessage(content=msg.content)
 
 
-def _extract_usage(messages) -> dict | None:
+def _extract_usage(messages: list) -> dict | None:
     """Sum token usage from AIMessage.usage_metadata across all LLM calls."""
     prompt_tokens = 0
     completion_tokens = 0

--- a/agents/langgraph/templates/react_with_database_memory/main.py
+++ b/agents/langgraph/templates/react_with_database_memory/main.py
@@ -49,7 +49,9 @@ class ChatCompletionRequest(BaseModel):
     """
 
     messages: list[ChatMessage] = Field(
-        ..., description="A list of messages comprising the conversation so far."
+        ...,
+        min_length=1,
+        description="A list of messages comprising the conversation so far.",
     )
     model: str | None = Field(
         None,
@@ -177,6 +179,28 @@ def _convert_dict_to_message(msg: ChatMessage):
         return AIMessage(content=msg.content)
     else:
         return HumanMessage(content=msg.content)
+
+
+def _extract_usage(messages) -> dict | None:
+    """Sum token usage from AIMessage.usage_metadata across all LLM calls."""
+    prompt_tokens = 0
+    completion_tokens = 0
+    total_tokens = 0
+    found = False
+    for message in messages:
+        if isinstance(message, AIMessage) and getattr(message, "usage_metadata", None):
+            meta = message.usage_metadata
+            prompt_tokens += meta.get("input_tokens", 0) or 0
+            completion_tokens += meta.get("output_tokens", 0) or 0
+            total_tokens += meta.get("total_tokens", 0) or 0
+            found = True
+    if not found:
+        return None
+    return {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": total_tokens,
+    }
 
 
 def _make_completion_id() -> str:
@@ -310,7 +334,7 @@ async def _handle_chat(
                 }
             ],
             "context": context_messages,
-            "usage": None,
+            "usage": _extract_usage(new_messages),
         }
 
     except Exception as e:

--- a/agents/langgraph/templates/react_with_database_memory/tests/test_api_contract.py
+++ b/agents/langgraph/templates/react_with_database_memory/tests/test_api_contract.py
@@ -1,0 +1,106 @@
+"""Regression tests for API-contract changes (RHAIENG-5747, RHAIENG-5748).
+
+Covers:
+- Empty messages validation returns 422 (not 500)
+- _extract_usage populates usage when AIMessage.usage_metadata is present
+- _extract_usage returns None when no metadata is available
+"""
+
+import os
+import sys
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from pydantic import ValidationError
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from main import ChatCompletionRequest, _extract_usage
+
+
+class TestEmptyMessagesValidation:
+    def test_empty_messages_rejected(self):
+        with pytest.raises(ValidationError) as exc_info:
+            ChatCompletionRequest(messages=[])
+        assert "messages" in str(exc_info.value)
+
+    def test_single_message_accepted(self):
+        req = ChatCompletionRequest(
+            messages=[{"role": "user", "content": "hello"}]
+        )
+        assert len(req.messages) == 1
+
+
+class TestExtractUsage:
+    def test_returns_none_when_no_ai_messages(self):
+        messages = [HumanMessage(content="hi")]
+        assert _extract_usage(messages) is None
+
+    def test_returns_none_when_ai_has_no_metadata(self):
+        messages = [AIMessage(content="response")]
+        assert _extract_usage(messages) is None
+
+    def test_returns_usage_when_metadata_present(self):
+        msg = AIMessage(
+            content="response",
+            usage_metadata={
+                "input_tokens": 10,
+                "output_tokens": 20,
+                "total_tokens": 30,
+            },
+        )
+        result = _extract_usage([msg])
+        assert result == {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+        }
+
+    def test_sums_across_multiple_ai_messages(self):
+        messages = [
+            AIMessage(
+                content="thought",
+                usage_metadata={
+                    "input_tokens": 5,
+                    "output_tokens": 10,
+                    "total_tokens": 15,
+                },
+            ),
+            ToolMessage(content="result", tool_call_id="tc1"),
+            AIMessage(
+                content="final",
+                usage_metadata={
+                    "input_tokens": 8,
+                    "output_tokens": 12,
+                    "total_tokens": 20,
+                },
+            ),
+        ]
+        result = _extract_usage(messages)
+        assert result == {
+            "prompt_tokens": 13,
+            "completion_tokens": 22,
+            "total_tokens": 35,
+        }
+
+    def test_skips_messages_without_metadata(self):
+        messages = [
+            AIMessage(content="no metadata"),
+            AIMessage(
+                content="has metadata",
+                usage_metadata={
+                    "input_tokens": 7,
+                    "output_tokens": 3,
+                    "total_tokens": 10,
+                },
+            ),
+        ]
+        result = _extract_usage(messages)
+        assert result == {
+            "prompt_tokens": 7,
+            "completion_tokens": 3,
+            "total_tokens": 10,
+        }
+
+    def test_returns_none_for_empty_list(self):
+        assert _extract_usage([]) is None

--- a/agents/langgraph/templates/react_with_database_memory/tests/test_api_contract.py
+++ b/agents/langgraph/templates/react_with_database_memory/tests/test_api_contract.py
@@ -25,9 +25,7 @@ class TestEmptyMessagesValidation:
         assert "messages" in str(exc_info.value)
 
     def test_single_message_accepted(self):
-        req = ChatCompletionRequest(
-            messages=[{"role": "user", "content": "hello"}]
-        )
+        req = ChatCompletionRequest(messages=[{"role": "user", "content": "hello"}])
         assert len(req.messages) == 1
 
 

--- a/agents/llamaindex/templates/websearch_agent/main.py
+++ b/agents/llamaindex/templates/websearch_agent/main.py
@@ -44,7 +44,9 @@ class ChatCompletionRequest(BaseModel):
     """
 
     messages: list[ChatMessage] = Field(
-        ..., description="A list of messages comprising the conversation so far."
+        ...,
+        min_length=1,
+        description="A list of messages comprising the conversation so far.",
     )
     model: str | None = Field(
         None,

--- a/agents/vanilla_python/templates/openai_responses_agent/main.py
+++ b/agents/vanilla_python/templates/openai_responses_agent/main.py
@@ -45,7 +45,9 @@ class ChatCompletionRequest(BaseModel):
     """
 
     messages: list[ChatMessage] = Field(
-        ..., description="A list of messages comprising the conversation so far."
+        ...,
+        min_length=1,
+        description="A list of messages comprising the conversation so far.",
     )
     model: str | None = Field(
         None,


### PR DESCRIPTION
## Summary
- **RHAIENG-5748**: Add `min_length=1` to the Pydantic `messages` field in 8 standard agents so FastAPI returns 422 on empty messages instead of crashing with 500. AutoGen already validates via `model_validator`.
- **RHAIENG-5747**: Extract token usage from framework responses and populate the `usage` field:
  - **LangGraph** (4 agents): sum `AIMessage.usage_metadata` across all LLM calls in a turn
  - **CrewAI**: forward `CrewOutput.token_usage`
  - **AutoGen**: add `usage` field to `ChatResponse` (defaults to None until framework exposes it)
  - **LlamaIndex, Vanilla Python, ADK**: remain None (framework limitation — use MLflow trace enrichment as workaround)

## Agents modified (9)
| Agent | min_length | usage extraction |
|-------|-----------|-----------------| 
| LangGraph React | Yes | AIMessage.usage_metadata |
| LangGraph HITL | Yes | AIMessage.usage_metadata |
| LangGraph DB Memory | Yes | AIMessage.usage_metadata |
| LangGraph Agentic RAG | Yes | AIMessage.usage_metadata |
| CrewAI Websearch | Yes | CrewOutput.token_usage |
| LlamaIndex Websearch | Yes | None (framework limitation) |
| Vanilla Python OpenAI | Yes | None (framework limitation) |
| Google ADK | Yes | None (framework limitation) |
| AutoGen MCP | N/A (has validator) | None (field added) |

## Fix: HITL usage over-counting (review feedback)
The HITL agent uses a `MemorySaver` checkpointer, so `result.value.get("messages", [])` returns the full conversation history across turns. The initial implementation passed `all_messages` to `_extract_usage`, which would accumulate token counts from ALL prior turns — not just the current request. Fixed by adding `prior_count` tracking (matching the DB Memory agent pattern) to scope usage and content extraction to new messages only.

## Test plan
- [x] Verify empty messages returns 422 (not 500) for each agent
- [x] Verify non-streaming response includes `usage` with token counts for LangGraph and CrewAI agents
- [x] Verify agents where usage is None still return valid responses
- [x] Verify HITL agent reports usage for current turn only (not cumulative across thread)
- [x] Run `tests/behavioral/api_contract/test_api_contract.py::test_empty_messages_list_handled` against a deployed agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)