### PR TITLE
docs: prefer Atlassian MCP for Jira and Confluence access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,11 @@ make dry-run    # preview Helm manifests
 - Never commit `.env` files -- only `.env.example` templates
 - Standard containers: UBI9 base (`registry.access.redhat.com/ubi9/python-312`), non-root UID 1001, port 8080
 
+## Tooling preferences
+
+- Prefer the Atlassian MCP server for Jira and Confluence access in this repository when it is available and authorized
+- Fall back to direct HTTP/API calls only when the Atlassian MCP server is unavailable or does not expose the needed capability
+
 ## Boundaries
 
 - Don't modify `agents/<framework>/deployment/` chart templates unless explicitly requested


### PR DESCRIPTION
## Description
Keep repository instructions aligned with the available integration so agents use the Atlassian MCP server first and only fall back to direct API calls when needed.

## Jira Ticket

NA

## Testing

- [ ] `make test` passes (run from the affected agent directory)
- [ ] Manual testing performed (describe steps below)
- [X] No testing required (documentation/config change only)

## Checklist

- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [X] No `.env` or secret files are included in this PR
- [ ] All changes are within scope of the linked Jira ticket (if not, explain in Description)