### PR TITLE
docs: add single-file verification commands to AGENTS.md (RHAIENG-5709)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,16 @@ make deploy     # deploy to OpenShift/K8s via Helm
 make dry-run    # preview Helm manifests
 ```
 
+## Single-file verification
+
+```bash
+# Lint a single file
+ruff check path/to/file.py
+
+# Format-check a single file
+ruff format --check path/to/file.py
+```
+
 ## Code style
 
 - Python >=3.12, <3.14. Use `uv` as package manager -- never `pip` directly


### PR DESCRIPTION
## Description

Add a **Single-file verification** section to AGENTS.md documenting per-file `ruff check` and `ruff format --check` commands. This gives AI coding agents and developers a fast way to verify individual files without running the full test suite or linting the entire repo.

## Jira Ticket

RHAIENG-5709

## Testing

- [ ] ~~`make test` passes (run from the affected agent directory)~~
- [ ] ~~Manual testing performed (describe steps below)~~
- [x] No testing required (documentation/config change only)

Verified `ruff check` and `ruff format --check` both complete in under 5 seconds on a sample agent file.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)

## Review Guidance

Single-file change to AGENTS.md only — adds a new section between Commands and Code style.

## Related PRs

<!-- none -->