### PR TITLE
test: add integration deployment test for db memory agent (RHAIENG-4030)

### DIFF
--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -68,7 +68,6 @@ jobs:
             POSTGRES_PORT: ${{ vars.POSTGRES_PORT }}
             POSTGRES_DB: ${{ vars.POSTGRES_DB }}
             POSTGRES_USER: ${{ vars.POSTGRES_USER }}
-            POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
     env:
       API_KEY: ${{ vars.API_KEY }}
       BASE_URL: ${{ vars.BASE_URL }}
@@ -90,7 +89,7 @@ jobs:
           POSTGRES_PORT: ${{ matrix.POSTGRES_PORT }}
           POSTGRES_DB: ${{ matrix.POSTGRES_DB }}
           POSTGRES_USER: ${{ matrix.POSTGRES_USER }}
-          POSTGRES_PASSWORD: ${{ matrix.POSTGRES_PASSWORD }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
         run: make test-integration
 
       - name: Upload test results

--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -61,6 +61,14 @@ jobs:
           - { name: langgraph-hitl-agent, dir: agents/langgraph/templates/human_in_the_loop }
           - { name: crewai-websearch-agent, dir: agents/crewai/templates/websearch_agent }
           - { name: google-adk-agent, dir: agents/google/templates/adk }
+          - { name: langgraph-db-memory-agent, dir: agents/langgraph/templates/react_with_database_memory }
+        include:
+          - agent: { name: langgraph-db-memory-agent, dir: agents/langgraph/templates/react_with_database_memory }
+            POSTGRES_HOST: ${{ vars.POSTGRES_HOST }}
+            POSTGRES_PORT: ${{ vars.POSTGRES_PORT }}
+            POSTGRES_DB: ${{ vars.POSTGRES_DB }}
+            POSTGRES_USER: ${{ vars.POSTGRES_USER }}
+            POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
     env:
       API_KEY: ${{ vars.API_KEY }}
       BASE_URL: ${{ vars.BASE_URL }}
@@ -77,6 +85,12 @@ jobs:
 
       - name: Run integration test
         working-directory: ${{ matrix.agent.dir }}
+        env:
+          POSTGRES_HOST: ${{ matrix.POSTGRES_HOST }}
+          POSTGRES_PORT: ${{ matrix.POSTGRES_PORT }}
+          POSTGRES_DB: ${{ matrix.POSTGRES_DB }}
+          POSTGRES_USER: ${{ matrix.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ matrix.POSTGRES_PASSWORD }}
         run: make test-integration
 
       - name: Upload test results

--- a/agents/langgraph/templates/react_with_database_memory/Makefile
+++ b/agents/langgraph/templates/react_with_database_memory/Makefile
@@ -5,7 +5,7 @@ VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 MODEL          ?= llama3.1:8b
 
-.PHONY: init re-init env ollama ogx-server run-app run-app-fresh run-cli build push build-openshift deploy undeploy test dry-run help
+.PHONY: init re-init env ollama ogx-server run-app run-app-fresh run-cli build push build-openshift deploy undeploy test test-integration dry-run help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-12s %s\n", $$1, $$2}'
@@ -178,3 +178,8 @@ undeploy: ## Remove deployment from cluster
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)
+
+test-integration: ## Run integration deployment test
+	PYTHONPATH=$$(git rev-parse --show-toplevel)/tests \
+	  uv run --extra dev python -m pytest tests/integration/test_deployment.py \
+	    -v --tb=long --junitxml=results.xml

--- a/agents/langgraph/templates/react_with_database_memory/tests/integration/conftest.py
+++ b/agents/langgraph/templates/react_with_database_memory/tests/integration/conftest.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+from integration.conftest import cluster_auth, repo_root  # noqa: F401
+from integration.utils import (
+    MakeTargetError,
+    RouteNotFoundError,
+    get_route,
+    load_agent_name,
+    resolve_agent_dir,
+    run_make,
+)
+
+logger = logging.getLogger(__name__)
+
+INTERNAL_REGISTRY = "image-registry.openshift-image-registry.svc:5000"
+
+_REQUIRED_ENV = (
+    "BASE_URL",
+    "MODEL_ID",
+    "POSTGRES_HOST",
+    "POSTGRES_PORT",
+    "POSTGRES_DB",
+    "POSTGRES_USER",
+    "POSTGRES_PASSWORD",
+)
+
+
+@pytest.fixture(scope="module")
+def agent_dir():
+    return resolve_agent_dir(__file__)
+
+
+@pytest.fixture(scope="module")
+def agent_name(agent_dir):
+    return load_agent_name(agent_dir)
+
+
+def _write_env_file(agent_dir, container_image):
+    """Write a .env file with base and PostgreSQL env vars."""
+    missing = [v for v in _REQUIRED_ENV if v not in os.environ]
+    if missing:
+        pytest.fail(
+            f"Missing required env vars for database-backed agent: {', '.join(missing)}. "
+            "Set them in the CI workflow or export locally."
+        )
+    env_path = agent_dir / ".env"
+    env_path.write_text(
+        f"API_KEY={os.environ.get('API_KEY', 'not-needed')}\n"
+        f"BASE_URL={os.environ['BASE_URL']}\n"
+        f"MODEL_ID={os.environ['MODEL_ID']}\n"
+        f"CONTAINER_IMAGE={container_image}\n"
+        f"POSTGRES_HOST={os.environ['POSTGRES_HOST']}\n"
+        f"POSTGRES_PORT={os.environ['POSTGRES_PORT']}\n"
+        f"POSTGRES_DB={os.environ['POSTGRES_DB']}\n"
+        f"POSTGRES_USER={os.environ['POSTGRES_USER']}\n"
+        f"POSTGRES_PASSWORD={os.environ['POSTGRES_PASSWORD']}\n"
+    )
+    return env_path
+
+
+@pytest.fixture(scope="module")
+def deployed_agent(cluster_auth, agent_dir, agent_name):
+    namespace = cluster_auth["namespace"]
+    container_image = f"{INTERNAL_REGISTRY}/{namespace}/{agent_name}:latest"
+    env_path = _write_env_file(agent_dir, container_image)
+
+    deployed = False
+    try:
+        try:
+            logger.info("Building image on cluster via build-openshift...")
+            run_make("build-openshift", cwd=agent_dir, timeout=600)
+
+            logger.info("Deploying to cluster...")
+            run_make("deploy", cwd=agent_dir, timeout=300)
+            deployed = True
+
+            route_url = get_route(agent_name, namespace=namespace)
+            logger.info("Agent deployed at %s", route_url)
+        except (MakeTargetError, RouteNotFoundError) as exc:
+            pytest.fail(f"Deployment failed: {exc}")
+        except Exception as exc:
+            pytest.fail(f"Unexpected error during deployment setup: {exc}")
+
+        yield route_url
+
+    finally:
+        if deployed:
+            logger.info("Tearing down deployment...")
+            try:
+                run_make("undeploy", cwd=agent_dir, timeout=120)
+            except MakeTargetError:
+                logger.warning(
+                    "Cleanup failed — manual undeploy may be needed", exc_info=True
+                )
+        env_path.unlink(missing_ok=True)

--- a/agents/langgraph/templates/react_with_database_memory/tests/integration/conftest.py
+++ b/agents/langgraph/templates/react_with_database_memory/tests/integration/conftest.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import logging
 import os
 
-import integration.conftest  # noqa: F401 — re-exports cluster_auth, repo_root
 import pytest
+from integration.conftest import cluster_auth, repo_root  # noqa: F401
 from integration.utils import (
     MakeTargetError,
     RouteNotFoundError,
@@ -63,7 +63,7 @@ def _write_env_file(agent_dir, container_image):
 
 
 @pytest.fixture(scope="module")
-def deployed_agent(cluster_auth, agent_dir, agent_name):
+def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
     namespace = cluster_auth["namespace"]
     container_image = f"{INTERNAL_REGISTRY}/{namespace}/{agent_name}:latest"
     env_path = _write_env_file(agent_dir, container_image)

--- a/agents/langgraph/templates/react_with_database_memory/tests/integration/conftest.py
+++ b/agents/langgraph/templates/react_with_database_memory/tests/integration/conftest.py
@@ -41,7 +41,7 @@ def agent_name(agent_dir):
 
 def _write_env_file(agent_dir, container_image):
     """Write a .env file with base and PostgreSQL env vars."""
-    missing = [v for v in _REQUIRED_ENV if v not in os.environ]
+    missing = [v for v in _REQUIRED_ENV if not os.environ.get(v)]
     if missing:
         pytest.fail(
             f"Missing required env vars for database-backed agent: {', '.join(missing)}. "

--- a/agents/langgraph/templates/react_with_database_memory/tests/integration/conftest.py
+++ b/agents/langgraph/templates/react_with_database_memory/tests/integration/conftest.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import logging
 import os
 
+import integration.conftest  # noqa: F401 — re-exports cluster_auth, repo_root
 import pytest
-from integration.conftest import cluster_auth, repo_root  # noqa: F401
 from integration.utils import (
     MakeTargetError,
     RouteNotFoundError,

--- a/agents/langgraph/templates/react_with_database_memory/tests/integration/test_deployment.py
+++ b/agents/langgraph/templates/react_with_database_memory/tests/integration/test_deployment.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import pytest
+from integration.utils import health_check
+
+
+@pytest.mark.integration
+def test_health_endpoint(deployed_agent):
+    route_url = deployed_agent
+    result = health_check(f"{route_url}/health", retries=12, backoff=5.0)
+
+    assert result["status"] == "healthy"
+    assert result["agent_initialized"] is True

--- a/agents/langgraph/templates/react_with_database_memory/tests/integration/test_deployment.py
+++ b/agents/langgraph/templates/react_with_database_memory/tests/integration/test_deployment.py
@@ -11,3 +11,4 @@ def test_health_endpoint(deployed_agent):
 
     assert result["status"] == "healthy"
     assert result["agent_initialized"] is True
+    assert result["database_connected"] is True

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -40,6 +40,11 @@ _REDACT_PATTERNS = [
     re.compile(r"(VECTOR_STORE_ID=)\S+"),
     re.compile(r'(--set\s+env\.VECTOR_STORE_ID=")[^"]*"'),
     re.compile(r"(--set\s+env\.VECTOR_STORE_ID=)\S+"),
+    re.compile(r"(POSTGRES_PASSWORD=)\S+"),
+    re.compile(r'(postgresPassword:\s*")[^"]*"'),
+    re.compile(r'(--set\s+secrets\.postgresPassword=")[^"]*"'),
+    re.compile(r"(--set\s+secrets\.postgresPassword=)\S+"),
+    re.compile(r"(POSTGRES_USER=)\S+"),
 ]
 
 


### PR DESCRIPTION
## Description

Add integration deployment test for the **LangGraph React with DB Memory Agent** (Tier 2). This agent requires a pre-provisioned PostgreSQL database on the cluster beyond the standard `API_KEY`/`BASE_URL`/`MODEL_ID` env vars.

Follows the `has_extra_env_vars` pattern established by the agentic_rag integration test — fixtures and deployment logic live in `conftest.py`, with a minimal `test_deployment.py`.

## Jira Ticket

RHAIENG-4030

## Testing

- [x] `make test` passes (run from the affected agent directory)
- [x] Test collection verified — `pytest --collect-only` shows 1 test, no import errors
- [x] Cross-agent consistency check — 7/7 checks pass against agentic_rag reference
- [x] Live cluster test — requires cluster access; will be validated in nightly CI

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket

## Review Guidance

- `conftest.py` follows the agentic_rag pattern — compare with `agents/langgraph/templates/agentic_rag/tests/integration/conftest.py`
- CI workflow uses `matrix.include` to scope POSTGRES vars to this agent only — `vars.*` for non-sensitive, `secrets.*` for password
- GitHub vars/secrets (`POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`) must be configured in the repo before the nightly CI run will pass

## Related PRs

- agentic-starter-kits-skills PR #12 — updated `add-integration-tests` skill with capability discovery for tier 2+ agents