### PR TITLE
ci: lightweight ty on PRs, comprehensive on push to main (RHAIENG-4064)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -129,18 +129,69 @@ jobs:
         run: pip install ty==0.0.51
 
       - name: Run type-check
-        # ty (Astral) — same toolchain as ruff/uv.
-        # --ignore rules suppress noise from third-party deps not installed
-        # in this job and framework-specific dynamic patterns (decorators,
-        # monkey-patching, global None|Callable singletons).
-        run: >
-          ty check
-          --ignore unresolved-import
-          --ignore unresolved-attribute
-          --ignore call-non-callable
-          --ignore invalid-argument-type
-          --ignore unsupported-operator
-          --ignore invalid-assignment
-          --ignore invalid-type-form
-          --ignore invalid-yield
-          agents/ components/
+        # Lightweight gate — rules in ty.toml suppress noise from missing
+        # third-party stubs. Push-to-main runs the comprehensive check.
+        run: ty check
+
+  type-check-comprehensive:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+        with:
+          version: "0.11.21"
+          enable-cache: true
+
+      - name: Install ty
+        run: pip install ty==0.0.51
+
+      - name: Run comprehensive type-check
+        # Auto-discovers every pyproject.toml under agents/ and components/,
+        # installs deps, then runs ty with --error all (overrides ty.toml).
+        # Checks src/ and main.py when present; falls back to *.py files.
+        shell: bash
+        run: |
+          failed=0
+          while IFS= read -r pyproject; do
+            dir="$(dirname "$pyproject")"
+            name=$(echo "$dir" | sed 's|^\./||;s|agents/||;s|/templates/|/|')
+
+            # Build the list of paths to check
+            check=()
+            [ -d "$dir/src" ] && check+=(src/)
+            [ -f "$dir/main.py" ] && check+=(main.py)
+            if [ ${#check[@]} -eq 0 ]; then
+              while IFS= read -r f; do
+                check+=("$(basename "$f")")
+              done < <(find "$dir" -maxdepth 1 -name '*.py' -not -name '__init__.py')
+            fi
+            [ ${#check[@]} -eq 0 ] && continue
+
+            echo "::group::$name"
+            echo "Installing deps in $dir..."
+            (cd "$dir" && uv sync --frozen)
+            echo "Running ty check (--error all) on: ${check[*]}"
+            if (cd "$dir" && ty check --error all --python .venv "${check[@]}"); then
+              echo "✅ $name passed"
+            else
+              echo "::error::ty check failed for $name"
+              failed=1
+            fi
+            echo "::endgroup::"
+          done < <(find ./agents ./components -name pyproject.toml \
+                        ! -path '*/.venv/*' ! -path '*/egg-info/*' | sort)
+          exit $failed

--- a/agents/a2a/templates/langgraph_crewai_agent/src/a2a_langgraph_crewai/crew_a2a_server.py
+++ b/agents/a2a/templates/langgraph_crewai_agent/src/a2a_langgraph_crewai/crew_a2a_server.py
@@ -70,7 +70,7 @@ def _run_crew(user_prompt: str) -> str:
     # in newer CrewAI versions (>=1.10). If a future version fixes this, remove
     # the manual wrapping below to avoid duplicate tool spans.
     for tool in tools:
-        tool._run = wrap_func_with_mlflow_trace(
+        tool._run = wrap_func_with_mlflow_trace(  # ty: ignore[invalid-assignment]
             tool._run, span_type="tool", name=tool.name
         )
 

--- a/agents/autogen/templates/mcp_agent/mcp_automl_template/utils.py
+++ b/agents/autogen/templates/mcp_agent/mcp_automl_template/utils.py
@@ -105,6 +105,7 @@ def json_schema_to_pydantic_model(
             )
         typ = prop.get("type", "string")
         enum_vals = prop.get("enum")
+        py_type = None
 
         if enum_vals is not None:
             if not enum_vals:
@@ -125,8 +126,9 @@ def json_schema_to_pydantic_model(
                         f"Unsupported JSON Schema type {typ!r} for field {name!r}"
                     )
 
+        assert py_type is not None
         field_definitions[name] = (
-            (py_type, ...) if name in required else (py_type | None, None)
+            (py_type, ...) if name in required else (py_type | None, None)  # ty: ignore[unsupported-operator]
         )
 
     return create_model(class_name, **field_definitions)

--- a/agents/crewai/templates/websearch_agent/src/crewai_web_search/crew.py
+++ b/agents/crewai/templates/websearch_agent/src/crewai_web_search/crew.py
@@ -30,7 +30,7 @@ class AssistanceAgents:
         # in newer CrewAI versions (>=1.10). If a future version fixes this, remove
         # the manual wrapping below to avoid duplicate tool spans.
         for tool in tools:
-            tool._run = wrap_func_with_mlflow_trace(
+            tool._run = wrap_func_with_mlflow_trace(  # ty: ignore[invalid-assignment]
                 tool._run, span_type="tool", name=tool.name
             )
 

--- a/agents/langgraph/templates/agentic_rag/src/agentic_rag/agent.py
+++ b/agents/langgraph/templates/agentic_rag/src/agentic_rag/agent.py
@@ -42,6 +42,7 @@ def get_graph_closure(
         model_id = getenv("MODEL_ID")
 
     # Check if using local deployment
+    assert base_url is not None
     is_local = any(host in base_url for host in ["localhost", "127.0.0.1"])
 
     if not is_local and not api_key:

--- a/agents/langgraph/templates/human_in_the_loop/main.py
+++ b/agents/langgraph/templates/human_in_the_loop/main.py
@@ -250,6 +250,7 @@ async def _handle_chat(
     global agent_graph_closure, checkpointer
 
     try:
+        assert agent_graph_closure is not None
         agent = agent_graph_closure(checkpointer)
 
         if request.approval:
@@ -360,6 +361,7 @@ async def _handle_stream(
 
     async def event_generator():
         try:
+            assert agent_graph_closure is not None
             agent = agent_graph_closure(checkpointer)
 
             if request.approval:

--- a/agents/langgraph/templates/human_in_the_loop/src/human_in_the_loop/agent.py
+++ b/agents/langgraph/templates/human_in_the_loop/src/human_in_the_loop/agent.py
@@ -41,6 +41,7 @@ def get_graph_closure(
     if base_url and not base_url.endswith("/v1"):
         base_url = base_url.rstrip("/") + "/v1"
 
+    assert base_url is not None
     is_local = any(host in base_url for host in ["localhost", "127.0.0.1"])
     if not is_local and not api_key:
         raise ValueError("API_KEY is required for non-local environments.")

--- a/agents/langgraph/templates/react_agent/src/react_agent/agent.py
+++ b/agents/langgraph/templates/react_agent/src/react_agent/agent.py
@@ -34,6 +34,7 @@ def get_graph_closure(
     if not model_id:
         model_id = getenv("MODEL_ID")
 
+    assert base_url is not None
     is_local = any(host in base_url for host in ["localhost", "127.0.0.1"])
 
     if not is_local and not api_key:

--- a/agents/langgraph/templates/react_with_database_memory/examples/ai_service.py
+++ b/agents/langgraph/templates/react_with_database_memory/examples/ai_service.py
@@ -131,7 +131,7 @@ def ai_stream_service(
 
             return execute_response
 
-    def generate_stream(context) -> Generator[dict, ..., ...]:
+    def generate_stream(context) -> Generator[dict, None, None]:
         headers = context.get_headers()
         is_assistant = headers.get("X-Ai-Interface") == "assistant"
 

--- a/agents/langgraph/templates/react_with_database_memory/main.py
+++ b/agents/langgraph/templates/react_with_database_memory/main.py
@@ -260,6 +260,7 @@ async def _handle_chat(
     global agent_graph_closure, DB_URI
 
     try:
+        assert agent_graph_closure is not None
         async with AsyncPostgresSaver.from_conn_string(DB_URI) as saver:
             await saver.setup()
 
@@ -333,6 +334,7 @@ async def _handle_stream(
 
     async def event_generator():
         try:
+            assert agent_graph_closure is not None
             async with AsyncPostgresSaver.from_conn_string(DB_URI) as saver:
                 await saver.setup()
 

--- a/agents/langgraph/templates/react_with_database_memory/src/react_with_database_memory/agent.py
+++ b/agents/langgraph/templates/react_with_database_memory/src/react_with_database_memory/agent.py
@@ -73,6 +73,7 @@ def get_graph_closure(
         base_url = base_url.rstrip("/") + "/v1"
 
     # Validate API key for non-local environments
+    assert base_url is not None
     is_local = any(host in base_url for host in ["localhost", "127.0.0.1"])
     if not is_local and not api_key:
         raise ValueError("API_KEY is required for non-local environments.")

--- a/agents/llamaindex/templates/websearch_agent/examples/_interactive_chat.py
+++ b/agents/llamaindex/templates/websearch_agent/examples/_interactive_chat.py
@@ -57,7 +57,7 @@ class InteractiveChat:
             f"\n\033[31m\n> Questions:\033[0m\n{self._ordered_list(self._questions)}\n"
         )
 
-    def _user_input_loop(self) -> Generator[str, bool, None]:
+    def _user_input_loop(self) -> Generator[tuple[str, str], None, None]:
         print(self._help_message)
         while True:
             print(self._questions_prompt)

--- a/agents/llamaindex/templates/websearch_agent/main.py
+++ b/agents/llamaindex/templates/websearch_agent/main.py
@@ -278,6 +278,7 @@ async def _handle_chat(user_message: str, model_id: str):
     global get_agent
 
     try:
+        assert get_agent is not None
         agent = get_agent()
         messages = [{"role": "user", "content": user_message}]
 
@@ -335,6 +336,7 @@ async def _handle_stream(user_message: str, model_id: str):
 
     async def event_generator():
         try:
+            assert get_agent is not None
             agent = get_agent()
             messages = [{"role": "user", "content": user_message}]
 

--- a/agents/llamaindex/templates/websearch_agent/src/websearch_agent/agent.py
+++ b/agents/llamaindex/templates/websearch_agent/src/websearch_agent/agent.py
@@ -22,6 +22,7 @@ def get_workflow_closure(
     if not model_id:
         model_id = getenv("MODEL_ID")
 
+    assert base_url is not None
     is_local = any(host in base_url for host in ["localhost", "127.0.0.1"])
 
     if not is_local and not api_key:

--- a/agents/vanilla_python/templates/openai_responses_agent/main.py
+++ b/agents/vanilla_python/templates/openai_responses_agent/main.py
@@ -192,6 +192,7 @@ async def _handle_chat(user_message: str, model_id: str):
     global get_agent
 
     try:
+        assert get_agent is not None
         agent = get_agent()
         messages = [{"role": "user", "content": user_message}]
 
@@ -253,6 +254,7 @@ async def _handle_stream(user_message: str, model_id: str):
                 queue.put_nowait((event_type, data))
 
             def run_agent():
+                assert get_agent is not None
                 adapter = get_agent()
                 agent = AIAgent(
                     model=adapter._model_id,

--- a/agents/vanilla_python/templates/openai_responses_agent/src/openai_responses_agent/agent.py
+++ b/agents/vanilla_python/templates/openai_responses_agent/src/openai_responses_agent/agent.py
@@ -94,7 +94,7 @@ class _AIAgentAdapter:
             func = wrap_func_with_mlflow_trace(func, span_type="tool")
             agent.register_tool(name, func)
 
-        agent.query = wrap_func_with_mlflow_trace(agent.query, span_type="agent")
+        agent.query = wrap_func_with_mlflow_trace(agent.query, span_type="agent")  # ty: ignore[invalid-assignment]
         answer = await asyncio.to_thread(agent.query, question)
         if answer is None:
             answer = ""

--- a/evals/evalhub_adapter/adapter.py
+++ b/evals/evalhub_adapter/adapter.py
@@ -49,7 +49,7 @@ from .evaluations import QuerySpec, get_benchmark, load_queries, resolve_scorers
 try:
     from harness.mlflow_client import MLflowTraceClient
 except ImportError:
-    MLflowTraceClient = None  # type: ignore[misc,assignment]
+    MLflowTraceClient = None  # type: ignore[misc,assignment]  # ty: ignore[invalid-assignment]
 
 logger = logging.getLogger(__name__)
 

--- a/evals/harness/tests/test_runner_langflow.py
+++ b/evals/harness/tests/test_runner_langflow.py
@@ -290,7 +290,7 @@ class TestRunTaskLangflow:
         result = asyncio.run(run_task(config, client=mock_client))
 
         assert result.success is False
-        assert "500" in result.error
+        assert result.error is not None and "500" in result.error
 
 
 # ---------------------------------------------------------------------------

--- a/tests/behavioral/api_contract/conftest.py
+++ b/tests/behavioral/api_contract/conftest.py
@@ -20,4 +20,5 @@ def agent_url() -> str:
             "AGENT_URL env var is required for API contract tests. "
             "Set it to the base URL of a running agent."
         )
+        raise SystemExit  # unreachable; narrows type for ty
     return url

--- a/ty.toml
+++ b/ty.toml
@@ -1,0 +1,9 @@
+# Lightweight ty config — used by PR checks and local dev.
+# Suppresses errors from third-party deps not installed and
+# framework-specific dynamic patterns (decorators, monkey-patching).
+# The comprehensive push-to-main check overrides these with --error all.
+
+[rules]
+unresolved-import = "ignore"
+unresolved-attribute = "ignore"
+invalid-argument-type = "ignore"


### PR DESCRIPTION
- Add ty.toml with ignore rules for lightweight PR gate (no deps needed)
- PR check: `ty check agents/ components/` — picks up ty.toml, fast
- Push to main: new type-check-comprehensive job loops agents, installs deps via uv sync, runs `ty check --error all --python .venv` overriding ty.toml ignores
- No matrix — single job with grouped output per agent

<!-- PR title must follow Conventional Commits (e.g. feat: add health check endpoint). It becomes the commit message on main. -->

## Description

<!-- Summarize your changes and the motivation behind them -->

## Jira Ticket

<!-- e.g. RHAIENG-123. Include the ticket ID so the PR appears as a linked pull request on the Jira issue. -->

## Testing

- [ ] `make test` passes (run from the affected agent directory)
- [ ] Manual testing performed (describe steps below)
- [ ] No testing required (documentation/config change only)

<!-- Describe any additional verification steps -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] No `.env` or secret files are included in this PR
- [ ] All changes are within scope of the linked Jira ticket (if not, explain in Description)

## Review Guidance

<!-- Optional: highlight areas that need careful review, key design decisions, or files that can be safely skipped -->

## Related PRs

<!-- Link any related pull requests, e.g. #42, #56 -->
