### PR TITLE
feat: add integration tests for OpenAI Responses Agent (RHAIENG-4032)

### DIFF
--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -94,7 +94,7 @@ jobs:
         if: matrix.agent.name != 'autogen-mcp-agent' || vars.MCP_SERVER_URL != ''
         working-directory: ${{ matrix.agent.dir }}
         env:
-          API_KEY: ${{ matrix.API_KEY || vars.API_KEY }}
+          API_KEY: ${{ matrix.agent.name == 'vanilla-python-openai-responses-agent' && secrets.OPENAI_API_KEY || vars.API_KEY }}
           BASE_URL: ${{ matrix.BASE_URL || vars.BASE_URL }}
           MODEL_ID: ${{ matrix.MODEL_ID || vars.MODEL_ID }}
           POSTGRES_HOST: ${{ matrix.POSTGRES_HOST }}

--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -64,6 +64,7 @@ jobs:
           - { name: llamaindex-websearch-agent, dir: agents/llamaindex/templates/websearch_agent }
           - { name: langgraph-db-memory-agent, dir: agents/langgraph/templates/react_with_database_memory }
           - { name: autogen-mcp-agent, dir: agents/autogen/templates/mcp_agent }
+          - { name: vanilla-python-openai-responses-agent, dir: agents/vanilla_python/templates/openai_responses_agent }
         include:
           - agent: { name: langgraph-db-memory-agent, dir: agents/langgraph/templates/react_with_database_memory }
             POSTGRES_HOST: ${{ vars.POSTGRES_HOST }}
@@ -72,6 +73,9 @@ jobs:
             POSTGRES_USER: ${{ vars.POSTGRES_USER }}
           - agent: { name: autogen-mcp-agent, dir: agents/autogen/templates/mcp_agent }
             MCP_SERVER_URL: ${{ vars.MCP_SERVER_URL }}
+          - agent: { name: vanilla-python-openai-responses-agent, dir: agents/vanilla_python/templates/openai_responses_agent }
+            BASE_URL: ${{ vars.OPENAI_BASE_URL }}
+            MODEL_ID: ${{ vars.OPENAI_MODEL_ID }}
     env:
       API_KEY: ${{ vars.API_KEY }}
       BASE_URL: ${{ vars.BASE_URL }}
@@ -90,6 +94,9 @@ jobs:
         if: matrix.agent.name != 'autogen-mcp-agent' || vars.MCP_SERVER_URL != ''
         working-directory: ${{ matrix.agent.dir }}
         env:
+          API_KEY: ${{ matrix.API_KEY || vars.API_KEY }}
+          BASE_URL: ${{ matrix.BASE_URL || vars.BASE_URL }}
+          MODEL_ID: ${{ matrix.MODEL_ID || vars.MODEL_ID }}
           POSTGRES_HOST: ${{ matrix.POSTGRES_HOST }}
           POSTGRES_PORT: ${{ matrix.POSTGRES_PORT }}
           POSTGRES_DB: ${{ matrix.POSTGRES_DB }}

--- a/agents/vanilla_python/templates/openai_responses_agent/Makefile
+++ b/agents/vanilla_python/templates/openai_responses_agent/Makefile
@@ -4,7 +4,7 @@ CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 
-.PHONY: init re-init env run-app run-app-fresh run-cli build push build-openshift deploy undeploy test dry-run help
+.PHONY: init re-init env run-app run-app-fresh run-cli build push build-openshift deploy undeploy test test-integration dry-run help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-12s %s\n", $$1, $$2}'
@@ -130,3 +130,8 @@ undeploy: ## Remove deployment from cluster
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)
+
+test-integration: ## Run integration deployment test
+	PYTHONPATH=$$(git rev-parse --show-toplevel)/tests \
+	  uv run --extra dev python -m pytest tests/integration/test_deployment.py \
+	    -v --tb=long --junitxml=results.xml

--- a/agents/vanilla_python/templates/openai_responses_agent/tests/integration/conftest.py
+++ b/agents/vanilla_python/templates/openai_responses_agent/tests/integration/conftest.py
@@ -1,0 +1,2 @@
+# Re-export shared integration fixtures so pytest discovers them.
+from integration.conftest import cluster_auth, repo_root  # noqa: F401

--- a/agents/vanilla_python/templates/openai_responses_agent/tests/integration/test_deployment.py
+++ b/agents/vanilla_python/templates/openai_responses_agent/tests/integration/test_deployment.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+from integration.utils import (
+    MakeTargetError,
+    RouteNotFoundError,
+    get_route,
+    health_check,
+    load_agent_name,
+    resolve_agent_dir,
+    run_make,
+)
+
+logger = logging.getLogger(__name__)
+
+INTERNAL_REGISTRY = "image-registry.openshift-image-registry.svc:5000"
+
+
+@pytest.fixture(scope="module")
+def agent_dir():
+    return resolve_agent_dir(__file__)
+
+
+@pytest.fixture(scope="module")
+def agent_name(agent_dir):
+    return load_agent_name(agent_dir)
+
+
+def _write_env_file(agent_dir, container_image):
+    """Write a .env file so Makefile targets can source it."""
+    missing = [v for v in ("BASE_URL", "MODEL_ID") if v not in os.environ]
+    if missing:
+        pytest.fail(
+            f"Missing required env vars: {', '.join(missing)}. "
+            "Set them in the CI workflow or export locally."
+        )
+    env_path = agent_dir / ".env"
+    orig_env = None
+    if env_path.exists():
+        orig_env = env_path.read_text(encoding="utf-8")
+    env_path.write_text(
+        f"API_KEY={os.environ.get('API_KEY', 'not-needed')}\n"
+        f"BASE_URL={os.environ['BASE_URL']}\n"
+        f"MODEL_ID={os.environ['MODEL_ID']}\n"
+        f"CONTAINER_IMAGE={container_image}\n",
+        encoding="utf-8",
+    )
+    return env_path, orig_env
+
+
+@pytest.fixture(scope="module")
+def deployed_agent(cluster_auth, agent_dir, agent_name):
+    namespace = cluster_auth["namespace"]
+    container_image = f"{INTERNAL_REGISTRY}/{namespace}/{agent_name}:latest"
+    env_path, orig_env = _write_env_file(agent_dir, container_image)
+
+    deployed = False
+    try:
+        logger.info("Building image on cluster via build-openshift...")
+        run_make("build-openshift", cwd=agent_dir, timeout=600)
+
+        logger.info("Deploying to cluster...")
+        run_make("deploy", cwd=agent_dir, timeout=300)
+        deployed = True
+
+        route_url = get_route(agent_name, namespace=namespace)
+        logger.info("Agent deployed at %s", route_url)
+
+        yield route_url
+
+    except (MakeTargetError, RouteNotFoundError) as exc:
+        pytest.fail(f"Deployment failed: {exc}")
+
+    finally:
+        if deployed:
+            logger.info("Tearing down deployment...")
+            try:
+                run_make("undeploy", cwd=agent_dir, timeout=120)
+            except MakeTargetError:
+                logger.warning(
+                    "Cleanup failed — manual undeploy may be needed", exc_info=True
+                )
+        if orig_env is not None:
+            try:
+                env_path.write_text(orig_env, encoding="utf-8")
+            except Exception:
+                logger.exception("Failed to restore pre-existing .env at %s", env_path)
+        else:
+            env_path.unlink(missing_ok=True)
+
+
+@pytest.mark.integration
+def test_health_endpoint(deployed_agent):
+    route_url = deployed_agent
+    result = health_check(f"{route_url}/health", retries=12, backoff=5.0)
+
+    assert result["status"] == "healthy"
+    assert result["agent_initialized"] is True

--- a/agents/vanilla_python/templates/openai_responses_agent/tests/integration/test_deployment.py
+++ b/agents/vanilla_python/templates/openai_responses_agent/tests/integration/test_deployment.py
@@ -31,18 +31,19 @@ def agent_name(agent_dir):
 
 def _write_env_file(agent_dir, container_image):
     """Write a .env file so Makefile targets can source it."""
-    missing = [v for v in ("BASE_URL", "MODEL_ID") if v not in os.environ]
+    missing = [v for v in ("API_KEY", "BASE_URL", "MODEL_ID") if v not in os.environ]
     if missing:
         pytest.fail(
             f"Missing required env vars: {', '.join(missing)}. "
-            "Set them in the CI workflow or export locally."
+            "This agent requires a real OpenAI API key — set OPENAI_API_KEY "
+            "in CI secrets or export API_KEY locally."
         )
     env_path = agent_dir / ".env"
     orig_env = None
     if env_path.exists():
         orig_env = env_path.read_text(encoding="utf-8")
     env_path.write_text(
-        f"API_KEY={os.environ.get('API_KEY', 'not-needed')}\n"
+        f"API_KEY={os.environ['API_KEY']}\n"
         f"BASE_URL={os.environ['BASE_URL']}\n"
         f"MODEL_ID={os.environ['MODEL_ID']}\n"
         f"CONTAINER_IMAGE={container_image}\n",


### PR DESCRIPTION
## Summary
- Add deployment health-check integration test for the vanilla Python OpenAI Responses Agent
- Add `test-integration` Makefile target and CI workflow matrix entry
- Uses `matrix.include` to inject OpenAI-specific env vars (`vars.OPENAI_BASE_URL`, `vars.OPENAI_MODEL_ID`) and a step-level conditional for `secrets.OPENAI_API_KEY` so this Tier 2 agent gets its own env vars while other agents keep using vLLM defaults

## CI Prerequisites
Before this agent can run in the nightly pipeline, configure in GitHub repo settings:
- **Secret**: `OPENAI_API_KEY` — a real OpenAI API key
- **Variable**: `OPENAI_BASE_URL` — e.g. `https://api.openai.com/v1`
- **Variable**: `OPENAI_MODEL_ID` — e.g. `gpt-4o-mini`

## Test plan
- [x] `pytest --collect-only` passes (1 test collected, no import errors)
- [x] Live cluster test (`make test-integration`) — passed on `ci-testing` namespace (build-openshift → deploy → health check → undeploy, 2m12s)
- [x] Cross-agent consistency check — matches standard pattern (react_agent, crewai/websearch_agent)
- [x] CI YAML valid — actionlint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)