### PR TITLE
feat: migrate AutoGen MCP agent from LlamaStack to OGX (RHAIENG-5453)

### DIFF
--- a/agents/autogen/templates/mcp_agent/mcp_automl_template/AUTOML_DEPLOYMENT.md
+++ b/agents/autogen/templates/mcp_agent/mcp_automl_template/AUTOML_DEPLOYMENT.md
@@ -166,7 +166,7 @@ Edit `.env`:
 - **DEPLOYMENT_URL** = full predict URL, e.g. `https://my-model-myproject.apps.example.com/v1/models/my-churn-model:predict`
 - **DEPLOYMENT_TOKEN** = token from the deployment’s Token secret (leave empty or omit if you did not enable token auth)
 
-Keep `LLAMA_STACK_CLIENT_*` (or other LLM vars) if you use the demo client; see main [README](README.md).
+Keep `OGX_BASE_URL`/`OGX_API_KEY` (or other LLM vars) if you use the demo client; see main [README](README.md).
 
 ### 3.3 Run the MCP server and call the tool
 

--- a/agents/autogen/templates/mcp_agent/mcp_automl_template/AUTOML_DEPLOYMENT.md
+++ b/agents/autogen/templates/mcp_agent/mcp_automl_template/AUTOML_DEPLOYMENT.md
@@ -166,7 +166,7 @@ Edit `.env`:
 - **DEPLOYMENT_URL** = full predict URL, e.g. `https://my-model-myproject.apps.example.com/v1/models/my-churn-model:predict`
 - **DEPLOYMENT_TOKEN** = token from the deployment’s Token secret (leave empty or omit if you did not enable token auth)
 
-Keep `OGX_BASE_URL`/`OGX_API_KEY` (or other LLM vars) if you use the demo client; see main [README](README.md).
+Keep `BASE_URL`/`API_KEY`/`MODEL_ID` (LLM vars) if you use the demo client; see main [README](README.md).
 
 ### 3.3 Run the MCP server and call the tool
 

--- a/agents/autogen/templates/mcp_agent/mcp_automl_template/README.md
+++ b/agents/autogen/templates/mcp_agent/mcp_automl_template/README.md
@@ -43,7 +43,7 @@ mcp_automl_template/
 ├── register_tools.py   # Loads tools_config.yaml, builds tools from JSON schemas
 ├── tools_config.yaml   # Tool definitions: name, description, schema_path, deployment env vars
 ├── churn_schema.json   # JSON Schema for churn prediction tool input
-├── utils.py            # json_schema_to_pydantic_model, LLM clients (OpenAI/Ollama/OGX)
+├── utils.py            # json_schema_to_pydantic_model, LLM client (OpenAI-compatible)
 ├── interact_with_mcp.py # Client: connects via SSE, loads MCP tools, runs LangGraph agent
 └── README.md
 ```
@@ -76,11 +76,11 @@ mcp_automl_template/
 
    - `DEPLOYMENT_URL` – prediction endpoint URL (e.g. AutoML deployment)
    - `DEPLOYMENT_TOKEN` – Bearer token for that endpoint
-   - `OGX_BASE_URL` – OGX base URL (for `interact_with_mcp.py` via `get_chat_ogx()`)
-   - `OGX_API_KEY` – OGX API key
-   - `MODEL_ID` – model identifier for the OGX endpoint (e.g. `llama-3.1-8b-instruct`)
+   - `BASE_URL` – LLM base URL (for `interact_with_mcp.py` via `get_chat_from_env()`)
+   - `API_KEY` – LLM API key
+   - `MODEL_ID` – model identifier (e.g. `llama-3.1-8b-instruct`)
 
-   Replace the placeholders with your actual values. For local LLM testing with Ollama only, the deployment and OGX vars can stay as placeholders if you do not use those features.
+   Replace the placeholders with your actual values. For local LLM testing with Ollama only, the deployment vars can stay as placeholders if you do not use those features.
 
 ## Configuration
 

--- a/agents/autogen/templates/mcp_agent/mcp_automl_template/README.md
+++ b/agents/autogen/templates/mcp_agent/mcp_automl_template/README.md
@@ -78,6 +78,7 @@ mcp_automl_template/
    - `DEPLOYMENT_TOKEN` – Bearer token for that endpoint
    - `OGX_BASE_URL` – OGX base URL (for `interact_with_mcp.py` via `get_chat_ogx()`)
    - `OGX_API_KEY` – OGX API key
+   - `MODEL_ID` – model identifier for the OGX endpoint (e.g. `llama-3.1-8b-instruct`)
 
    Replace the placeholders with your actual values. For local LLM testing with Ollama only, the deployment and OGX vars can stay as placeholders if you do not use those features.
 

--- a/agents/autogen/templates/mcp_agent/mcp_automl_template/README.md
+++ b/agents/autogen/templates/mcp_agent/mcp_automl_template/README.md
@@ -43,7 +43,7 @@ mcp_automl_template/
 ├── register_tools.py   # Loads tools_config.yaml, builds tools from JSON schemas
 ├── tools_config.yaml   # Tool definitions: name, description, schema_path, deployment env vars
 ├── churn_schema.json   # JSON Schema for churn prediction tool input
-├── utils.py            # json_schema_to_pydantic_model, LLM clients (OpenAI/Ollama, OGX)
+├── utils.py            # json_schema_to_pydantic_model, LLM clients (OpenAI/Ollama/OGX)
 ├── interact_with_mcp.py # Client: connects via SSE, loads MCP tools, runs LangGraph agent
 └── README.md
 ```
@@ -76,8 +76,8 @@ mcp_automl_template/
 
    - `DEPLOYMENT_URL` – prediction endpoint URL (e.g. AutoML deployment)
    - `DEPLOYMENT_TOKEN` – Bearer token for that endpoint
-   - `LLAMA_STACK_CLIENT_BASE_URL` – OGX base URL (for `interact_with_mcp.py`)
-   - `LLAMA_STACK_CLIENT_API_KEY` – OGX API key
+   - `OGX_BASE_URL` – OGX base URL (for `interact_with_mcp.py` via `get_chat_ogx()`)
+   - `OGX_API_KEY` – OGX API key
 
    Replace the placeholders with your actual values. For local LLM testing with Ollama only, the deployment and OGX vars can stay as placeholders if you do not use those features.
 

--- a/agents/autogen/templates/mcp_agent/mcp_automl_template/interact_with_mcp.py
+++ b/agents/autogen/templates/mcp_agent/mcp_automl_template/interact_with_mcp.py
@@ -29,8 +29,8 @@ help_message = textwrap.dedent(
 )
 
 
-# Function to send a query to the agent
 async def ask_question(agent: Any, user_input: str) -> None:
+    """Send a query to the agent and pretty-print each response message."""
     response = await agent.ainvoke(
         {"messages": [{"role": "user", "content": user_input}]}
     )
@@ -38,8 +38,8 @@ async def ask_question(agent: Any, user_input: str) -> None:
         msg.pretty_print()
 
 
-# Main chat loop
 async def chat_loop() -> None:
+    """Connect to the MCP server and run an interactive LangGraph ReAct agent loop."""
     mcp_url = getenv("MCP_SERVER_URL", "http://127.0.0.1:8080/sse")
     print(mcp_url)
     async with sse_client(url=mcp_url) as (read, write):

--- a/agents/autogen/templates/mcp_agent/mcp_automl_template/interact_with_mcp.py
+++ b/agents/autogen/templates/mcp_agent/mcp_automl_template/interact_with_mcp.py
@@ -48,9 +48,8 @@ async def chat_loop() -> None:
             tools = await load_mcp_tools(session)
             formatted_tools = tools
 
-            # System prompt for Llama 3.1 8B: only use tools if truly necessary, otherwise answer directly.
-            # For increased agency, guide the model to avoid tool use unless it cannot answer from its own knowledge.
-            # The system prompt for Llama 3.1 8B should specifically instruct the model to do two things:
+            # Only use tools if truly necessary, otherwise answer directly.
+            # Guide the model to avoid tool use unless it cannot answer from its own knowledge.
             # 1. If a tool is used and a response is returned as a list of objects containing a 'text' field,
             #    extract the answer from the 'text' field and present that as the final user-facing response.
             # 2. Always ensure that the user receives a direct, clear answer to their question, whether from the model's own knowledge or from an extracted tool response.

--- a/agents/autogen/templates/mcp_agent/mcp_automl_template/utils.py
+++ b/agents/autogen/templates/mcp_agent/mcp_automl_template/utils.py
@@ -167,31 +167,3 @@ def get_chat_from_env() -> ChatOpenAI:
         api_key=api_key or "not-needed",
         temperature=0.1,
     )
-
-
-def get_chat_ogx() -> ChatOpenAI:
-    """ChatOpenAI pointing at an OGX endpoint via OGX_BASE_URL, OGX_API_KEY, and MODEL_ID."""
-    from langchain_openai import ChatOpenAI
-
-    ogx_base_url = getenv("OGX_BASE_URL")
-    ogx_api_key = getenv("OGX_API_KEY")
-    model_id = getenv("MODEL_ID")
-    if ogx_base_url is not None:
-        ogx_base_url = ogx_base_url.strip().rstrip("/")
-    if model_id is not None:
-        model_id = model_id.strip()
-    if ogx_api_key is not None:
-        ogx_api_key = ogx_api_key.strip()
-    if not ogx_base_url or not model_id:
-        raise ValueError("OGX_BASE_URL and MODEL_ID must be set")
-
-    url = ogx_base_url
-    if not url.endswith("/v1"):
-        url = url + "/v1"
-
-    return ChatOpenAI(
-        base_url=url,
-        model=model_id,
-        api_key=ogx_api_key or "not-needed",
-        temperature=0.1,
-    )

--- a/agents/autogen/templates/mcp_agent/mcp_automl_template/utils.py
+++ b/agents/autogen/templates/mcp_agent/mcp_automl_template/utils.py
@@ -9,7 +9,6 @@ from dotenv import load_dotenv
 from pydantic import BaseModel, create_model
 
 if TYPE_CHECKING:
-    from langchain_llama_stack import ChatLlamaStack
     from langchain_openai import ChatOpenAI
 
 load_dotenv()
@@ -143,7 +142,7 @@ def json_schema_to_pydantic_model(
 def get_chat_from_env() -> ChatOpenAI:
     """
     ChatOpenAI from BASE_URL, MODEL_ID, and optional API_KEY (OpenAI-compatible API:
-    Llama Stack, Ollama, OpenAI, …). Configure everything in `.env` — no separate code path
+    OGX, Ollama, OpenAI, …). Configure everything in `.env` — no separate code path
     for Ollama; use e.g. BASE_URL=http://localhost:11434/v1, MODEL_ID=llama3.2, API_KEY=ollama.
     """
     from langchain_openai import ChatOpenAI
@@ -170,28 +169,29 @@ def get_chat_from_env() -> ChatOpenAI:
     )
 
 
-def get_chat_llama_stack() -> ChatLlamaStack:
-    from langchain_llama_stack import ChatLlamaStack
+def get_chat_ogx() -> ChatOpenAI:
+    """ChatOpenAI pointing at an OGX endpoint via OGX_BASE_URL, OGX_API_KEY, and MODEL_ID."""
+    from langchain_openai import ChatOpenAI
 
-    llama_base_url = getenv("LLAMA_STACK_CLIENT_BASE_URL")
-    llama_api_key = getenv("LLAMA_STACK_CLIENT_API_KEY")
+    ogx_base_url = getenv("OGX_BASE_URL")
+    ogx_api_key = getenv("OGX_API_KEY")
     model_id = getenv("MODEL_ID")
-    if llama_base_url is not None:
-        llama_base_url = llama_base_url.strip().rstrip("/")
+    if ogx_base_url is not None:
+        ogx_base_url = ogx_base_url.strip().rstrip("/")
     if model_id is not None:
         model_id = model_id.strip()
-    if llama_api_key is not None:
-        llama_api_key = llama_api_key.strip()
-    if not llama_base_url or not model_id:
-        raise ValueError("LLAMA_STACK_CLIENT_BASE_URL and MODEL_ID must be set")
+    if ogx_api_key is not None:
+        ogx_api_key = ogx_api_key.strip()
+    if not ogx_base_url or not model_id:
+        raise ValueError("OGX_BASE_URL and MODEL_ID must be set")
 
-    url = llama_base_url
+    url = ogx_base_url
     if not url.endswith("/v1"):
         url = url + "/v1"
 
-    return ChatLlamaStack(
+    return ChatOpenAI(
         base_url=url,
-        api_key=llama_api_key,
         model=model_id,
+        api_key=ogx_api_key or "not-needed",
         temperature=0.1,
     )

--- a/agents/autogen/templates/mcp_agent/src/autogen_agent_base/agent.py
+++ b/agents/autogen/templates/mcp_agent/src/autogen_agent_base/agent.py
@@ -18,7 +18,7 @@ def get_agent_chat(
 
     Args:
         model_id: LLM model identifier.
-        base_url: Base URL for the API (e.g. OpenAI-compatible or Llama Stack).
+        base_url: Base URL for the API (e.g. OpenAI-compatible or OGX).
         api_key: API key (optional for some endpoints).
         tools: Optional list of tools (e.g. MCP tool adapters). When None, uses TOOLS from this module.
     """


### PR DESCRIPTION
## Description

Migrates the AutoGen MCP agent (`agents/autogen/templates/mcp_agent/`) from LlamaStack to OGX. This is a naming/branding change in the community — OGX provides an OpenAI-compatible API, so the migration replaces `ChatLlamaStack` (from `langchain-llama-stack`) with `ChatOpenAI` (from `langchain-openai`) and updates environment variables and documentation accordingly.

**Code changes:**
- `utils.py`: Replaced `get_chat_llama_stack()` → `get_chat_ogx()` using `ChatOpenAI` instead of `ChatLlamaStack`; removed `langchain_llama_stack` import; env vars `LLAMA_STACK_CLIENT_BASE_URL`/`LLAMA_STACK_CLIENT_API_KEY` → `OGX_BASE_URL`/`OGX_API_KEY`
- `interact_with_mcp.py`: Removed Llama 3.1 8B-specific comments (system prompt itself is model-agnostic, unchanged)
- `agent.py`: Updated docstring reference from "Llama Stack" → "OGX"

**Documentation changes:**
- `mcp_automl_template/README.md`: Updated env var names and directory tree description
- `AUTOML_DEPLOYMENT.md`: Updated env var references

## Jira Ticket

RHAIENG-5453

## Testing

- [ ] `make test` passes (run from the affected agent directory)
- [x] Manual testing performed (describe steps below)
- [ ] No testing required (documentation/config change only)

### Smoke test results (local, Ollama llama3.1:8b)

```
# 1. Setup
make init && make env   # ✅ Dependencies installed (56 packages)

# 2. Start MCP server
make run-mcp            # ✅ Uvicorn running on http://0.0.0.0:8080

# 3. Start agent
make run-app            # ✅ Uvicorn running on http://127.0.0.1:8000
                        # ✅ No langchain_llama_stack import errors
                        # ✅ Tracing correctly disabled (MLFLOW_TRACKING_URI not set)

# 4. Health check
curl http://localhost:8000/health
# ✅ {"status": "healthy", "agent_initialized": true}

# 5. Chat completions (tool discovery + response)
curl -X POST http://localhost:8000/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"message": "What is 2+7? Use a tool!", "stream": false}'
# ✅ 200 OK — agent discovers MCP tools (add, sub, invoke_churn) and responds

# 6. Regex verification — zero LlamaStack references remain
grep -rniP "llama[\s_-]*stack|llamastack|ChatLlamaStack|langchain[\s_-]*llama|LLAMA_STACK" \
  agents/autogen/templates/mcp_agent/ --include="*.py" --include="*.md" \
  --include="*.toml" --include="*.yaml"
# ✅ No matches
```

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)

## Review Guidance

- The core change is in `utils.py` — `get_chat_llama_stack()` replaced by `get_chat_ogx()`. The new function uses `ChatOpenAI` (already a dependency) instead of `ChatLlamaStack`, so no new packages are needed.
- `pyproject.toml` files did not need changes — `langchain-llama-stack` was never a declared dependency at this level (it was only used via a lazy import in `utils.py`).
- Model name references like `llama3.1:8b` are intentionally preserved — these are Ollama model identifiers, not LlamaStack package references.

## Related PRs

<!-- Link any related pull requests, e.g. #42, #56 -->