### PR TITLE
fix: restore mcp_agent container build context (RHAIENG-5912)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ CLAUDE.local.md
 .cursor
 .pre-commit-cache/
 .worktrees/
+.build-context.*
 **/REFACTORING.md
 STATUS.md
 .e2e-workdir

--- a/agents/autogen/templates/mcp_agent/Makefile
+++ b/agents/autogen/templates/mcp_agent/Makefile
@@ -5,6 +5,15 @@ VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 MODEL          ?= llama3.1:8b
 
+STAGE_BUILD_CONTEXT = \
+	BUILD_CONTEXT=$$(mktemp -d ./.build-context.XXXXXX) && \
+	trap 'rm -rf "$$BUILD_CONTEXT"' EXIT && \
+	cp Dockerfile pyproject.toml main.py "$$BUILD_CONTEXT"/ && \
+	cp -r src playground "$$BUILD_CONTEXT"/ && \
+	cp -r ../../../../images "$$BUILD_CONTEXT"/images && \
+	if [ -d ./images ]; then cp -r ./images/. "$$BUILD_CONTEXT"/images/; fi && \
+	mkdir -p "$$BUILD_CONTEXT"/components && cp -r ../../../../components/auth "$$BUILD_CONTEXT"/components/auth
+
 .PHONY: init env ollama ogx-server run-app run-app-fresh run-mcp interact-mcp build push build-openshift deploy deploy-mcp undeploy undeploy-mcp test test-integration dry-run dry-run-mcp help
 
 help: ## Show this help
@@ -94,13 +103,7 @@ build: ## Build container image locally (podman/docker)
 	@[ -n "$(CONTAINER_CLI)" ] || { echo "ERROR: neither podman nor docker found in PATH"; exit 1; } && \
 	  source .env && \
 	  [ -n "$${CONTAINER_IMAGE}" ] || { echo "ERROR: CONTAINER_IMAGE is not set in .env"; exit 1; } && \
-	  BUILD_CONTEXT=$$(mktemp -d ./.build-context.XXXXXX) && \
-	  trap 'rm -rf "$$BUILD_CONTEXT"' EXIT && \
-	  cp Dockerfile pyproject.toml main.py "$$BUILD_CONTEXT"/ && \
-	  cp -r src playground "$$BUILD_CONTEXT"/ && \
-	  cp -r ../../../../images "$$BUILD_CONTEXT"/images && \
-	  if [ -d ./images ]; then cp -r ./images/. "$$BUILD_CONTEXT"/images/; fi && \
-	  mkdir -p "$$BUILD_CONTEXT"/components && cp -r ../../../../components/auth "$$BUILD_CONTEXT"/components/auth && \
+	  $(STAGE_BUILD_CONTEXT) && \
 	  $(CONTAINER_CLI) build --platform linux/amd64 -t "$${CONTAINER_IMAGE}" -f "$$BUILD_CONTEXT/Dockerfile" "$$BUILD_CONTEXT"
 
 push: ## Push container image to registry
@@ -110,13 +113,7 @@ push: ## Push container image to registry
 	  $(CONTAINER_CLI) push "$${CONTAINER_IMAGE}"
 
 build-openshift: ## Build image in-cluster via OpenShift BuildConfig (no podman/docker needed)
-	@BUILD_CONTEXT=$$(mktemp -d ./.build-context.XXXXXX) && \
-	  trap 'rm -rf "$$BUILD_CONTEXT"' EXIT && \
-	  cp Dockerfile pyproject.toml main.py "$$BUILD_CONTEXT"/ && \
-	  cp -r src playground "$$BUILD_CONTEXT"/ && \
-	  cp -r ../../../../images "$$BUILD_CONTEXT"/images && \
-	  if [ -d ./images ]; then cp -r ./images/. "$$BUILD_CONTEXT"/images/; fi && \
-	  mkdir -p "$$BUILD_CONTEXT"/components && cp -r ../../../../components/auth "$$BUILD_CONTEXT"/components/auth && \
+	@$(STAGE_BUILD_CONTEXT) && \
 	  oc new-build --strategy=docker --binary --name=$(AGENT_NAME) --to=$(AGENT_NAME):latest 2>/dev/null || true && \
 	  oc start-build $(AGENT_NAME) --from-dir="$$BUILD_CONTEXT" --follow && \
 	  NS=$$(oc project -q) && \

--- a/agents/autogen/templates/mcp_agent/Makefile
+++ b/agents/autogen/templates/mcp_agent/Makefile
@@ -94,8 +94,14 @@ build: ## Build container image locally (podman/docker)
 	@[ -n "$(CONTAINER_CLI)" ] || { echo "ERROR: neither podman nor docker found in PATH"; exit 1; } && \
 	  source .env && \
 	  [ -n "$${CONTAINER_IMAGE}" ] || { echo "ERROR: CONTAINER_IMAGE is not set in .env"; exit 1; } && \
-	  cp -r ../../../../images ./images && trap 'rm -rf ./images' EXIT && \
-	  $(CONTAINER_CLI) build --platform linux/amd64 -t "$${CONTAINER_IMAGE}" -f Dockerfile .
+	  BUILD_CONTEXT=$$(mktemp -d ./.build-context.XXXXXX) && \
+	  trap 'rm -rf "$$BUILD_CONTEXT"' EXIT && \
+	  cp Dockerfile pyproject.toml main.py "$$BUILD_CONTEXT"/ && \
+	  cp -r src playground "$$BUILD_CONTEXT"/ && \
+	  cp -r ../../../../images "$$BUILD_CONTEXT"/images && \
+	  if [ -d ./images ]; then cp -r ./images/. "$$BUILD_CONTEXT"/images/; fi && \
+	  mkdir -p "$$BUILD_CONTEXT"/components && cp -r ../../../../components/auth "$$BUILD_CONTEXT"/components/auth && \
+	  $(CONTAINER_CLI) build --platform linux/amd64 -t "$${CONTAINER_IMAGE}" -f "$$BUILD_CONTEXT/Dockerfile" "$$BUILD_CONTEXT"
 
 push: ## Push container image to registry
 	@[ -n "$(CONTAINER_CLI)" ] || { echo "ERROR: neither podman nor docker found in PATH"; exit 1; } && \
@@ -104,9 +110,15 @@ push: ## Push container image to registry
 	  $(CONTAINER_CLI) push "$${CONTAINER_IMAGE}"
 
 build-openshift: ## Build image in-cluster via OpenShift BuildConfig (no podman/docker needed)
-	@cp -r ../../../../images ./images && trap 'rm -rf ./images' EXIT && \
+	@BUILD_CONTEXT=$$(mktemp -d ./.build-context.XXXXXX) && \
+	  trap 'rm -rf "$$BUILD_CONTEXT"' EXIT && \
+	  cp Dockerfile pyproject.toml main.py "$$BUILD_CONTEXT"/ && \
+	  cp -r src playground "$$BUILD_CONTEXT"/ && \
+	  cp -r ../../../../images "$$BUILD_CONTEXT"/images && \
+	  if [ -d ./images ]; then cp -r ./images/. "$$BUILD_CONTEXT"/images/; fi && \
+	  mkdir -p "$$BUILD_CONTEXT"/components && cp -r ../../../../components/auth "$$BUILD_CONTEXT"/components/auth && \
 	  oc new-build --strategy=docker --binary --name=$(AGENT_NAME) --to=$(AGENT_NAME):latest 2>/dev/null || true && \
-	  oc start-build $(AGENT_NAME) --from-dir=. --follow && \
+	  oc start-build $(AGENT_NAME) --from-dir="$$BUILD_CONTEXT" --follow && \
 	  NS=$$(oc project -q) && \
 	  echo "" && \
 	  echo "Image built. To deploy, set in .env:" && \

--- a/agents/autogen/templates/mcp_agent/tests/test_packaging_config.py
+++ b/agents/autogen/templates/mcp_agent/tests/test_packaging_config.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+AGENT_DIR = Path(__file__).resolve().parents[1]
+MAKEFILE = (AGENT_DIR / "Makefile").read_text(encoding="utf-8")
+DOCKERFILE = (AGENT_DIR / "Dockerfile").read_text(encoding="utf-8")
+NORMALIZED_MAKEFILE = re.sub(r"\s+", " ", MAKEFILE)
+NORMALIZED_DOCKERFILE = re.sub(r"\s+", " ", DOCKERFILE)
+
+
+def test_makefile_stages_auth_component_for_container_builds() -> None:
+    build_context_pattern = r"BUILD_CONTEXT=\$\$\(mktemp -d \./\.build-context\.XXXXXX\)"
+    copy_pattern = (
+        r'mkdir -p "\$\$BUILD_CONTEXT"/components && cp -r '
+        r'\.\./\.\./\.\./\.\./components/auth "\$\$BUILD_CONTEXT"/components/auth'
+    )
+    cleanup_pattern = r"trap 'rm -rf \"\$\$BUILD_CONTEXT\"' EXIT"
+
+    assert len(re.findall(build_context_pattern, NORMALIZED_MAKEFILE)) == 2
+    assert len(re.findall(copy_pattern, NORMALIZED_MAKEFILE)) == 2
+    assert len(re.findall(cleanup_pattern, NORMALIZED_MAKEFILE)) == 2
+
+
+def test_makefile_preserves_tracked_images_during_container_builds() -> None:
+    shared_stage_pattern = (
+        r'cp -r \.\./\.\./\.\./\.\./images "\$\$BUILD_CONTEXT"/images'
+    )
+    merge_pattern = (
+        r'if \[ -d \./images \]; then cp -r \./images/\. "\$\$BUILD_CONTEXT"/images/; fi'
+    )
+
+    assert len(re.findall(shared_stage_pattern, NORMALIZED_MAKEFILE)) == 2
+    assert len(re.findall(merge_pattern, NORMALIZED_MAKEFILE)) == 2
+
+
+def test_makefile_builds_from_temporary_context() -> None:
+    local_build_pattern = (
+        r'\$\(CONTAINER_CLI\) build --platform linux/amd64 -t "\$\$\{CONTAINER_IMAGE\}" '
+        r'-f "\$\$BUILD_CONTEXT/Dockerfile" "\$\$BUILD_CONTEXT"'
+    )
+    openshift_build_pattern = (
+        r'oc start-build \$\(AGENT_NAME\) --from-dir="\$\$BUILD_CONTEXT" --follow'
+    )
+
+    assert re.search(local_build_pattern, NORMALIZED_MAKEFILE)
+    assert re.search(openshift_build_pattern, NORMALIZED_MAKEFILE)
+
+
+def test_dockerfile_consumes_staged_auth_component() -> None:
+    assert re.search(r"COPY components/auth/ \./components/auth/", NORMALIZED_DOCKERFILE)
+    assert re.search(r"RUN uv pip install --no-cache \./components/auth", NORMALIZED_DOCKERFILE)

--- a/agents/autogen/templates/mcp_agent/tests/test_packaging_config.py
+++ b/agents/autogen/templates/mcp_agent/tests/test_packaging_config.py
@@ -11,7 +11,9 @@ NORMALIZED_DOCKERFILE = re.sub(r"\s+", " ", DOCKERFILE)
 
 
 def test_makefile_stages_auth_component_for_container_builds() -> None:
-    build_context_pattern = r"BUILD_CONTEXT=\$\$\(mktemp -d \./\.build-context\.XXXXXX\)"
+    build_context_pattern = (
+        r"BUILD_CONTEXT=\$\$\(mktemp -d \./\.build-context\.XXXXXX\)"
+    )
     copy_pattern = (
         r'mkdir -p "\$\$BUILD_CONTEXT"/components && cp -r '
         r'\.\./\.\./\.\./\.\./components/auth "\$\$BUILD_CONTEXT"/components/auth'
@@ -27,9 +29,7 @@ def test_makefile_preserves_tracked_images_during_container_builds() -> None:
     shared_stage_pattern = (
         r'cp -r \.\./\.\./\.\./\.\./images "\$\$BUILD_CONTEXT"/images'
     )
-    merge_pattern = (
-        r'if \[ -d \./images \]; then cp -r \./images/\. "\$\$BUILD_CONTEXT"/images/; fi'
-    )
+    merge_pattern = r'if \[ -d \./images \]; then cp -r \./images/\. "\$\$BUILD_CONTEXT"/images/; fi'
 
     assert len(re.findall(shared_stage_pattern, NORMALIZED_MAKEFILE)) == 2
     assert len(re.findall(merge_pattern, NORMALIZED_MAKEFILE)) == 2
@@ -49,5 +49,9 @@ def test_makefile_builds_from_temporary_context() -> None:
 
 
 def test_dockerfile_consumes_staged_auth_component() -> None:
-    assert re.search(r"COPY components/auth/ \./components/auth/", NORMALIZED_DOCKERFILE)
-    assert re.search(r"RUN uv pip install --no-cache \./components/auth", NORMALIZED_DOCKERFILE)
+    assert re.search(
+        r"COPY components/auth/ \./components/auth/", NORMALIZED_DOCKERFILE
+    )
+    assert re.search(
+        r"RUN uv pip install --no-cache \./components/auth", NORMALIZED_DOCKERFILE
+    )

--- a/agents/autogen/templates/mcp_agent/tests/test_packaging_config.py
+++ b/agents/autogen/templates/mcp_agent/tests/test_packaging_config.py
@@ -4,13 +4,16 @@ import re
 from pathlib import Path
 
 AGENT_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = AGENT_DIR.parents[3]
 MAKEFILE = (AGENT_DIR / "Makefile").read_text(encoding="utf-8")
 DOCKERFILE = (AGENT_DIR / "Dockerfile").read_text(encoding="utf-8")
+GITIGNORE = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8")
 NORMALIZED_MAKEFILE = re.sub(r"\s+", " ", MAKEFILE)
 NORMALIZED_DOCKERFILE = re.sub(r"\s+", " ", DOCKERFILE)
 
 
 def test_makefile_stages_auth_component_for_container_builds() -> None:
+    helper_pattern = r"(?m)^STAGE_BUILD_CONTEXT = \\$"
     build_context_pattern = (
         r"BUILD_CONTEXT=\$\$\(mktemp -d \./\.build-context\.XXXXXX\)"
     )
@@ -20,9 +23,10 @@ def test_makefile_stages_auth_component_for_container_builds() -> None:
     )
     cleanup_pattern = r"trap 'rm -rf \"\$\$BUILD_CONTEXT\"' EXIT"
 
-    assert len(re.findall(build_context_pattern, NORMALIZED_MAKEFILE)) == 2
-    assert len(re.findall(copy_pattern, NORMALIZED_MAKEFILE)) == 2
-    assert len(re.findall(cleanup_pattern, NORMALIZED_MAKEFILE)) == 2
+    assert re.search(helper_pattern, MAKEFILE)
+    assert len(re.findall(build_context_pattern, NORMALIZED_MAKEFILE)) == 1
+    assert len(re.findall(copy_pattern, NORMALIZED_MAKEFILE)) == 1
+    assert len(re.findall(cleanup_pattern, NORMALIZED_MAKEFILE)) == 1
 
 
 def test_makefile_preserves_tracked_images_during_container_builds() -> None:
@@ -31,8 +35,16 @@ def test_makefile_preserves_tracked_images_during_container_builds() -> None:
     )
     merge_pattern = r'if \[ -d \./images \]; then cp -r \./images/\. "\$\$BUILD_CONTEXT"/images/; fi'
 
-    assert len(re.findall(shared_stage_pattern, NORMALIZED_MAKEFILE)) == 2
-    assert len(re.findall(merge_pattern, NORMALIZED_MAKEFILE)) == 2
+    assert len(re.findall(shared_stage_pattern, NORMALIZED_MAKEFILE)) == 1
+    assert len(re.findall(merge_pattern, NORMALIZED_MAKEFILE)) == 1
+
+
+def test_makefile_build_targets_use_shared_context_helper() -> None:
+    assert len(re.findall(r"\$\(STAGE_BUILD_CONTEXT\)", MAKEFILE)) == 2
+
+
+def test_gitignore_ignores_temp_build_context_dirs() -> None:
+    assert ".build-context.*" in GITIGNORE
 
 
 def test_makefile_builds_from_temporary_context() -> None:


### PR DESCRIPTION

## Description

Stage auth and image assets in a temporary build context so local and OpenShift builds satisfy the Dockerfile without mutating tracked files. Add packaging regression tests so make test now covers the container staging path.

## Jira Ticket

RHAIENG-5912

## Testing

- [x] `make test` passes (run from the affected agent directory)
- [ ] Manual testing performed (describe steps below)
- [ ] No testing required (documentation/config change only)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)

## Related PRs

https://github.com/red-hat-data-services/agentic-starter-kits/pull/210