### PR TITLE
feat(ci): add static CI health dashboard for GitHub Pages

### DIFF
--- a/.github/scripts/fixtures/ci-runs-sample.json
+++ b/.github/scripts/fixtures/ci-runs-sample.json
@@ -1,0 +1,82 @@
+{
+  "code-quality.yml": [
+    {
+      "id": 10001,
+      "name": "Code Quality",
+      "event": "push",
+      "head_branch": "main",
+      "status": "completed",
+      "conclusion": "success",
+      "html_url": "https://github.com/red-hat-data-services/agentic-starter-kits/actions/runs/10001",
+      "created_at": "2026-07-05T08:15:22Z",
+      "updated_at": "2026-07-05T08:18:40Z",
+      "run_started_at": "2026-07-05T08:15:30Z"
+    },
+    {
+      "id": 10000,
+      "name": "Code Quality",
+      "event": "push",
+      "head_branch": "main",
+      "status": "completed",
+      "conclusion": "failure",
+      "html_url": "https://github.com/red-hat-data-services/agentic-starter-kits/actions/runs/10000",
+      "created_at": "2026-07-03T14:02:11Z",
+      "updated_at": "2026-07-03T14:05:02Z",
+      "run_started_at": "2026-07-03T14:02:20Z"
+    }
+  ],
+  "agent-tests.yml": [
+    {
+      "id": 10011,
+      "name": "Agent Tests",
+      "event": "push",
+      "head_branch": "main",
+      "status": "completed",
+      "conclusion": "success",
+      "html_url": "https://github.com/red-hat-data-services/agentic-starter-kits/actions/runs/10011",
+      "created_at": "2026-07-05T08:20:05Z",
+      "updated_at": "2026-07-05T08:24:18Z",
+      "run_started_at": "2026-07-05T08:20:12Z"
+    }
+  ],
+  "eval-gating.yml": [
+    {
+      "id": 10021,
+      "name": "Inner Loop Gating",
+      "event": "workflow_dispatch",
+      "head_branch": "main",
+      "status": "completed",
+      "conclusion": "success",
+      "html_url": "https://github.com/red-hat-data-services/agentic-starter-kits/actions/runs/10021",
+      "created_at": "2026-07-04T16:45:00Z",
+      "updated_at": "2026-07-04T17:12:33Z",
+      "run_started_at": "2026-07-04T16:45:08Z"
+    }
+  ],
+  "agent-deployment-test.yaml": [
+    {
+      "id": 10031,
+      "name": "QG4: Agent Deployment Integration Tests",
+      "event": "schedule",
+      "head_branch": "main",
+      "status": "completed",
+      "conclusion": "failure",
+      "html_url": "https://github.com/red-hat-data-services/agentic-starter-kits/actions/runs/10031",
+      "created_at": "2026-07-05T03:05:10Z",
+      "updated_at": "2026-07-05T04:18:55Z",
+      "run_started_at": "2026-07-05T03:05:18Z"
+    },
+    {
+      "id": 10030,
+      "name": "QG4: Agent Deployment Integration Tests",
+      "event": "schedule",
+      "head_branch": "main",
+      "status": "completed",
+      "conclusion": "success",
+      "html_url": "https://github.com/red-hat-data-services/agentic-starter-kits/actions/runs/10030",
+      "created_at": "2026-07-04T03:04:44Z",
+      "updated_at": "2026-07-04T03:58:12Z",
+      "run_started_at": "2026-07-04T03:04:52Z"
+    }
+  ]
+}

--- a/.github/scripts/generate_ci_health_page.py
+++ b/.github/scripts/generate_ci_health_page.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""
+Generate a static CI health dashboard from GitHub Actions workflow runs.
+
+Used by the ci-health-pages workflow to publish a read-only summary for the
+QG8 in-scope workflows on main and scheduled/nightly executions.
+
+Environment variables (optional):
+    GITHUB_TOKEN      Token with actions:read (defaults to GITHUB_TOKEN in CI)
+    GITHUB_REPOSITORY owner/repo (required for live API mode)
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+API_ROOT = "https://api.github.com"
+WORKFLOWS = (
+    {
+        "file": "code-quality.yml",
+        "name": "Code Quality",
+        "description": "Lint, format, and markdown checks on main and PRs.",
+    },
+    {
+        "file": "agent-tests.yml",
+        "name": "Agent Tests",
+        "description": "Unit tests for agent templates.",
+    },
+    {
+        "file": "eval-gating.yml",
+        "name": "Inner Loop Gating",
+        "description": "Behavioral pytest and EvalHub gating on selected paths.",
+    },
+    {
+        "file": "agent-deployment-test.yaml",
+        "name": "QG4: Agent Deployment Integration Tests",
+        "description": "Nightly OpenShift deploy, /health checks, and teardown.",
+    },
+)
+RELEVANT_EVENTS = frozenset({"push", "schedule", "workflow_dispatch"})
+
+
+@dataclass(frozen=True)
+class WorkflowRun:
+    id: int
+    name: str
+    event: str
+    head_branch: str
+    status: str
+    conclusion: str | None
+    html_url: str
+    created_at: str
+    updated_at: str
+    run_started_at: str | None
+
+    @classmethod
+    def from_api(cls, payload: dict) -> WorkflowRun:
+        return cls(
+            id=payload["id"],
+            name=payload.get("name") or "workflow run",
+            event=payload.get("event") or "unknown",
+            head_branch=payload.get("head_branch") or "",
+            status=payload.get("status") or "unknown",
+            conclusion=payload.get("conclusion"),
+            html_url=payload.get("html_url") or "",
+            created_at=payload.get("created_at") or "",
+            updated_at=payload.get("updated_at") or "",
+            run_started_at=payload.get("run_started_at"),
+        )
+
+
+@dataclass(frozen=True)
+class WorkflowSummary:
+    workflow_file: str
+    display_name: str
+    description: str
+    latest: WorkflowRun | None
+    recent_runs: tuple[WorkflowRun, ...]
+    pass_rate_7d: float | None
+    total_runs_7d: int
+    passed_runs_7d: int
+
+
+def parse_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def duration_seconds(run: WorkflowRun) -> int | None:
+    if not run.run_started_at or not run.updated_at:
+        return None
+    if run.status != "completed":
+        return None
+    start = parse_timestamp(run.run_started_at)
+    end = parse_timestamp(run.updated_at)
+    return max(int((end - start).total_seconds()), 0)
+
+
+def format_duration(seconds: int | None) -> str:
+    if seconds is None:
+        return "—"
+    minutes, secs = divmod(seconds, 60)
+    if minutes:
+        return f"{minutes}m {secs}s"
+    return f"{secs}s"
+
+
+def is_relevant_run(run: WorkflowRun) -> bool:
+    if run.event not in RELEVANT_EVENTS:
+        return False
+    if run.event == "push" and run.head_branch != "main":
+        return False
+    return True
+
+
+def conclusion_label(conclusion: str | None, status: str) -> tuple[str, str]:
+    if status != "completed":
+        return ("In progress", "status-running")
+    mapping = {
+        "success": ("Pass", "status-pass"),
+        "failure": ("Fail", "status-fail"),
+        "cancelled": ("Cancelled", "status-neutral"),
+        "skipped": ("Skipped", "status-neutral"),
+        "timed_out": ("Timed out", "status-fail"),
+        "action_required": ("Action required", "status-neutral"),
+    }
+    return mapping.get(conclusion or "", ("Unknown", "status-neutral"))
+
+
+def compute_pass_rate(runs: list[WorkflowRun], *, days: int = 7) -> tuple[float | None, int, int]:
+    cutoff = datetime.now(UTC) - timedelta(days=days)
+    scoped = [
+        run
+        for run in runs
+        if is_relevant_run(run)
+        and run.created_at
+        and parse_timestamp(run.created_at) >= cutoff
+        and run.status == "completed"
+        and run.conclusion in {"success", "failure", "timed_out"}
+    ]
+    if not scoped:
+        return None, 0, 0
+    passed = sum(1 for run in scoped if run.conclusion == "success")
+    return round(100 * passed / len(scoped), 1), len(scoped), passed
+
+
+class GitHubActionsClient:
+    def __init__(self, token: str, repository: str) -> None:
+        self.repository = repository
+        self.headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "agentic-starter-kits-ci-health-dashboard",
+        }
+
+    def _request(self, path: str, query: dict | None = None) -> dict:
+        url = f"{API_ROOT}{path}"
+        if query:
+            url = f"{url}?{urllib.parse.urlencode(query)}"
+        request = urllib.request.Request(url, headers=self.headers)
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                return json.load(response)
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"GitHub API error {exc.code} for {path}: {body}") from exc
+
+    def list_workflow_runs(self, workflow_file: str, *, per_page: int = 30) -> list[WorkflowRun]:
+        path = f"/repos/{self.repository}/actions/workflows/{workflow_file}/runs"
+        payload = self._request(path, {"per_page": per_page})
+        return [WorkflowRun.from_api(item) for item in payload.get("workflow_runs", [])]
+
+
+def summarize_workflow(
+    workflow: dict,
+    runs: list[WorkflowRun],
+) -> WorkflowSummary:
+    relevant = [run for run in runs if is_relevant_run(run)]
+    latest = relevant[0] if relevant else None
+    pass_rate, total, passed = compute_pass_rate(runs)
+    return WorkflowSummary(
+        workflow_file=workflow["file"],
+        display_name=workflow["name"],
+        description=workflow["description"],
+        latest=latest,
+        recent_runs=tuple(relevant[:5]),
+        pass_rate_7d=pass_rate,
+        total_runs_7d=total,
+        passed_runs_7d=passed,
+    )
+
+
+def load_fixture(path: Path) -> dict[str, list[dict]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("Fixture root must be a JSON object keyed by workflow file name")
+    return payload
+
+
+def summaries_from_fixture(path: Path) -> list[WorkflowSummary]:
+    payload = load_fixture(path)
+    summaries: list[WorkflowSummary] = []
+    for workflow in WORKFLOWS:
+        runs = [WorkflowRun.from_api(item) for item in payload.get(workflow["file"], [])]
+        summaries.append(summarize_workflow(workflow, runs))
+    return summaries
+
+
+def summaries_from_api(repository: str, token: str) -> list[WorkflowSummary]:
+    client = GitHubActionsClient(token, repository)
+    summaries: list[WorkflowSummary] = []
+    for workflow in WORKFLOWS:
+        runs = client.list_workflow_runs(workflow["file"])
+        summaries.append(summarize_workflow(workflow, runs))
+    return summaries
+
+
+def render_workflow_card(summary: WorkflowSummary) -> str:
+    latest = summary.latest
+    if latest is None:
+        body = "<p class='muted'>No recent runs on <code>main</code> or scheduled triggers.</p>"
+    else:
+        label, css_class = conclusion_label(latest.conclusion, latest.status)
+        body = f"""
+        <div class="metric-row">
+          <span class="pill {css_class}">{html.escape(label)}</span>
+          <span>{html.escape(latest.event)}</span>
+          <span>{html.escape(format_duration(duration_seconds(latest)))}</span>
+          <span>{html.escape(parse_timestamp(latest.created_at).strftime("%Y-%m-%d %H:%M UTC"))}</span>
+        </div>
+        <p><a href="{html.escape(latest.html_url, quote=True)}">Open latest run</a></p>
+        """
+
+    if summary.pass_rate_7d is None:
+        rate_text = "No completed runs in the last 7 days"
+    else:
+        rate_text = (
+            f"{summary.pass_rate_7d:.1f}% pass rate "
+            f"({summary.passed_runs_7d}/{summary.total_runs_7d} runs)"
+        )
+
+    recent_rows = []
+    for run in summary.recent_runs:
+        label, css_class = conclusion_label(run.conclusion, run.status)
+        recent_rows.append(
+            "<tr>"
+            f"<td><span class='pill {css_class}'>{html.escape(label)}</span></td>"
+            f"<td>{html.escape(run.event)}</td>"
+            f"<td>{html.escape(parse_timestamp(run.created_at).strftime('%Y-%m-%d %H:%M'))}</td>"
+            f"<td><a href='{html.escape(run.html_url, quote=True)}'>#{run.id}</a></td>"
+            "</tr>"
+        )
+    recent_table = (
+        "<table><thead><tr><th>Result</th><th>Event</th><th>Started</th><th>Run</th></tr></thead>"
+        f"<tbody>{''.join(recent_rows)}</tbody></table>"
+        if recent_rows
+        else "<p class='muted'>No recent qualifying runs.</p>"
+    )
+
+    return f"""
+    <section class="card">
+      <h2>{html.escape(summary.display_name)}</h2>
+      <p class="muted">{html.escape(summary.description)}</p>
+      <p><strong>7-day health:</strong> {html.escape(rate_text)}</p>
+      <h3>Latest qualifying run</h3>
+      {body}
+      <h3>Recent runs</h3>
+      {recent_table}
+    </section>
+    """
+
+
+def render_page(
+    summaries: list[WorkflowSummary],
+    *,
+    repository: str,
+    generated_at: datetime,
+    data_source: str,
+) -> str:
+    cards = "\n".join(render_workflow_card(summary) for summary in summaries)
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>CI Health Dashboard</title>
+  <style>
+  :root {{
+    color-scheme: light dark;
+    --bg: #0f172a;
+    --panel: #111827;
+    --text: #e5e7eb;
+    --muted: #9ca3af;
+    --border: #1f2937;
+    --pass: #166534;
+    --fail: #991b1b;
+    --neutral: #374151;
+    --running: #1d4ed8;
+  }}
+  @media (prefers-color-scheme: light) {{
+    :root {{
+      --bg: #f8fafc;
+      --panel: #ffffff;
+      --text: #0f172a;
+      --muted: #475569;
+      --border: #e2e8f0;
+      --pass: #dcfce7;
+      --fail: #fee2e2;
+      --neutral: #e2e8f0;
+      --running: #dbeafe;
+    }}
+  }}
+  body {{
+    margin: 0;
+    font-family: Inter, system-ui, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.5;
+  }}
+  main {{
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 2rem 1.25rem 3rem;
+  }}
+  h1, h2, h3 {{ margin-top: 0; }}
+  .hero, .card {{
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 1rem;
+  }}
+  .muted {{ color: var(--muted); }}
+  .grid {{
+    display: grid;
+    gap: 1rem;
+  }}
+  .metric-row {{
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.75rem;
+    margin: 0.75rem 0;
+  }}
+  .pill {{
+    display: inline-block;
+    padding: 0.15rem 0.55rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+  }}
+  .status-pass {{ background: var(--pass); }}
+  .status-fail {{ background: var(--fail); }}
+  .status-neutral {{ background: var(--neutral); }}
+  .status-running {{ background: var(--running); }}
+  table {{
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+  }}
+  th, td {{
+    border-bottom: 1px solid var(--border);
+    padding: 0.5rem 0.25rem;
+    text-align: left;
+  }}
+  a {{ color: #60a5fa; }}
+  code {{
+    background: rgba(148, 163, 184, 0.15);
+    padding: 0.1rem 0.35rem;
+    border-radius: 4px;
+  }}
+  </style>
+</head>
+<body>
+  <main>
+    <section class="hero">
+      <h1>agentic-starter-kits CI Health</h1>
+      <p class="muted">
+        Daily summary for QG8 in-scope workflows on <code>main</code> and scheduled runs.
+      </p>
+      <p><strong>Repository:</strong> <code>{html.escape(repository)}</code></p>
+      <p><strong>Last updated:</strong> {html.escape(generated_at.strftime("%Y-%m-%d %H:%M:%S UTC"))}</p>
+      <p><strong>Data source:</strong> {html.escape(data_source)}</p>
+    </section>
+    <div class="grid">
+      {cards}
+    </div>
+  </main>
+</body>
+</html>
+"""
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("site/index.html"),
+        help="Path to write the generated HTML file",
+    )
+    parser.add_argument(
+        "--repository",
+        default=os.environ.get("GITHUB_REPOSITORY", ""),
+        help="owner/repo for live GitHub API queries",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("GITHUB_TOKEN", ""),
+        help="GitHub token with actions:read",
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        help="Optional fixture JSON for offline generation and tests",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    generated_at = datetime.now(UTC)
+
+    if args.input:
+        summaries = summaries_from_fixture(args.input)
+        repository = args.repository or "red-hat-data-services/agentic-starter-kits"
+        data_source = f"fixture: {args.input.as_posix()}"
+    else:
+        if not args.repository:
+            print("error: --repository or GITHUB_REPOSITORY is required", file=sys.stderr)
+            return 1
+        if not args.token:
+            print("error: --token or GITHUB_TOKEN is required", file=sys.stderr)
+            return 1
+        summaries = summaries_from_api(args.repository, args.token)
+        repository = args.repository
+        data_source = "GitHub Actions API (main + scheduled/workflow_dispatch runs)"
+
+    page = render_page(
+        summaries,
+        repository=repository,
+        generated_at=generated_at,
+        data_source=data_source,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(page, encoding="utf-8")
+    print(f"Wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/generate_ci_health_page.py
+++ b/.github/scripts/generate_ci_health_page.py
@@ -117,9 +117,9 @@ def format_duration(seconds: int | None) -> str:
 def is_relevant_run(run: WorkflowRun) -> bool:
     if run.event not in RELEVANT_EVENTS:
         return False
-    if run.event == "push" and run.head_branch != "main":
-        return False
-    return True
+    if run.event == "schedule":
+        return True
+    return run.head_branch == "main"
 
 
 def conclusion_label(conclusion: str | None, status: str) -> tuple[str, str]:
@@ -178,20 +178,49 @@ class GitHubActionsClient:
             raise RuntimeError(
                 f"GitHub API error {exc.code} for {path}: {body}"
             ) from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(
+                f"GitHub API request failed for {path}: {exc.reason}"
+            ) from exc
 
     def list_workflow_runs(
-        self, workflow_file: str, *, per_page: int = 30
+        self,
+        workflow_file: str,
+        *,
+        per_page: int = 100,
+        lookback_days: int = 7,
+        max_pages: int = 10,
     ) -> list[WorkflowRun]:
         path = f"/repos/{self.repository}/actions/workflows/{workflow_file}/runs"
-        payload = self._request(path, {"per_page": per_page})
-        return [WorkflowRun.from_api(item) for item in payload.get("workflow_runs", [])]
+        cutoff = datetime.now(UTC) - timedelta(days=lookback_days)
+        runs: list[WorkflowRun] = []
+        for page in range(1, max_pages + 1):
+            payload = self._request(path, {"per_page": per_page, "page": page})
+            batch = [
+                WorkflowRun.from_api(item) for item in payload.get("workflow_runs", [])
+            ]
+            if not batch:
+                break
+            runs.extend(batch)
+            timestamps = [
+                parse_timestamp(run.created_at) for run in batch if run.created_at
+            ]
+            if timestamps and min(timestamps) < cutoff:
+                break
+            if len(batch) < per_page:
+                break
+        return runs
 
 
 def summarize_workflow(
     workflow: dict,
     runs: list[WorkflowRun],
 ) -> WorkflowSummary:
-    relevant = [run for run in runs if is_relevant_run(run)]
+    relevant = sorted(
+        (run for run in runs if is_relevant_run(run)),
+        key=lambda run: run.created_at,
+        reverse=True,
+    )
     latest = relevant[0] if relevant else None
     pass_rate, total, passed = compute_pass_rate(runs)
     return WorkflowSummary(

--- a/.github/scripts/generate_ci_health_page.py
+++ b/.github/scripts/generate_ci_health_page.py
@@ -136,7 +136,9 @@ def conclusion_label(conclusion: str | None, status: str) -> tuple[str, str]:
     return mapping.get(conclusion or "", ("Unknown", "status-neutral"))
 
 
-def compute_pass_rate(runs: list[WorkflowRun], *, days: int = 7) -> tuple[float | None, int, int]:
+def compute_pass_rate(
+    runs: list[WorkflowRun], *, days: int = 7
+) -> tuple[float | None, int, int]:
     cutoff = datetime.now(UTC) - timedelta(days=days)
     scoped = [
         run
@@ -173,9 +175,13 @@ class GitHubActionsClient:
                 return json.load(response)
         except urllib.error.HTTPError as exc:
             body = exc.read().decode("utf-8", errors="replace")
-            raise RuntimeError(f"GitHub API error {exc.code} for {path}: {body}") from exc
+            raise RuntimeError(
+                f"GitHub API error {exc.code} for {path}: {body}"
+            ) from exc
 
-    def list_workflow_runs(self, workflow_file: str, *, per_page: int = 30) -> list[WorkflowRun]:
+    def list_workflow_runs(
+        self, workflow_file: str, *, per_page: int = 30
+    ) -> list[WorkflowRun]:
         path = f"/repos/{self.repository}/actions/workflows/{workflow_file}/runs"
         payload = self._request(path, {"per_page": per_page})
         return [WorkflowRun.from_api(item) for item in payload.get("workflow_runs", [])]
@@ -203,7 +209,9 @@ def summarize_workflow(
 def load_fixture(path: Path) -> dict[str, list[dict]]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
-        raise ValueError("Fixture root must be a JSON object keyed by workflow file name")
+        raise ValueError(
+            "Fixture root must be a JSON object keyed by workflow file name"
+        )
     return payload
 
 
@@ -211,7 +219,9 @@ def summaries_from_fixture(path: Path) -> list[WorkflowSummary]:
     payload = load_fixture(path)
     summaries: list[WorkflowSummary] = []
     for workflow in WORKFLOWS:
-        runs = [WorkflowRun.from_api(item) for item in payload.get(workflow["file"], [])]
+        runs = [
+            WorkflowRun.from_api(item) for item in payload.get(workflow["file"], [])
+        ]
         summaries.append(summarize_workflow(workflow, runs))
     return summaries
 
@@ -436,7 +446,9 @@ def main(argv: list[str] | None = None) -> int:
         data_source = f"fixture: {args.input.as_posix()}"
     else:
         if not args.repository:
-            print("error: --repository or GITHUB_REPOSITORY is required", file=sys.stderr)
+            print(
+                "error: --repository or GITHUB_REPOSITORY is required", file=sys.stderr
+            )
             return 1
         if not args.token:
             print("error: --token or GITHUB_TOKEN is required", file=sys.stderr)

--- a/.github/scripts/tests/test_generate_ci_health_page.py
+++ b/.github/scripts/tests/test_generate_ci_health_page.py
@@ -25,7 +25,9 @@ def test_fixture_loads_all_workflows():
 
 def test_qg4_latest_failure_is_surfaced():
     summaries = summaries_from_fixture(FIXTURE)
-    qg4 = next(item for item in summaries if item.workflow_file == "agent-deployment-test.yaml")
+    qg4 = next(
+        item for item in summaries if item.workflow_file == "agent-deployment-test.yaml"
+    )
     assert qg4.latest is not None
     assert qg4.latest.conclusion == "failure"
 

--- a/.github/scripts/tests/test_generate_ci_health_page.py
+++ b/.github/scripts/tests/test_generate_ci_health_page.py
@@ -2,12 +2,14 @@
 """Tests for the CI health dashboard generator."""
 
 import sys
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from generate_ci_health_page import (  # noqa: E402
     WorkflowRun,
     compute_pass_rate,
+    is_relevant_run,
     main,
     summaries_from_fixture,
 )
@@ -33,6 +35,9 @@ def test_qg4_latest_failure_is_surfaced():
 
 
 def test_pass_rate_ignores_pull_requests():
+    now = datetime.now(UTC)
+    earlier = (now - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    later = (now - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
     runs = [
         WorkflowRun(
             id=1,
@@ -42,9 +47,9 @@ def test_pass_rate_ignores_pull_requests():
             status="completed",
             conclusion="failure",
             html_url="https://example.com/1",
-            created_at="2026-07-05T10:00:00Z",
-            updated_at="2026-07-05T10:05:00Z",
-            run_started_at="2026-07-05T10:00:10Z",
+            created_at=earlier,
+            updated_at=later,
+            run_started_at=earlier,
         ),
         WorkflowRun(
             id=2,
@@ -54,15 +59,31 @@ def test_pass_rate_ignores_pull_requests():
             status="completed",
             conclusion="success",
             html_url="https://example.com/2",
-            created_at="2026-07-05T11:00:00Z",
-            updated_at="2026-07-05T11:05:00Z",
-            run_started_at="2026-07-05T11:00:10Z",
+            created_at=later,
+            updated_at=(now - timedelta(minutes=55)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            run_started_at=later,
         ),
     ]
     rate, total, passed = compute_pass_rate(runs, days=7)
     assert total == 1
     assert passed == 1
     assert rate == 100.0
+
+
+def test_workflow_dispatch_on_feature_branch_is_ignored():
+    run = WorkflowRun(
+        id=3,
+        name="Code Quality",
+        event="workflow_dispatch",
+        head_branch="feature-branch",
+        status="completed",
+        conclusion="success",
+        html_url="https://example.com/3",
+        created_at=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        updated_at=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        run_started_at=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    )
+    assert is_relevant_run(run) is False
 
 
 def test_main_writes_html(tmp_path):

--- a/.github/scripts/tests/test_generate_ci_health_page.py
+++ b/.github/scripts/tests/test_generate_ci_health_page.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Tests for the CI health dashboard generator."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from generate_ci_health_page import (  # noqa: E402
+    WorkflowRun,
+    compute_pass_rate,
+    main,
+    summaries_from_fixture,
+)
+
+FIXTURE = Path(__file__).resolve().parent.parent / "fixtures" / "ci-runs-sample.json"
+
+
+def test_fixture_loads_all_workflows():
+    summaries = summaries_from_fixture(FIXTURE)
+    assert len(summaries) == 4
+    assert summaries[0].display_name == "Code Quality"
+    assert summaries[0].latest is not None
+    assert summaries[0].latest.conclusion == "success"
+
+
+def test_qg4_latest_failure_is_surfaced():
+    summaries = summaries_from_fixture(FIXTURE)
+    qg4 = next(item for item in summaries if item.workflow_file == "agent-deployment-test.yaml")
+    assert qg4.latest is not None
+    assert qg4.latest.conclusion == "failure"
+
+
+def test_pass_rate_ignores_pull_requests():
+    runs = [
+        WorkflowRun(
+            id=1,
+            name="Code Quality",
+            event="pull_request",
+            head_branch="feature",
+            status="completed",
+            conclusion="failure",
+            html_url="https://example.com/1",
+            created_at="2026-07-05T10:00:00Z",
+            updated_at="2026-07-05T10:05:00Z",
+            run_started_at="2026-07-05T10:00:10Z",
+        ),
+        WorkflowRun(
+            id=2,
+            name="Code Quality",
+            event="push",
+            head_branch="main",
+            status="completed",
+            conclusion="success",
+            html_url="https://example.com/2",
+            created_at="2026-07-05T11:00:00Z",
+            updated_at="2026-07-05T11:05:00Z",
+            run_started_at="2026-07-05T11:00:10Z",
+        ),
+    ]
+    rate, total, passed = compute_pass_rate(runs, days=7)
+    assert total == 1
+    assert passed == 1
+    assert rate == 100.0
+
+
+def test_main_writes_html(tmp_path):
+    output = tmp_path / "index.html"
+    assert main(["--input", str(FIXTURE), "--output", str(output)]) == 0
+    content = output.read_text(encoding="utf-8")
+    assert "agentic-starter-kits CI Health" in content
+    assert "QG4: Agent Deployment Integration Tests" in content

--- a/.github/workflows/ci-health-pages.yml
+++ b/.github/workflows/ci-health-pages.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v5.3.0

--- a/.github/workflows/ci-health-pages.yml
+++ b/.github/workflows/ci-health-pages.yml
@@ -1,0 +1,79 @@
+# Publish a static CI health dashboard to GitHub Pages.
+#
+# Bootstrap:
+#   1. Repo admin enables Settings -> Pages -> Source: GitHub Actions
+#   2. Merge this workflow, or run workflow_dispatch from the PR branch to demo
+#   3. After merge to main, scheduled runs refresh the page daily
+
+name: CI Health Pages
+
+on:
+  workflow_dispatch:
+    inputs:
+      use_fixture:
+        description: "Generate from sample fixture instead of live GitHub API"
+        type: boolean
+        default: false
+  schedule:
+  # Refresh after the QG4 nightly window (03:00 UTC) and morning review time.
+    - cron: "0 6 * * *"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/ci-health-pages.yml"
+      - ".github/scripts/generate_ci_health_page.py"
+      - ".github/scripts/fixtures/ci-runs-sample.json"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  actions: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: github.repository == 'red-hat-data-services/agentic-starter-kits'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v4.2.2
+
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v5.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Generate CI health page (fixture)
+        if: github.event_name == 'workflow_dispatch' && inputs.use_fixture == true
+        run: |
+          python .github/scripts/generate_ci_health_page.py \
+            --input .github/scripts/fixtures/ci-runs-sample.json \
+            --output site/index.html
+
+      - name: Generate CI health page (live)
+        if: github.event_name != 'workflow_dispatch' || inputs.use_fixture != true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          python .github/scripts/generate_ci_health_page.py --output site/index.html
+
+      - name: Setup Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v5.0.0
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v3.0.1
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v4.0.5

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ evals/evalhub_adapter/provider-*.json
 results.xml
 BTEST_VALIDATION_REPORT.md
 btest-results/
+site/

--- a/docs/ci-health-dashboard.md
+++ b/docs/ci-health-dashboard.md
@@ -1,0 +1,68 @@
+# CI Health Dashboard
+
+Static HTML summary of QG8 in-scope GitHub Actions workflows for `agentic-starter-kits`.
+
+## Scope
+
+The dashboard covers these workflows on `main` and scheduled or manual shared-branch runs:
+
+| Workflow file | Display name |
+|---------------|--------------|
+| `code-quality.yml` | Code Quality |
+| `agent-tests.yml` | Agent Tests |
+| `eval-gating.yml` | Inner Loop Gating |
+| `agent-deployment-test.yaml` | QG4: Agent Deployment Integration Tests |
+
+Pull request runs are excluded from the summary to keep the page focused on shared-branch health.
+
+## Data source
+
+- **Live mode:** GitHub Actions REST API via `GITHUB_TOKEN` with `actions: read`
+- **Fixture mode:** `.github/scripts/fixtures/ci-runs-sample.json` for offline generation and demos
+
+## Update cadence
+
+- Daily at `06:00 UTC` via `.github/workflows/ci-health-pages.yml`
+- Manual refresh via **Actions → CI Health Pages → Run workflow**
+
+## Enable GitHub Pages before merge
+
+You can enable Pages while the PR is still in review:
+
+1. Repo admin opens **Settings → Pages**
+2. Set **Build and deployment → Source** to **GitHub Actions**
+3. Merge is not required for this setting
+
+After the workflow file exists on your PR branch:
+
+1. Open **Actions → CI Health Pages**
+2. Click **Run workflow**
+3. Optional: enable **use_fixture** for a deterministic demo before merge
+4. Open the deployment URL from the workflow summary
+
+Once the PR merges to `main`, scheduled runs keep the page current.
+
+## Local preview
+
+```bash
+python .github/scripts/generate_ci_health_page.py \
+  --input .github/scripts/fixtures/ci-runs-sample.json \
+  --output site/index.html
+
+python -m http.server 8080 --directory site
+```
+
+Live API mode:
+
+```bash
+export GITHUB_TOKEN="$(gh auth token)"
+python .github/scripts/generate_ci_health_page.py \
+  --repository red-hat-data-services/agentic-starter-kits \
+  --output site/index.html
+```
+
+## Tests
+
+```bash
+python -m pytest .github/scripts/tests/test_generate_ci_health_page.py -v
+```


### PR DESCRIPTION
 ## Description
  Adds a lightweight, read-only CI health dashboard for RHAIENG-5940 (QG8 stretch goal under RHAIENG-5841).
  This PR introduces:
  - A Python generator (`.github/scripts/generate_ci_health_page.py`) that summarizes the four in-scope QG8 workflows from the GitHub Actions API or a committed fixture
  - A `CI Health Pages` workflow that builds static HTML and deploys it to GitHub Pages via `configure-pages` / `upload-pages-artifact` / `deploy-pages`
  - Documentation for data source, update cadence, and bootstrap steps (`docs/ci-health-dashboard.md`)
  The dashboard focuses on shared-branch health (`main` push, `schedule`, and `workflow_dispatch` runs). PR runs are excluded to avoid noise.
  **Design decisions:**
  - Static HTML only (no MkDocs) for this spike; runbooks can be proposed separately based on feedback
  - `workflow_dispatch` supports a `use_fixture` input for safe pre-merge demos
  - Daily refresh at 06:00 UTC (after the QG4 nightly window)
  ## Jira Ticket
  RHAIENG-5940
  ## Testing
  - [ ] `make test` passes (run from the affected agent directory)
  - [x] Manual testing performed (describe steps below)
  - [ ] No testing required (documentation/config change only)
  - `python -m pytest .github/scripts/tests/test_generate_ci_health_page.py -v` — 4 tests passed
  - `ruff check` on generator and test files — passed
  - Generated sample page locally with `--input .github/scripts/fixtures/ci-runs-sample.json`
  **Post-merge / PR-branch verification:**
  1. Actions → **CI Health Pages** → Run workflow on this branch with `use_fixture: true`
  2. Confirm deploy job succeeds and Pages URL serves the dashboard
  3. Re-run with live API data after merge
  ## Checklist
  - [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
  - [x] No `.env` or secret files are included in this PR
  - [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)
  ## Review Guidance
  - `.github/scripts/generate_ci_health_page.py` — core logic and HTML output
  - `.github/workflows/ci-health-pages.yml` — Pages permissions, fixture vs live generation, schedule
  - `docs/ci-health-dashboard.md` — operator setup (Pages must be enabled with Source: GitHub Actions)
  ## Related PRs
  N/A (first CI health dashboard PR for QG8)
