### PR TITLE
feat: add OpenCode A2A agent deployment for Kagenti discovery

### DIFF
--- a/agents/opencode/deployment/Containerfile.a2a
+++ b/agents/opencode/deployment/Containerfile.a2a
@@ -1,0 +1,30 @@
+# OpenCode with A2A agent card support
+#
+# Extends the pre-built OpenCode image with:
+# - opencode-a2a server for Kagenti discovery (A2A protocol)
+# - Custom entrypoint running both opencode serve and opencode-a2a
+#
+# Build:
+#   podman build --platform linux/amd64 -t opencode-a2a:latest -f Containerfile.a2a .
+#
+# The A2A agent card is served at:
+#   GET /.well-known/agent-card.json (port 8000)
+
+FROM quay.io/opendatahub/odh-opencode-rhel9:latest
+
+USER 0
+
+# Install opencode-a2a from agent-servers repo
+RUN pip3 install --no-cache-dir \
+    'opencode-a2a @ git+https://github.com/red-hat-data-services/agent-servers.git#subdirectory=opencode'
+
+# Copy entrypoint that runs both opencode serve and opencode-a2a
+COPY entrypoint-a2a.sh /usr/local/bin/entrypoint-a2a.sh
+RUN chmod 755 /usr/local/bin/entrypoint-a2a.sh
+
+USER 1001
+
+# A2A server port
+EXPOSE 8000
+
+ENTRYPOINT ["/usr/local/bin/entrypoint-a2a.sh"]

--- a/agents/opencode/deployment/Containerfile.a2a
+++ b/agents/opencode/deployment/Containerfile.a2a
@@ -15,6 +15,8 @@ FROM quay.io/opendatahub/odh-opencode-rhel9:latest
 USER 0
 
 # Install opencode-a2a from agent-servers repo
+# TODO(RHAIENG-5826): Pin to specific version tag once A2A protocol support is complete
+# and agent-servers repo has established versioning
 RUN pip3 install --no-cache-dir \
     'opencode-a2a @ git+https://github.com/red-hat-data-services/agent-servers.git#subdirectory=opencode'
 

--- a/agents/opencode/deployment/README-a2a.md
+++ b/agents/opencode/deployment/README-a2a.md
@@ -216,9 +216,12 @@ helm upgrade kagenti /path/to/kagenti/chart \
 
 ## Verification
 
-### Check AgentCard Creation
+### Check AgentRuntime and AgentCard Creation
 
 ```bash
+# Check AgentRuntime was created
+oc get agentruntime -n your-namespace
+
 # List AgentCards in your namespace
 oc get agentcard -n your-namespace
 
@@ -226,7 +229,14 @@ oc get agentcard -n your-namespace
 oc get agentcard opencode-a2a-deployment-card -n your-namespace -o yaml
 ```
 
-Expected output shows `Synced=True`:
+Expected AgentRuntime output shows `Phase=Active`:
+
+```text
+NAME                       TYPE    TARGET          PHASE
+opencode-a2a-runtime       agent   opencode-a2a    Active
+```
+
+Expected AgentCard output shows `Synced=True`:
 
 ```text
 NAME                          PROTOCOL   KIND         TARGET        AGENT      VERIFIED   BOUND   SYNCED   LASTSYNC
@@ -438,7 +448,7 @@ Verify LLM_API_BASE is correct:
 
 ```bash
 oc exec -n your-namespace deployment/opencode-a2a -- \
-  curl -s $LLM_API_BASE/models
+  sh -c 'curl -s $LLM_API_BASE/models'
 ```
 
 Check OpenCode config was generated:
@@ -478,6 +488,6 @@ oc logs -n your-namespace deployment/opencode-a2a --previous
 
 Common issues:
 
-- Missing LLM_API_BASE: entrypoint will skip config generation
+- Missing LLM_API_BASE: Pod fails to start with validation error (required when LLM_MODEL is set)
 - Invalid LLM_API_BASE: OpenCode serve starts but can't reach LLM
 - Missing secret: Pod fails to start if `LLM_API_KEY_SECRET` doesn't exist

--- a/agents/opencode/deployment/README-a2a.md
+++ b/agents/opencode/deployment/README-a2a.md
@@ -1,0 +1,483 @@
+# OpenCode A2A Agent Deployment
+
+This directory contains a reference implementation for deploying [OpenCode](https://opencode.ai) as a Kagenti-discoverable agent using the Agent-to-Agent (A2A) protocol.
+
+## Overview
+
+OpenCode is an AI-powered coding assistant. This implementation wraps OpenCode with an A2A agent card server to enable:
+
+- **Service discovery** via Kagenti agent catalog
+- **Standardized configuration** using Kagenti-standard environment variables
+- **Multi-provider support** (direct vLLM, OGX, OpenAI, etc.)
+
+## Architecture
+
+```text
+┌──────────────────────────────────────────────┐
+│  Container (port 8000)                       │
+│                                              │
+│  ┌───────────────────────────────────────┐   │
+│  │ opencode-a2a (FastAPI)                │   │
+│  │ - Serves /.well-known/agent-card.json │   │
+│  │ - Proxies /health from opencode serve │   │
+│  └──────────────┬────────────────────────┘   │
+│                 │ http://localhost:4096      │
+│  ┌──────────────▼────────────────────────┐   │
+│  │ opencode serve (port 4096)            │   │
+│  │ - OpenCode HTTP API                   │   │
+│  │ - Configured via ~/.config/opencode/  │   │
+│  └──────────────┬────────────────────────┘   │
+│                 │                            │
+└─────────────────┼────────────────────────────┘
+                  │
+                  ▼
+          LLM_API_BASE (vLLM, OGX, etc.)
+```
+
+### Components
+
+1. **Base Image**: `quay.io/opendatahub/odh-opencode-rhel9:latest`
+   - Pre-built OpenCode container from Red Hat OpenShift AI
+
+2. **opencode-a2a Server** (`Containerfile.a2a`)
+   - Installed from `agent-servers` repo (opencode subdirectory)
+   - Serves A2A agent card for Kagenti discovery
+   - Proxies health checks from OpenCode
+
+3. **Entrypoint Script** (`entrypoint-a2a.sh`)
+   - Translates Kagenti-standard env vars to OpenCode config
+   - Starts both `opencode serve` and `opencode-a2a` processes
+
+4. **Kubernetes Template** (`kagenti-agent.yaml`)
+   - OpenShift Template for deployment
+   - Configures Kagenti discovery labels
+   - Supports multiple deployment variants (direct vLLM, OGX, etc.)
+
+## Environment Variables
+
+The deployment follows [Kagenti standard naming conventions](https://github.com/kagenti):
+
+| Variable           | Description                                              | Required | Default    |
+|--------------------|----------------------------------------------------------|----------|------------|
+| `LLM_PROVIDER`     | Provider name (vllm, ogx, openai, etc.)                  | No       | `vllm`     |
+| `LLM_API_BASE`     | LLM API endpoint (e.g., `https://api.openai.com/v1`)     | Yes      | -          |
+| `LLM_MODEL`        | Model identifier (e.g., `gpt-4o`, `gpt-oss-120b`)        | Yes      | -          |
+| `LLM_API_KEY`      | API key for the LLM provider                             | No       | -          |
+| `A2A_PORT`         | Port for A2A server                                      | No       | `8000`     |
+| `A2A_PROVIDER_ORG` | Organization name in agent card                          | No       | `Red Hat`  |
+
+### Provider-Specific Model Naming
+
+- **Direct vLLM**: Use model name only (e.g., `LLM_MODEL=gpt-oss-120b`)
+- **Through OGX**: Use provider/model format (e.g., `LLM_MODEL=vllm/gpt-oss-120b`)
+- **OpenAI**: Use OpenAI model names (e.g., `LLM_MODEL=gpt-4o`)
+
+## Deployment
+
+### Prerequisites
+
+- OpenShift/Kubernetes cluster
+- Kagenti installed and configured (for agent discovery)
+- LLM endpoint accessible from the cluster
+- Secret containing LLM API key (if required)
+
+### Build Container Image
+
+Using OpenShift BuildConfig (recommended for OpenShift deployments):
+
+```bash
+cd agents/opencode/deployment
+
+# Create ImageStream to store the built image
+oc create imagestream opencode-a2a -n your-namespace
+
+# Create BuildConfig for binary builds
+cat <<EOF | oc apply -f -
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: opencode-a2a
+  namespace: your-namespace
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: opencode-a2a:latest
+  source:
+    type: Binary
+  strategy:
+    dockerStrategy:
+      dockerfilePath: Containerfile.a2a
+    type: Docker
+EOF
+
+# Trigger build from current directory
+oc start-build opencode-a2a --from-dir=. --follow -n your-namespace
+
+# The image will be available at:
+# image-registry.openshift-image-registry.svc:5000/your-namespace/opencode-a2a:latest
+```
+
+Alternative: Using podman/docker (for testing or non-OpenShift environments):
+
+```bash
+cd agents/opencode/deployment
+
+# Build for amd64
+podman build --platform linux/amd64 \
+  -t opencode-a2a:latest \
+  -f Containerfile.a2a .
+
+# Tag for your registry
+podman tag opencode-a2a:latest \
+  your-registry.example.com/your-namespace/opencode-a2a:latest
+
+# Push to registry
+podman push your-registry.example.com/your-namespace/opencode-a2a:latest
+```
+
+### Deploy to OpenShift
+
+#### Option 1: Direct vLLM Connection
+
+```bash
+# Create secret with API key (if needed)
+oc create secret generic opencode-model-credentials \
+  --from-literal=api-key="your-api-key" \
+  -n your-namespace
+
+# Deploy using template
+oc process -f kagenti-agent.yaml \
+  -p NAMESPACE=your-namespace \
+  -p IMAGE=image-registry.openshift-image-registry.svc:5000/your-namespace/opencode-a2a:latest \
+  -p LLM_PROVIDER=vllm \
+  -p LLM_API_BASE=http://vllm-service.namespace.svc.cluster.local:8000/v1 \
+  -p LLM_MODEL=gpt-oss-120b \
+  | oc apply -f -
+```
+
+#### Option 2: Through OGX
+
+```bash
+oc process -f kagenti-agent.yaml \
+  -p NAMESPACE=your-namespace \
+  -p IMAGE=image-registry.openshift-image-registry.svc:5000/your-namespace/opencode-a2a:latest \
+  -p LLM_PROVIDER=ogx \
+  -p LLM_API_BASE=http://ogx-service.namespace.svc.cluster.local:8321/v1 \
+  -p LLM_MODEL=vllm/gpt-oss-120b \
+  | oc apply -f -
+```
+
+Note: OGX namespaces models by provider, so use `provider/model` format.
+
+#### Option 3: OpenAI API
+
+```bash
+oc process -f kagenti-agent.yaml \
+  -p NAMESPACE=your-namespace \
+  -p IMAGE=image-registry.openshift-image-registry.svc:5000/your-namespace/opencode-a2a:latest \
+  -p LLM_PROVIDER=openai \
+  -p LLM_API_BASE=https://api.openai.com/v1 \
+  -p LLM_MODEL=gpt-4o \
+  -p LLM_API_KEY_SECRET=openai-api-key \
+  | oc apply -f -
+```
+
+### Enable Kagenti Discovery
+
+Add your namespace to Kagenti's monitored namespaces:
+
+```bash
+# Add Helm labels and annotations to namespace
+oc label namespace your-namespace \
+  app.kubernetes.io/managed-by=Helm \
+  app.kubernetes.io/instance=kagenti \
+  app.kubernetes.io/name=kagenti \
+  kagenti.io/enabled=true
+
+oc annotate namespace your-namespace \
+  meta.helm.sh/release-name=kagenti \
+  meta.helm.sh/release-namespace=kagenti-system
+
+# Update Kagenti Helm values
+helm get values kagenti -n kagenti-system -o yaml > /tmp/kagenti-values.yaml
+
+# Edit /tmp/kagenti-values.yaml and add your namespace to agentNamespaces list:
+# agentNamespaces:
+#   - team1
+#   - team2
+#   - your-namespace  # <-- Add this
+
+# Upgrade Kagenti
+helm upgrade kagenti /path/to/kagenti/chart \
+  -n kagenti-system \
+  -f /tmp/kagenti-values.yaml
+```
+
+## Verification
+
+### Check AgentCard Creation
+
+```bash
+# List AgentCards in your namespace
+oc get agentcard -n your-namespace
+
+# View AgentCard details
+oc get agentcard opencode-a2a-deployment-card -n your-namespace -o yaml
+```
+
+Expected output shows `Synced=True`:
+
+```text
+NAME                          PROTOCOL   KIND         TARGET        AGENT      VERIFIED   BOUND   SYNCED   LASTSYNC
+opencode-a2a-deployment-card  a2a        Deployment   opencode-a2a  OpenCode              false   True     30s
+```
+
+### Test Agent Card Endpoint
+
+```bash
+# From within the pod
+oc exec -n your-namespace deployment/opencode-a2a -- \
+  curl -s http://localhost:8000/.well-known/agent-card.json | jq .
+
+# From another pod in cluster
+oc run -it --rm debug --image=curlimages/curl -- \
+  curl -s http://opencode-a2a.your-namespace.svc.cluster.local:8000/.well-known/agent-card.json
+```
+
+### Verify OpenCode Configuration
+
+```bash
+# Exec into pod
+oc exec -it -n your-namespace deployment/opencode-a2a -- /bin/bash
+
+# Check generated OpenCode config
+cat ~/.config/opencode/opencode.json
+
+# Should show provider configuration:
+# {
+#   "$schema": "https://opencode.ai/config.json",
+#   "provider": {
+#     "vllm": {
+#       "npm": "@ai-sdk/openai-compatible",
+#       "name": "vllm",
+#       "options": {
+#         "baseURL": "http://vllm:8000/v1",
+#         "apiKey": ""
+#       },
+#       "models": {
+#         "gpt-oss-120b": {
+#           "name": "gpt-oss-120b"
+#         }
+#       }
+#     }
+#   },
+#   "model": "vllm/gpt-oss-120b",
+#   ...
+# }
+```
+
+### Test OpenCode TUI Attachment
+
+```bash
+# Exec into pod and attach to OpenCode TUI
+oc exec -it -n your-namespace deployment/opencode-a2a -- /bin/bash
+
+# Inside pod:
+opencode attach http://localhost:4096
+
+# You should see the OpenCode TUI interface
+# Try sending a message to verify LLM connectivity
+```
+
+### Check Kagenti UI
+
+1. Access Kagenti UI: `https://kagenti-ui-kagenti-system.apps.YOUR_CLUSTER/`
+2. Navigate to agent catalog
+3. Your namespace should appear with OpenCode agents listed
+4. Agent card shows name, description, skills, and provider info
+
+### Verify LLM Traffic
+
+Monitor logs to confirm requests reach the LLM:
+
+```bash
+# OpenCode pod logs
+oc logs -n your-namespace deployment/opencode-a2a --tail=50
+
+# vLLM logs (if direct connection)
+oc logs -n vllm-namespace deployment/vllm --tail=50
+
+# OGX logs (if using OGX)
+oc logs -n ogx-namespace deployment/ogx --tail=50
+```
+
+## Configuration Details
+
+### How Environment Variables are Translated
+
+The `entrypoint-a2a.sh` script performs the following translation:
+
+```bash
+# Input (Kagenti standard):
+LLM_PROVIDER=vllm
+LLM_API_BASE=http://vllm:8000/v1
+LLM_MODEL=gpt-oss-120b
+LLM_API_KEY=secret-key
+
+# Output (OpenCode config at ~/.config/opencode/opencode.json):
+{
+  "provider": {
+    "vllm": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "vllm",
+      "options": {
+        "baseURL": "http://vllm:8000/v1",
+        "apiKey": "secret-key"
+      },
+      "models": {
+        "gpt-oss-120b": {
+          "name": "gpt-oss-120b"
+        }
+      }
+    }
+  },
+  "model": "vllm/gpt-oss-120b",
+  "small_model": "vllm/gpt-oss-120b",
+  "enabled_providers": ["vllm"]
+}
+```
+
+This approach allows:
+
+- **Standardization**: Use Kagenti conventions across all agents
+- **Flexibility**: Support any OpenAI-compatible provider
+- **Runtime configuration**: No image rebuilds for different providers
+
+## Known Limitations
+
+### A2A Protocol Execution Not Implemented
+
+**Current state (RHAIENG-5825 ✅):**
+
+- Agent card server is implemented and running
+- Agent discovery works in Kagenti UI
+- Health checks are proxied
+- Configuration is correctly generated
+
+**Not yet implemented (RHAIENG-5826 ⏳):**
+
+- A2A task execution endpoint (`POST /v1/agent/tasks`)
+- Request proxying from Kagenti to OpenCode
+- Streaming response support
+- State management
+
+**Current behavior:**
+
+- Agent appears in Kagenti catalog ✅
+- Clicking "Try it" returns 404 error ⚠️
+- Direct OpenCode TUI access works ✅
+
+The full A2A protocol implementation is tracked in **RHAIENG-5826** and will enable end-to-end agent execution through Kagenti.
+
+### OpenCode TUI Access
+
+Users can bypass the A2A protocol limitation by exec'ing into the pod and using OpenCode's TUI directly:
+
+```bash
+oc exec -it -n your-namespace deployment/opencode-a2a -- opencode attach http://localhost:4096
+```
+
+## Files Reference
+
+| File                  | Purpose                                                       |
+|-----------------------|---------------------------------------------------------------|
+| `Containerfile.a2a`   | Extends base OpenCode image with opencode-a2a server          |
+| `entrypoint-a2a.sh`   | Entrypoint that configures OpenCode and runs both servers     |
+| `kagenti-agent.yaml`  | OpenShift Template for Kagenti-compatible deployment          |
+| `README-a2a.md`       | This file - deployment and usage guide                        |
+
+## Related Work
+
+- **agent-servers repo**: Source for opencode-a2a Python package
+  - Installation: `pip install 'opencode-a2a @ git+https://github.com/red-hat-data-services/agent-servers.git#subdirectory=opencode'`
+
+- **Kagenti**: Agent orchestration platform
+  - Uses A2A protocol for agent discovery and execution
+  - Monitors namespaces with `kagenti.io/enabled=true` label
+
+- **OpenCode**: AI coding assistant
+  - Project: <https://opencode.ai>
+  - Supports multiple LLM providers via Vercel AI SDK
+
+## Troubleshooting
+
+### Agent not appearing in Kagenti UI
+
+Check namespace is in Kagenti's `agentNamespaces` list:
+
+```bash
+helm get values kagenti -n kagenti-system | grep -A 5 agentNamespaces
+```
+
+Verify AgentCard is created and synced:
+
+```bash
+oc get agentcard -n your-namespace
+```
+
+Check Kagenti backend logs:
+
+```bash
+oc logs -n kagenti-system deployment/kagenti-backend --tail=50
+```
+
+### OpenCode can't reach LLM
+
+Verify LLM_API_BASE is correct:
+
+```bash
+oc exec -n your-namespace deployment/opencode-a2a -- \
+  curl -s $LLM_API_BASE/models
+```
+
+Check OpenCode config was generated:
+
+```bash
+oc exec -n your-namespace deployment/opencode-a2a -- \
+  cat ~/.config/opencode/opencode.json
+```
+
+Test from OpenCode TUI to see detailed errors:
+
+```bash
+oc exec -it -n your-namespace deployment/opencode-a2a -- \
+  opencode attach http://localhost:4096
+```
+
+### Image pull errors
+
+Ensure you're using the correct image path:
+
+```bash
+# Check deployment image
+oc get deployment opencode-a2a -n your-namespace -o jsonpath='{.spec.template.spec.containers[0].image}'
+
+# If wrong, update it
+oc set image deployment/opencode-a2a -n your-namespace \
+  opencode-a2a=image-registry.openshift-image-registry.svc:5000/your-namespace/opencode-a2a:latest
+```
+
+### Pod crashes or restarts
+
+Check logs for startup errors:
+
+```bash
+oc logs -n your-namespace deployment/opencode-a2a --previous
+```
+
+Common issues:
+
+- Missing LLM_API_BASE: entrypoint will skip config generation
+- Invalid LLM_API_BASE: OpenCode serve starts but can't reach LLM
+- Missing secret: Pod fails to start if `LLM_API_KEY_SECRET` doesn't exist

--- a/agents/opencode/deployment/entrypoint-a2a.sh
+++ b/agents/opencode/deployment/entrypoint-a2a.sh
@@ -29,15 +29,19 @@ if [[ -n "${LLM_API_BASE}" || -n "${LLM_MODEL}" ]]; then
     API_KEY="${LLM_API_KEY:-}"
     MODEL_NAME="${LLM_MODEL:-gpt-4o}"
 
-    echo "  LLM_PROVIDER=${PROVIDER_NAME}"
-    echo "  LLM_API_BASE=${BASE_URL}"
-    echo "  LLM_MODEL=${MODEL_NAME}"
-    if [[ -n "${API_KEY}" ]]; then
-        echo "  LLM_API_KEY=****"
+    # Validate required fields
+    if [[ -z "${BASE_URL}" ]]; then
+        echo "ERROR: LLM_API_BASE is required when generating OpenCode configuration"
+        echo "Please set the LLM_API_BASE environment variable to your LLM API endpoint"
+        exit 1
     fi
 
+    echo "  Provider: ${PROVIDER_NAME}, Model: ${MODEL_NAME}"
+
     # Generate full OpenCode provider config (following msager-opencode reference)
-    cat > "${CONFIG_DIR}/opencode.json" <<EOF
+    # Use umask 077 to ensure config file is created with 0600 permissions (owner-only read/write)
+    # since it contains sensitive API key
+    (umask 077 && cat > "${CONFIG_DIR}/opencode.json" <<EOF
 {
   "\$schema": "https://opencode.ai/config.json",
   "provider": {
@@ -60,6 +64,7 @@ if [[ -n "${LLM_API_BASE}" || -n "${LLM_MODEL}" ]]; then
   "enabled_providers": ["${PROVIDER_NAME}"]
 }
 EOF
+    )
     echo "  Config written to ${CONFIG_DIR}/opencode.json"
 fi
 
@@ -67,6 +72,10 @@ fi
 echo "Starting opencode serve on port 4096..."
 opencode serve &
 OPENCODE_PID=$!
+
+# Set up trap to cleanly shutdown background opencode serve process
+# when container receives SIGTERM/SIGINT or when script exits
+trap "echo 'Shutting down opencode serve...'; kill $OPENCODE_PID 2>/dev/null; wait $OPENCODE_PID 2>/dev/null; exit 0" EXIT INT TERM
 
 # Wait for opencode serve to be ready
 echo "Waiting for opencode serve to be ready..."
@@ -81,8 +90,8 @@ for i in {1..30}; do
     sleep 1
 done
 
-# Run opencode-a2a in foreground (PID 1 for signal handling)
+# Run opencode-a2a in foreground (shell remains PID 1 for trap handling)
 echo "Starting opencode-a2a on port 8000..."
-exec opencode-a2a \
+opencode-a2a \
     --port "${A2A_PORT:-8000}" \
     --opencode-url "${OPENCODE_BASE_URL:-http://127.0.0.1:4096}"

--- a/agents/opencode/deployment/entrypoint-a2a.sh
+++ b/agents/opencode/deployment/entrypoint-a2a.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Entrypoint for OpenCode A2A container
+#
+# Runs two processes:
+# 1. opencode serve (background) - OpenCode HTTP API on port 4096
+# 2. opencode-a2a (foreground) - A2A agent card server on port 8000
+#
+# Environment variables (Kagenti standard names):
+#   LLM_API_BASE  - LLM API endpoint (e.g., https://api.openai.com/v1)
+#   LLM_API_KEY   - API key for the LLM provider (optional)
+#   LLM_MODEL     - Model identifier (e.g., gpt-4o)
+
+set -e
+
+echo "Starting OpenCode A2A container..."
+
+# Translate Kagenti-standard LLM_* env vars to OpenCode configuration
+# Kagenti standard: LLM_API_BASE, LLM_API_KEY, LLM_MODEL
+# OpenCode needs: Full provider configuration in opencode.json
+if [[ -n "${LLM_API_BASE}" || -n "${LLM_MODEL}" ]]; then
+    echo "Configuring OpenCode from Kagenti LLM_* environment variables..."
+
+    CONFIG_DIR="${HOME}/.config/opencode"
+    mkdir -p "${CONFIG_DIR}"
+
+    # Set defaults if not provided
+    PROVIDER_NAME="${LLM_PROVIDER:-vllm}"
+    BASE_URL="${LLM_API_BASE:-}"
+    API_KEY="${LLM_API_KEY:-}"
+    MODEL_NAME="${LLM_MODEL:-gpt-4o}"
+
+    echo "  LLM_PROVIDER=${PROVIDER_NAME}"
+    echo "  LLM_API_BASE=${BASE_URL}"
+    echo "  LLM_MODEL=${MODEL_NAME}"
+    if [[ -n "${API_KEY}" ]]; then
+        echo "  LLM_API_KEY=****"
+    fi
+
+    # Generate full OpenCode provider config (following msager-opencode reference)
+    cat > "${CONFIG_DIR}/opencode.json" <<EOF
+{
+  "\$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "${PROVIDER_NAME}": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "${PROVIDER_NAME}",
+      "options": {
+        "baseURL": "${BASE_URL}",
+        "apiKey": "${API_KEY}"
+      },
+      "models": {
+        "${MODEL_NAME}": {
+          "name": "${MODEL_NAME}"
+        }
+      }
+    }
+  },
+  "model": "${PROVIDER_NAME}/${MODEL_NAME}",
+  "small_model": "${PROVIDER_NAME}/${MODEL_NAME}",
+  "enabled_providers": ["${PROVIDER_NAME}"]
+}
+EOF
+    echo "  Config written to ${CONFIG_DIR}/opencode.json"
+fi
+
+# Start opencode serve in background
+echo "Starting opencode serve on port 4096..."
+opencode serve &
+OPENCODE_PID=$!
+
+# Wait for opencode serve to be ready
+echo "Waiting for opencode serve to be ready..."
+for i in {1..30}; do
+    if curl -sf http://127.0.0.1:4096/health >/dev/null 2>&1; then
+        echo "opencode serve is ready"
+        break
+    fi
+    if [ $i -eq 30 ]; then
+        echo "Warning: opencode serve health check timed out, continuing anyway..."
+    fi
+    sleep 1
+done
+
+# Run opencode-a2a in foreground (PID 1 for signal handling)
+echo "Starting opencode-a2a on port 8000..."
+exec opencode-a2a \
+    --port "${A2A_PORT:-8000}" \
+    --opencode-url "${OPENCODE_BASE_URL:-http://127.0.0.1:4096}"

--- a/agents/opencode/deployment/entrypoint-a2a.sh
+++ b/agents/opencode/deployment/entrypoint-a2a.sh
@@ -73,9 +73,20 @@ echo "Starting opencode serve on port 4096..."
 opencode serve &
 OPENCODE_PID=$!
 
-# Set up trap to cleanly shutdown background opencode serve process
-# when container receives SIGTERM/SIGINT or when script exits
-trap "echo 'Shutting down opencode serve...'; kill $OPENCODE_PID 2>/dev/null; wait $OPENCODE_PID 2>/dev/null; exit 0" EXIT INT TERM
+# Cleanup function for background opencode serve process
+cleanup() {
+    echo 'Shutting down opencode serve...'
+    kill $OPENCODE_PID 2>/dev/null
+    wait $OPENCODE_PID 2>/dev/null
+}
+
+# Set up traps to cleanly shutdown background process
+# EXIT trap: cleanup on normal exit or crash (preserves exit code)
+# TERM trap: cleanup on SIGTERM, exit 143 (128 + 15)
+# INT trap: cleanup on SIGINT, exit 130 (128 + 2)
+trap cleanup EXIT
+trap 'cleanup; exit 143' TERM
+trap 'cleanup; exit 130' INT
 
 # Wait for opencode serve to be ready
 echo "Waiting for opencode serve to be ready..."

--- a/agents/opencode/deployment/kagenti-agent.yaml
+++ b/agents/opencode/deployment/kagenti-agent.yaml
@@ -138,6 +138,14 @@ objects:
                 initialDelaySeconds: 10
                 periodSeconds: 5
                 failureThreshold: 12
+              livenessProbe:
+                httpGet:
+                  path: /.well-known/agent-card.json
+                  port: 8000
+                initialDelaySeconds: 30
+                periodSeconds: 10
+                failureThreshold: 3
+                timeoutSeconds: 5
               resources:
                 requests:
                   cpu: 100m

--- a/agents/opencode/deployment/kagenti-agent.yaml
+++ b/agents/opencode/deployment/kagenti-agent.yaml
@@ -21,8 +21,9 @@ parameters:
     description: "Target namespace for deployment"
     required: true
   - name: IMAGE
-    description: "Container image for OpenCode A2A"
-    value: "quay.io/opendatahub/opencode-a2a:latest"
+    description: "Container image for OpenCode A2A (build locally via BuildConfig)"
+    # TODO: Pin to specific version tag once container image versioning is established
+    value: "image-registry.openshift-image-registry.svc:5000/${NAMESPACE}/opencode-a2a:latest"
   - name: LLM_PROVIDER
     description: "Provider name (vllm, ogx, openai, etc.) - defaults to vllm"
     value: "vllm"
@@ -44,6 +45,20 @@ objects:
     metadata:
       name: opencode-a2a
       namespace: ${NAMESPACE}
+  - apiVersion: agent.kagenti.dev/v1alpha1
+    kind: AgentRuntime
+    metadata:
+      name: opencode-a2a-runtime
+      namespace: ${NAMESPACE}
+      labels:
+        app.kubernetes.io/name: opencode-a2a
+    spec:
+      type: agent
+      protocol: a2a
+      targetRef:
+        apiVersion: apps/v1
+        kind: Deployment
+        name: opencode-a2a
   - apiVersion: v1
     kind: Service
     metadata:
@@ -51,13 +66,11 @@ objects:
       namespace: ${NAMESPACE}
       labels:
         app.kubernetes.io/name: opencode-a2a
-        kagenti.io/type: agent
-        protocol.kagenti.io/a2a: ""
+        protocol.kagenti.io/a2a: "true"
     spec:
       type: ClusterIP
       selector:
         app.kubernetes.io/name: opencode-a2a
-        kagenti.io/type: agent
       ports:
         - name: a2a
           port: 8000
@@ -70,24 +83,17 @@ objects:
       namespace: ${NAMESPACE}
       labels:
         app.kubernetes.io/name: opencode-a2a
-        app.kubernetes.io/component: agent
-        kagenti.io/type: agent
-        kagenti.io/framework: opencode
-        kagenti.io/workload-type: deployment
-        protocol.kagenti.io/a2a: ""
+        protocol.kagenti.io/a2a: "true"
     spec:
       replicas: 1
       selector:
         matchLabels:
           app.kubernetes.io/name: opencode-a2a
-          kagenti.io/type: agent
       template:
         metadata:
           labels:
             app.kubernetes.io/name: opencode-a2a
-            kagenti.io/type: agent
-            kagenti.io/framework: opencode
-            protocol.kagenti.io/a2a: ""
+            protocol.kagenti.io/a2a: "true"
           annotations:
             sidecar.istio.io/inject: "false"
         spec:
@@ -126,12 +132,12 @@ objects:
                 - name: LLM_MODEL
                   value: ${LLM_MODEL}
               readinessProbe:
-                tcpSocket:
+                httpGet:
+                  path: /.well-known/agent-card.json
                   port: 8000
-                initialDelaySeconds: 5
+                initialDelaySeconds: 10
                 periodSeconds: 5
                 failureThreshold: 12
-                timeoutSeconds: 1
               resources:
                 requests:
                   cpu: 100m

--- a/agents/opencode/deployment/kagenti-agent.yaml
+++ b/agents/opencode/deployment/kagenti-agent.yaml
@@ -1,0 +1,151 @@
+# OpenCode A2A Agent - Kagenti-compatible OpenShift Template
+#
+# Deploy with:
+#   oc process -f kagenti-agent.yaml \
+#     -p NAMESPACE=my-namespace \
+#     -p LLM_API_BASE=https://api.openai.com/v1 \
+#     -p LLM_MODEL=gpt-4o | oc apply -f -
+#
+# Or create a parameters file and use:
+#   oc process -f kagenti-agent.yaml --param-file=params.env | oc apply -f -
+#
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: opencode-a2a-agent
+  annotations:
+    description: "OpenCode A2A Agent for Kagenti discovery"
+    tags: "agent,a2a,opencode,kagenti"
+parameters:
+  - name: NAMESPACE
+    description: "Target namespace for deployment"
+    required: true
+  - name: IMAGE
+    description: "Container image for OpenCode A2A"
+    value: "quay.io/opendatahub/opencode-a2a:latest"
+  - name: LLM_PROVIDER
+    description: "Provider name (vllm, ogx, openai, etc.) - defaults to vllm"
+    value: "vllm"
+  - name: LLM_API_BASE
+    description: "LLM API endpoint (e.g., https://api.openai.com/v1) - Kagenti standard"
+    value: ""
+  - name: LLM_MODEL
+    description: "Model identifier (e.g., gpt-4o) - Kagenti standard"
+    value: ""
+  - name: LLM_API_KEY_SECRET
+    description: "Secret name containing LLM API key (key: api-key)"
+    value: "opencode-model-credentials"
+  - name: PROVIDER_ORG
+    description: "Organization name shown in agent card"
+    value: "Red Hat"
+objects:
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: opencode-a2a
+      namespace: ${NAMESPACE}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: opencode-a2a
+      namespace: ${NAMESPACE}
+      labels:
+        app.kubernetes.io/name: opencode-a2a
+        kagenti.io/type: agent
+        protocol.kagenti.io/a2a: ""
+    spec:
+      type: ClusterIP
+      selector:
+        app.kubernetes.io/name: opencode-a2a
+        kagenti.io/type: agent
+      ports:
+        - name: a2a
+          port: 8000
+          targetPort: 8000
+          protocol: TCP
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: opencode-a2a
+      namespace: ${NAMESPACE}
+      labels:
+        app.kubernetes.io/name: opencode-a2a
+        app.kubernetes.io/component: agent
+        kagenti.io/type: agent
+        kagenti.io/framework: opencode
+        kagenti.io/workload-type: deployment
+        protocol.kagenti.io/a2a: ""
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: opencode-a2a
+          kagenti.io/type: agent
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: opencode-a2a
+            kagenti.io/type: agent
+            kagenti.io/framework: opencode
+            protocol.kagenti.io/a2a: ""
+          annotations:
+            sidecar.istio.io/inject: "false"
+        spec:
+          serviceAccountName: opencode-a2a
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: opencode-a2a
+              image: ${IMAGE}
+              imagePullPolicy: Always
+              ports:
+                - name: a2a
+                  containerPort: 8000
+                  protocol: TCP
+              env:
+                - name: A2A_HOST
+                  value: "0.0.0.0"
+                - name: A2A_PORT
+                  value: "8000"
+                - name: AGENT_ENDPOINT
+                  value: "http://opencode-a2a.${NAMESPACE}.svc.cluster.local:8000/"
+                - name: A2A_PROVIDER_ORG
+                  value: ${PROVIDER_ORG}
+                - name: LLM_PROVIDER
+                  value: ${LLM_PROVIDER}
+                - name: LLM_API_BASE
+                  value: ${LLM_API_BASE}
+                - name: LLM_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${LLM_API_KEY_SECRET}
+                      key: api-key
+                      optional: true
+                - name: LLM_MODEL
+                  value: ${LLM_MODEL}
+              readinessProbe:
+                tcpSocket:
+                  port: 8000
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                failureThreshold: 12
+                timeoutSeconds: 1
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  cpu: "1"
+                  memory: 1Gi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+          terminationGracePeriodSeconds: 30
+          restartPolicy: Always


### PR DESCRIPTION
## Description

Integrates the OpenCode A2A agent card server into the OpenCode container image on RHOAI, enabling OpenCode agents to be discovered in the Kagenti UI catalog.

New files:
- Containerfile.a2a - Extends base OpenCode image with OpenCode A2A server
- entrypoint-a2a.sh - Translates Kagenti-standard env vars (LLM_*) to OpenCode config
- kagenti-agent.yaml - OpenShift Template with Kagenti discovery labels
- README-a2a.md - Deployment and troubleshooting guide

Key features:
- Agent discovery via Kagenti UI (A2A protocol)
- Standardized LLM_API_BASE, LLM_MODEL, LLM_API_KEY environment variables
- Multi-provider support (vLLM, OGX, OpenAI-compatible endpoints)
- Provider config generated at container startup from env vars (no image rebuilds)

## Jira Ticket

RHAIENG-5825

## Testing

-[ ] AgentCard created and shows Synced=True
-[ ] Agent card endpoint returns valid JSON
-[ ] OpenCode config contains correct LLM provider settings from env vars
-[ ] OpenCode TUI accessible via oc exec and processes requests successfully
-[ ] Agent appears in Kagenti UI catalog
-[ ] LLM requests route correctly through configured provider