### PR TITLE
fix(ci): make CI health dashboard reactive and resilient

### DIFF
--- a/.github/scripts/fixtures/ci-runs-sample.json
+++ b/.github/scripts/fixtures/ci-runs-sample.json
@@ -1,4 +1,5 @@
 {
+  "_note": "Demo fixture only. Timestamps must fall within the last 7 days for pass-rate display; refresh dates when stale.",
   "code-quality.yml": [
     {
       "id": 10001,

--- a/.github/scripts/generate_ci_health_page.py
+++ b/.github/scripts/generate_ci_health_page.py
@@ -3,7 +3,8 @@
 Generate a static CI health dashboard from GitHub Actions workflow runs.
 
 Used by the ci-health-pages workflow to publish a read-only summary for the
-QG8 in-scope workflows on main and scheduled/nightly executions.
+QG8 in-scope workflows. The page rebuilds when those workflows complete on
+main or via schedule.
 
 Environment variables (optional):
     GITHUB_TOKEN      Token with actions:read (defaults to GITHUB_TOKEN in CI)
@@ -89,6 +90,7 @@ class WorkflowSummary:
     pass_rate_7d: float | None
     total_runs_7d: int
     passed_runs_7d: int
+    error_message: str | None = None
 
 
 def parse_timestamp(value: str) -> datetime:
@@ -235,6 +237,20 @@ def summarize_workflow(
     )
 
 
+def unavailable_workflow_summary(workflow: dict, error: str) -> WorkflowSummary:
+    return WorkflowSummary(
+        workflow_file=workflow["file"],
+        display_name=workflow["name"],
+        description=workflow["description"],
+        latest=None,
+        recent_runs=(),
+        pass_rate_7d=None,
+        total_runs_7d=0,
+        passed_runs_7d=0,
+        error_message=error,
+    )
+
+
 def load_fixture(path: Path) -> dict[str, list[dict]]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
@@ -259,12 +275,26 @@ def summaries_from_api(repository: str, token: str) -> list[WorkflowSummary]:
     client = GitHubActionsClient(token, repository)
     summaries: list[WorkflowSummary] = []
     for workflow in WORKFLOWS:
-        runs = client.list_workflow_runs(workflow["file"])
-        summaries.append(summarize_workflow(workflow, runs))
+        try:
+            runs = client.list_workflow_runs(workflow["file"])
+            summaries.append(summarize_workflow(workflow, runs))
+        except RuntimeError as exc:
+            print(f"WARNING: skipping {workflow['file']}: {exc}", file=sys.stderr)
+            summaries.append(unavailable_workflow_summary(workflow, str(exc)))
     return summaries
 
 
 def render_workflow_card(summary: WorkflowSummary) -> str:
+    if summary.error_message:
+        return f"""
+    <section class="card">
+      <h2>{html.escape(summary.display_name)}</h2>
+      <p class="muted">{html.escape(summary.description)}</p>
+      <p><span class="pill status-neutral">Data unavailable</span></p>
+      <p class="muted">{html.escape(summary.error_message)}</p>
+    </section>
+    """
+
     latest = summary.latest
     if latest is None:
         body = "<p class='muted'>No recent runs on <code>main</code> or scheduled triggers.</p>"
@@ -424,7 +454,8 @@ def render_page(
     <section class="hero">
       <h1>agentic-starter-kits CI Health</h1>
       <p class="muted">
-        Daily summary for QG8 in-scope workflows on <code>main</code> and scheduled runs.
+        CI health summary for QG8 in-scope workflows on <code>main</code> and
+        scheduled runs. Rebuilds when those workflows complete.
       </p>
       <p><strong>Repository:</strong> <code>{html.escape(repository)}</code></p>
       <p><strong>Last updated:</strong> {html.escape(generated_at.strftime("%Y-%m-%d %H:%M:%S UTC"))}</p>

--- a/.github/scripts/tests/test_generate_ci_health_page.py
+++ b/.github/scripts/tests/test_generate_ci_health_page.py
@@ -7,11 +7,16 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from generate_ci_health_page import (  # noqa: E402
+    WORKFLOWS,
     WorkflowRun,
     compute_pass_rate,
     is_relevant_run,
     main,
+    render_workflow_card,
+    summaries_from_api,
     summaries_from_fixture,
+    summarize_workflow,
+    unavailable_workflow_summary,
 )
 
 FIXTURE = Path(__file__).resolve().parent.parent / "fixtures" / "ci-runs-sample.json"
@@ -84,6 +89,62 @@ def test_workflow_dispatch_on_feature_branch_is_ignored():
         run_started_at=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
     )
     assert is_relevant_run(run) is False
+
+
+def test_schedule_run_is_always_relevant():
+    run = WorkflowRun(
+        id=4,
+        name="QG4: Agent Deployment Integration Tests",
+        event="schedule",
+        head_branch="",
+        status="completed",
+        conclusion="success",
+        html_url="https://example.com/4",
+        created_at=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        updated_at=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        run_started_at=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    )
+    assert is_relevant_run(run) is True
+
+
+def test_empty_workflow_summary():
+    summary = summarize_workflow(WORKFLOWS[0], [])
+    assert summary.latest is None
+    assert summary.pass_rate_7d is None
+    assert summary.recent_runs == ()
+
+
+def test_unavailable_workflow_renders_error_card():
+    summary = unavailable_workflow_summary(
+        WORKFLOWS[2],
+        "GitHub API error 404 for /repos/example/actions/workflows/eval-gating.yml/runs",
+    )
+    card = render_workflow_card(summary)
+    assert "Data unavailable" in card
+    assert "Inner Loop Gating" in card
+    assert "404" in card
+
+
+def test_summaries_from_api_continues_after_workflow_failure(monkeypatch):
+    class FakeClient:
+        def list_workflow_runs(self, workflow_file: str) -> list[WorkflowRun]:
+            if workflow_file == "eval-gating.yml":
+                raise RuntimeError("GitHub API error 404")
+            return []
+
+    monkeypatch.setattr(
+        "generate_ci_health_page.GitHubActionsClient",
+        lambda token, repository: FakeClient(),
+    )
+
+    summaries = summaries_from_api(
+        "red-hat-data-services/agentic-starter-kits", "token"
+    )
+    assert len(summaries) == 4
+    gating = next(item for item in summaries if item.workflow_file == "eval-gating.yml")
+    assert gating.error_message is not None
+    assert "404" in gating.error_message
+    assert all(item.error_message is None for item in summaries if item != gating)
 
 
 def test_main_writes_html(tmp_path):

--- a/.github/workflows/ci-health-pages.yml
+++ b/.github/workflows/ci-health-pages.yml
@@ -2,21 +2,25 @@
 #
 # Bootstrap:
 #   1. Repo admin enables Settings -> Pages -> Source: GitHub Actions
-#   2. Merge this workflow, or run workflow_dispatch from the PR branch to demo
-#   3. After merge to main, scheduled runs refresh the page daily
+#   2. Merge this workflow to main, then run workflow_dispatch for a first deploy
+#   3. After merge, each qualifying CI workflow completion rebuilds the page
 
 name: CI Health Pages
 
 on:
+  workflow_run:
+    workflows:
+      - Code Quality
+      - Agent Tests
+      - Inner Loop Gating
+      - "QG4: Agent Deployment Integration Tests"
+    types: [completed]
   workflow_dispatch:
     inputs:
       use_fixture:
         description: "Generate from sample fixture instead of live GitHub API"
         type: boolean
         default: false
-  schedule:
-  # Refresh after the QG4 nightly window (03:00 UTC) and morning review time.
-    - cron: "0 6 * * *"
   push:
     branches: [main]
     paths:
@@ -32,11 +36,19 @@ permissions:
 
 concurrency:
   group: pages
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   deploy:
-    if: github.repository == 'red-hat-data-services/agentic-starter-kits'
+    # Only publish from main; workflow_dispatch on feature branches must not
+    # overwrite the production Pages site.
+    if: >-
+      github.repository == 'red-hat-data-services/agentic-starter-kits' &&
+      github.ref == 'refs/heads/main' &&
+      (github.event_name != 'workflow_run' ||
+        (github.event.workflow_run.event != 'pull_request' &&
+         (github.event.workflow_run.head_branch == 'main' ||
+          github.event.workflow_run.event == 'schedule')))
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -53,20 +65,18 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Generate CI health page (fixture)
-        if: github.event_name == 'workflow_dispatch' && inputs.use_fixture == true
-        run: |
-          python .github/scripts/generate_ci_health_page.py \
-            --input .github/scripts/fixtures/ci-runs-sample.json \
-            --output site/index.html
-
-      - name: Generate CI health page (live)
-        if: github.event_name != 'workflow_dispatch' || inputs.use_fixture != true
+      - name: Generate CI health page
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
-          python .github/scripts/generate_ci_health_page.py --output site/index.html
+          if [[ "${{ github.event_name == 'workflow_dispatch' && inputs.use_fixture == true }}" == "true" ]]; then
+            python .github/scripts/generate_ci_health_page.py \
+              --input .github/scripts/fixtures/ci-runs-sample.json \
+              --output site/index.html
+          else
+            python .github/scripts/generate_ci_health_page.py --output site/index.html
+          fi
 
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v5.0.0

--- a/docs/ci-health-dashboard.md
+++ b/docs/ci-health-dashboard.md
@@ -18,12 +18,13 @@ Pull request runs are excluded from the summary to keep the page focused on shar
 ## Data source
 
 - **Live mode:** GitHub Actions REST API via `GITHUB_TOKEN` with `actions: read`
-- **Fixture mode:** `.github/scripts/fixtures/ci-runs-sample.json` for offline generation and demos
+- **Fixture mode:** `.github/scripts/fixtures/ci-runs-sample.json` for offline generation and demos (timestamps must be within the last 7 days for pass-rate display)
 
 ## Update cadence
 
-- Daily at `06:00 UTC` via `.github/workflows/ci-health-pages.yml`
+- **Push model:** rebuilds when any in-scope CI workflow completes on `main` or via `schedule` (`workflow_run` trigger in `.github/workflows/ci-health-pages.yml`)
 - Manual refresh via **Actions → CI Health Pages → Run workflow**
+- Also rebuilds when dashboard generator or workflow files change on `main`
 
 ## Enable GitHub Pages before merge
 
@@ -40,7 +41,7 @@ After the workflow file exists on your PR branch:
 3. Optional: enable **use_fixture** for a deterministic demo before merge
 4. Open the deployment URL from the workflow summary
 
-Once the PR merges to `main`, scheduled runs keep the page current.
+Once the PR merges to `main`, each qualifying CI completion keeps the page current.
 
 ## Local preview
 


### PR DESCRIPTION
Rebuild Pages on workflow_run completion instead of a daily cron, guard deploys to main only, degrade per-workflow API failures to error cards, and expand tests for schedule/empty/unavailable paths.

## Summary
  Follow-up to #234 (RHAIENG-5940) after merge and review feedback.
  - Switch from daily cron to **`workflow_run`** — dashboard rebuilds when in-scope CI workflows complete on `main` or via `schedule`
  - **Per-workflow API resilience** — a single workflow 404/error renders a "Data unavailable" card instead of failing the whole deploy
  - **Main-only Pages deploy** — `workflow_dispatch` from feature branches cannot overwrite production
  - Coalesce burst deploys with `cancel-in-progress: true` on the Pages concurrency group
  - Docs + fixture note for 7-day pass-rate timestamps; 4 new tests (9 total)
  ## Jira Ticket
  RHAIENG-5940
  ## Testing
  - [ ] `make test` passes (run from the affected agent directory)
  - [x] Manual testing performed (describe steps below)
  - [ ] No testing required (documentation/config change only)
  - `python -m pytest .github/scripts/tests/test_generate_ci_health_page.py -v` — 9 tests passed
  - `ruff check` / `ruff format --check` on generator and tests — passed
  **Post-merge verification:**
  1. Merge a small change to `main` that triggers Code Quality or Agent Tests
  2. Confirm **CI Health Pages** runs after that workflow completes
  3. Verify https://red-hat-data-services.github.io/agentic-starter-kits/ reflects the latest run status
  ## Checklist
  - [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
  - [x] No `.env` or secret files are included in this PR
  - [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)
  ## Review Guidance
  - `.github/workflows/ci-health-pages.yml` — `workflow_run` trigger, deploy `if:` guards, merged generate step
  - `.github/scripts/generate_ci_health_page.py` — `unavailable_workflow_summary()` + per-workflow try/except
  - `.github/scripts/tests/test_generate_ci_health_page.py` — new edge-case coverage
  ## Related PRs
  - #234 (merged — initial CI health dashboard)

