### PR TITLE
docs: consolidate MLflow auth/TLS for harness agents (RHAIENG-5904)

### DIFF
--- a/agents/claude-code/README.md
+++ b/agents/claude-code/README.md
@@ -769,7 +769,7 @@ The default Containerfile uses MLflow 3.12 with a Python hook. MLflow 3.14+ also
 >
 > Both point to the same file (`/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`). Do not remove `MLFLOW_TRACKING_SERVER_CERT_PATH` when switching to the plugin path — the setup step will fail with an SSL error. Upstream work is in progress to support `MLFLOW_TRACKING_SERVER_CERT_PATH` in the TS SDK directly ([mlflow#24140](https://github.com/mlflow/mlflow/issues/24140)). Kubernetes-native auth (`MLFLOW_TRACKING_AUTH`) is also being added to the TypeScript SDK ([mlflow#24141](https://github.com/mlflow/mlflow/issues/24141)).
 >
-> **Workspace:** The MLflow Claude plugin path requires `MLFLOW_WORKSPACE` to be set to your namespace name in the deployment manifest. The Python hook path (3.12) does not need this — see [TypeScript SDK: What's Different](../../docs/mlflow-openshift-auth-and-tls.md#typescript-sdk-whats-different) for why.
+> **Workspace:** The MLflow Claude Code plugin path requires `MLFLOW_WORKSPACE` to be set to your namespace name in the deployment manifest. The Python hook path (3.12) does not need this — see [TypeScript SDK: What's Different](../../docs/mlflow-openshift-auth-and-tls.md#typescript-sdk-whats-different) for why.
 
 For detailed tracing investigation results and benchmark data, see [mlflow-tracing.md](mlflow-tracing.md).
 

--- a/agents/claude-code/README.md
+++ b/agents/claude-code/README.md
@@ -705,36 +705,21 @@ The container image includes MLflow 3.12 with the `kubernetes-namespaced` auth p
 
 ### Prerequisites
 
-- An MLflow instance running on your RHOAI cluster with a workspace matching your namespace.
+- An MLflow instance running on your RHOAI cluster.
+- A RoleBinding granting your service account the `mlflow-integration` ClusterRole — see [Which service account?](../../docs/mlflow-openshift-auth-and-tls.md#which-service-account) for whether to use the `default` SA or create a dedicated one.
+- For RBAC, TLS, and authentication concepts, see [MLflow on OpenShift: Authentication and TLS](../../docs/mlflow-openshift-auth-and-tls.md).
 
-### 1. Grant RBAC
+### 1. Configure MLflow env vars
 
-```bash
-oc adm policy add-role-to-user edit -z default -n <your-namespace>
-```
+All four deployment files (`deployment.yaml`, `deployment-vllm.yaml`, `deployment-vertex.yaml`, `deployment-ogx-vllm.yaml`) include commented-out MLflow env vars — uncomment and configure them. The key settings are:
 
-For production, use a dedicated service account with least-privilege RBAC scoped to the permissions MLflow's `kubernetes-namespaced` auth plugin requires.
+- `MLFLOW_TRACKING_URI` — the MLflow server URL (internal service or external route)
+- `MLFLOW_TRACKING_AUTH=kubernetes-namespaced` — authenticates using the pod's service account and auto-detects the workspace from the namespace (no `MLFLOW_WORKSPACE` needed)
+- `MLFLOW_TRACKING_SERVER_CERT_PATH` — points to the service CA for TLS verification
 
-### 2. Add MLflow env vars to your deployment manifest
+The deployment manifests also document the MLflow Claude Code plugin path (MLflow 3.14+), which uses the MLflow TypeScript SDK and handles auth and TLS differently. See the comments in your chosen manifest for details.
 
-Uncomment the MLflow env vars in your deployment manifest (all four manifests include commented-out placeholders), or add these to the `env` section:
-
-```yaml
-- name: MLFLOW_TRACKING_URI
-  value: "https://mlflow.<rhoai-namespace>.svc:8443/mlflow"
-- name: MLFLOW_TRACKING_AUTH
-  value: "kubernetes-namespaced"
-- name: MLFLOW_WORKSPACE
-  value: "<your-namespace>"
-- name: MLFLOW_EXPERIMENT_NAME
-  value: "claude-code-traces"
-- name: MLFLOW_TRACKING_INSECURE_TLS
-  value: "true"  # dev/test only; production should use proper TLS certificates
-```
-
-The `<rhoai-namespace>` is commonly `redhat-ods-applications`. The `/mlflow` path suffix is required for MLflow 3.12+.
-
-If your deployment is already running, re-apply the manifest and restart the pod to pick up the new env vars:
+### 2. Deploy or restart
 
 ```bash
 oc apply -f <your-deployment-manifest>.yaml
@@ -775,9 +760,16 @@ Each session captures tool call sequences, token counts (input/output/total), se
 
 ### MLflow version options
 
-The default Containerfile uses MLflow 3.12 with a Python hook. MLflow 3.14+ also supports an npm plugin approach — uncomment the npm plugin env var in your deployment manifest to enable it. The plugin must be built from [upstream master](https://github.com/mlflow/mlflow/tree/master/libs/typescript) until the next plugin release syncs the fix. See [mlflow-tracing.md](mlflow-tracing.md) for a comparison of both approaches.
+The default Containerfile uses MLflow 3.12 with a Python hook. MLflow 3.14+ also supports the [MLflow Claude Code plugin](https://github.com/mlflow/mlflow/tree/master/libs/typescript/integrations/claude-code), a Claude Code plugin that uses the MLflow TypeScript SDK. Uncomment the `NODE_EXTRA_CA_CERTS` env var in your deployment manifest to enable TLS for it. The plugin must be built from upstream source until the next release syncs the fix. See [mlflow-tracing.md](mlflow-tracing.md) for a comparison of both approaches.
 
-> **TLS note:** The npm plugin currently requires `NODE_TLS_REJECT_UNAUTHORIZED=0` or `NODE_EXTRA_CA_CERTS` for clusters with non-public TLS certificates. Both are process-wide Node.js settings. Upstream work is in progress to support `MLFLOW_TRACKING_INSECURE_TLS` and `MLFLOW_TRACKING_SERVER_CERT_PATH` scoped to MLflow connections only ([mlflow#24140](https://github.com/mlflow/mlflow/issues/24140)). Kubernetes-native auth (`MLFLOW_TRACKING_AUTH`) is also being added to the TypeScript SDK ([mlflow#24141](https://github.com/mlflow/mlflow/issues/24141)).
+> **TLS note (MLflow Claude Code plugin):** The plugin path requires **two** TLS env vars when connecting to the internal MLflow service:
+>
+> - `MLFLOW_TRACKING_SERVER_CERT_PATH` — needed by `mlflow autolog claude`, which is a Python CLI that runs at container startup to install and configure the plugin.
+> - `NODE_EXTRA_CA_CERTS` — needed by the MLflow TypeScript SDK at runtime (it does not read `MLFLOW_TRACKING_SERVER_CERT_PATH`).
+>
+> Both point to the same file (`/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`). Do not remove `MLFLOW_TRACKING_SERVER_CERT_PATH` when switching to the plugin path — the setup step will fail with an SSL error. Upstream work is in progress to support `MLFLOW_TRACKING_SERVER_CERT_PATH` in the TS SDK directly ([mlflow#24140](https://github.com/mlflow/mlflow/issues/24140)). Kubernetes-native auth (`MLFLOW_TRACKING_AUTH`) is also being added to the TypeScript SDK ([mlflow#24141](https://github.com/mlflow/mlflow/issues/24141)).
+>
+> **Workspace:** The MLflow Claude plugin path requires `MLFLOW_WORKSPACE` to be set to your namespace name in the deployment manifest. The Python hook path (3.12) does not need this — see [TypeScript SDK: What's Different](../../docs/mlflow-openshift-auth-and-tls.md#typescript-sdk-whats-different) for why.
 
 For detailed tracing investigation results and benchmark data, see [mlflow-tracing.md](mlflow-tracing.md).
 

--- a/agents/claude-code/deployment/deployment-ogx-vllm.yaml
+++ b/agents/claude-code/deployment/deployment-ogx-vllm.yaml
@@ -186,30 +186,29 @@ spec:
               value: "vllm/YOUR_MODEL_ID"
             # ===========================================
             # MLflow Tracing (Optional) — Python hook (default, MLflow 3.12)
+            # See docs/mlflow-openshift-auth-and-tls.md for TLS and auth details.
             # ===========================================
             # Uncomment and configure to enable.
-            # See the MLflow Tracing section in ../README.md for details.
             # - name: MLFLOW_TRACKING_URI
             #   value: "https://mlflow.<rhoai-namespace>.svc:8443/mlflow"
             # - name: MLFLOW_TRACKING_AUTH
             #   value: "kubernetes-namespaced"
-            # - name: MLFLOW_WORKSPACE
-            #   value: "<your-namespace>"
             # - name: MLFLOW_EXPERIMENT_NAME
             #   value: "claude-code-traces"
+            # - name: MLFLOW_TRACKING_SERVER_CERT_PATH
+            #   value: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+            # Dev-only fallback (not recommended — prefer MLFLOW_TRACKING_SERVER_CERT_PATH):
             # - name: MLFLOW_TRACKING_INSECURE_TLS
             #   value: "true"
             # ---
-            # MLflow Tracing — npm plugin (MLflow 3.14+)
-            # To use the npm plugin instead of the Python hook, uncomment
-            # the block above AND add this env var.
-            # WARNING: NODE_TLS_REJECT_UNAUTHORIZED=0 disables TLS verification
-            # for ALL Node.js connections in the container (not just MLflow).
-            # Only use in dev/test clusters with self-signed certs.
-            # For production, mount the cluster CA bundle instead:
-            #   NODE_EXTRA_CA_CERTS=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            # - name: NODE_TLS_REJECT_UNAUTHORIZED
-            #   value: "0"
+            # MLflow Claude Code plugin (MLflow 3.14+)
+            # Requires Option B in the Containerfile. Uncomment the env vars below
+            # in addition to the Python env vars above. See README.md "MLflow version
+            # options" for why both are needed.
+            # - name: NODE_EXTRA_CA_CERTS
+            #   value: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+            # - name: MLFLOW_WORKSPACE
+            #   value: "my-namespace"
             # ===========================================
             # Context Window Configuration (Optional)
             # ===========================================

--- a/agents/claude-code/deployment/deployment-vertex.yaml
+++ b/agents/claude-code/deployment/deployment-vertex.yaml
@@ -184,30 +184,29 @@ spec:
               value: "/var/secrets/google/key.json"
             # ===========================================
             # MLflow Tracing (Optional) — Python hook (default, MLflow 3.12)
+            # See docs/mlflow-openshift-auth-and-tls.md for TLS and auth details.
             # ===========================================
             # Uncomment and configure to enable.
-            # See the MLflow Tracing section in ../README.md for details.
             # - name: MLFLOW_TRACKING_URI
             #   value: "https://mlflow.<rhoai-namespace>.svc:8443/mlflow"
             # - name: MLFLOW_TRACKING_AUTH
             #   value: "kubernetes-namespaced"
-            # - name: MLFLOW_WORKSPACE
-            #   value: "<your-namespace>"
             # - name: MLFLOW_EXPERIMENT_NAME
             #   value: "claude-code-traces"
+            # - name: MLFLOW_TRACKING_SERVER_CERT_PATH
+            #   value: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+            # Dev-only fallback (not recommended — prefer MLFLOW_TRACKING_SERVER_CERT_PATH):
             # - name: MLFLOW_TRACKING_INSECURE_TLS
             #   value: "true"
             # ---
-            # MLflow Tracing — npm plugin (MLflow 3.14+)
-            # To use the npm plugin instead of the Python hook, uncomment
-            # the block above AND add this env var.
-            # WARNING: NODE_TLS_REJECT_UNAUTHORIZED=0 disables TLS verification
-            # for ALL Node.js connections in the container (not just MLflow).
-            # Only use in dev/test clusters with self-signed certs.
-            # For production, mount the cluster CA bundle instead:
-            #   NODE_EXTRA_CA_CERTS=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            # - name: NODE_TLS_REJECT_UNAUTHORIZED
-            #   value: "0"
+            # MLflow Claude Code plugin (MLflow 3.14+)
+            # Requires Option B in the Containerfile. Uncomment the env vars below
+            # in addition to the Python env vars above. See README.md "MLflow version
+            # options" for why both are needed.
+            # - name: NODE_EXTRA_CA_CERTS
+            #   value: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+            # - name: MLFLOW_WORKSPACE
+            #   value: "my-namespace"
             # ===========================================
             # Claude Code Configuration
             # ===========================================

--- a/agents/claude-code/deployment/deployment-vllm.yaml
+++ b/agents/claude-code/deployment/deployment-vllm.yaml
@@ -181,30 +181,29 @@ spec:
               value: "YOUR_MODEL_ID"
             # ===========================================
             # MLflow Tracing (Optional) — Python hook (default, MLflow 3.12)
+            # See docs/mlflow-openshift-auth-and-tls.md for TLS and auth details.
             # ===========================================
             # Uncomment and configure to enable.
-            # See the MLflow Tracing section in ../README.md for details.
             # - name: MLFLOW_TRACKING_URI
             #   value: "https://mlflow.<rhoai-namespace>.svc:8443/mlflow"
             # - name: MLFLOW_TRACKING_AUTH
             #   value: "kubernetes-namespaced"
-            # - name: MLFLOW_WORKSPACE
-            #   value: "<your-namespace>"
             # - name: MLFLOW_EXPERIMENT_NAME
             #   value: "claude-code-traces"
+            # - name: MLFLOW_TRACKING_SERVER_CERT_PATH
+            #   value: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+            # Dev-only fallback (not recommended — prefer MLFLOW_TRACKING_SERVER_CERT_PATH):
             # - name: MLFLOW_TRACKING_INSECURE_TLS
             #   value: "true"
             # ---
-            # MLflow Tracing — npm plugin (MLflow 3.14+)
-            # To use the npm plugin instead of the Python hook, uncomment
-            # the block above AND add this env var.
-            # WARNING: NODE_TLS_REJECT_UNAUTHORIZED=0 disables TLS verification
-            # for ALL Node.js connections in the container (not just MLflow).
-            # Only use in dev/test clusters with self-signed certs.
-            # For production, mount the cluster CA bundle instead:
-            #   NODE_EXTRA_CA_CERTS=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            # - name: NODE_TLS_REJECT_UNAUTHORIZED
-            #   value: "0"
+            # MLflow Claude Code plugin (MLflow 3.14+)
+            # Requires Option B in the Containerfile. Uncomment the env vars below
+            # in addition to the Python env vars above. See README.md "MLflow version
+            # options" for why both are needed.
+            # - name: NODE_EXTRA_CA_CERTS
+            #   value: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+            # - name: MLFLOW_WORKSPACE
+            #   value: "my-namespace"
             # ===========================================
             # Context Window Configuration (Optional)
             # ===========================================

--- a/agents/claude-code/deployment/deployment.yaml
+++ b/agents/claude-code/deployment/deployment.yaml
@@ -150,30 +150,29 @@ spec:
             #   value: "your-model"
             # ===========================================
             # MLflow Tracing (Optional) — Python hook (default, MLflow 3.12)
+            # See docs/mlflow-openshift-auth-and-tls.md for TLS and auth details.
             # ===========================================
             # Uncomment and configure to enable.
-            # See the MLflow Tracing section in ../README.md for details.
             # - name: MLFLOW_TRACKING_URI
             #   value: "https://mlflow.<rhoai-namespace>.svc:8443/mlflow"
             # - name: MLFLOW_TRACKING_AUTH
             #   value: "kubernetes-namespaced"
-            # - name: MLFLOW_WORKSPACE
-            #   value: "<your-namespace>"
             # - name: MLFLOW_EXPERIMENT_NAME
             #   value: "claude-code-traces"
+            # - name: MLFLOW_TRACKING_SERVER_CERT_PATH
+            #   value: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+            # Dev-only fallback (not recommended — prefer MLFLOW_TRACKING_SERVER_CERT_PATH):
             # - name: MLFLOW_TRACKING_INSECURE_TLS
             #   value: "true"
             # ---
-            # MLflow Tracing — npm plugin (MLflow 3.14+)
-            # To use the npm plugin instead of the Python hook, uncomment
-            # the block above AND add this env var.
-            # WARNING: NODE_TLS_REJECT_UNAUTHORIZED=0 disables TLS verification
-            # for ALL Node.js connections in the container (not just MLflow).
-            # Only use in dev/test clusters with self-signed certs.
-            # For production, mount the cluster CA bundle instead:
-            #   NODE_EXTRA_CA_CERTS=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            # - name: NODE_TLS_REJECT_UNAUTHORIZED
-            #   value: "0"
+            # MLflow Claude Code plugin (MLflow 3.14+)
+            # Requires Option B in the Containerfile. Uncomment the env vars below
+            # in addition to the Python env vars above. See README.md "MLflow version
+            # options" for why both are needed.
+            # - name: NODE_EXTRA_CA_CERTS
+            #   value: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+            # - name: MLFLOW_WORKSPACE
+            #   value: "my-namespace"
             - name: MCP_CONFIG_FILE
               value: "/etc/mcp/config.json"
             # WARNING: Setting SKIP_PERMISSIONS=true disables all Claude permission checks.

--- a/agents/claude-code/deployment/entrypoint.sh
+++ b/agents/claude-code/deployment/entrypoint.sh
@@ -309,9 +309,12 @@ print("[entrypoint] INFO: MLflow settings injected into " + sf)
     local mlflow_version
     mlflow_version=$(python3 -c 'import mlflow; print(mlflow.__version__)' 2>/dev/null || echo "unknown")
     if [[ "${mlflow_version}" != 3.12* ]]; then
-        claude plugin enable mlflow-tracing@mlflow-plugins 2>/dev/null \
-            && log_info "MLflow Claude Code plugin enabled" \
-            || log_info "MLflow Claude Code plugin already enabled"
+        local plugin_err
+        if plugin_err=$(claude plugin enable mlflow-tracing@mlflow-plugins 2>&1); then
+            log_info "MLflow Claude Code plugin enabled"
+        else
+            log_warn "MLflow Claude Code plugin enable failed: ${plugin_err:-unknown error}"
+        fi
     fi
 
     # Replace installed plugin bundle with pre-built version if available

--- a/agents/claude-code/deployment/entrypoint.sh
+++ b/agents/claude-code/deployment/entrypoint.sh
@@ -287,7 +287,7 @@ env = s.setdefault("env", {})
 env["MLFLOW_TRACKING_AUTH"] = os.environ.get("MLFLOW_TRACKING_AUTH", "kubernetes-namespaced")
 env["MLFLOW_WORKSPACE"] = os.environ.get("MLFLOW_WORKSPACE", "")
 env["MLFLOW_TRACKING_INSECURE_TLS"] = os.environ.get("MLFLOW_TRACKING_INSECURE_TLS", "false")
-# Inject SA token for npm plugin (Python SDK reads it automatically, Node.js does not)
+# Inject SA token for MLflow Claude Code plugin (Python SDK reads it automatically, TS SDK does not)
 sa_token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 try:
     with open(sa_token_path) as f:
@@ -301,8 +301,21 @@ print("[entrypoint] INFO: MLflow settings injected into " + sf)
         log_warn "MLflow settings injection failed. Tracing may not authenticate correctly."
     fi
 
+    # Auto-enable the MLflow Claude Code plugin (MLflow 3.14+).
+    # `mlflow autolog claude` installs the plugin but Claude Code requires
+    # explicit enablement via settings.local.json. Without this, the plugin
+    # starts disabled on every fresh PVC.
+    # On 3.12 (Python hook path), the plugin isn't used — skip.
+    local mlflow_version
+    mlflow_version=$(python3 -c 'import mlflow; print(mlflow.__version__)' 2>/dev/null || echo "unknown")
+    if [[ "${mlflow_version}" != 3.12* ]]; then
+        claude plugin enable mlflow-tracing@mlflow-plugins 2>/dev/null \
+            && log_info "MLflow Claude Code plugin enabled" \
+            || log_info "MLflow Claude Code plugin already enabled"
+    fi
+
     # Replace installed plugin bundle with pre-built version if available
-    # (needed until the npm plugin release includes the workspace header fix)
+    # (needed until the plugin release includes the workspace header fix)
     if [[ -f "/opt/mlflow-plugin/stop.cjs" ]]; then
         local cached_stop
         cached_stop=$(find "${CLAUDE_CONFIG_DIR:-/workspace/.claude}/plugins" -name "stop.cjs" -path "*/mlflow*" 2>/dev/null | head -1)

--- a/agents/claude-code/mlflow-tracing.md
+++ b/agents/claude-code/mlflow-tracing.md
@@ -1,6 +1,6 @@
 # MLflow Tracing for Claude Code Agent Runtimes on RHOAI
 
-> **Setup instructions:** For how to enable MLflow tracing in your Claude Code deployment, see the [MLflow Tracing section of the deployment guide](README.md#mlflow-tracing-optional). This document covers the investigation and validation of the tracing stack.
+> **Setup instructions:** For how to enable MLflow tracing in your Claude Code deployment, see the [MLflow Tracing section of the deployment guide](README.md#mlflow-tracing-optional). For TLS and RBAC configuration on RHOAI, see [MLflow on OpenShift: Authentication and TLS](../docs/mlflow-openshift-auth-and-tls.md). This document covers the investigation and validation of the tracing stack.
 
 Deploy Claude Code as a containerized agent on Red Hat OpenShift AI and wire it up to the MLflow instance running on the same cluster. To validate the full tracing stack, the same prompt, **"build me a tetris game"**, was run through three different backends: Vertex AI (Google Cloud), vLLM directly, and OGX routing to vLLM. In all three cases, MLflow captured the complete session trace including every tool call, token usage, latency, and the full execution waterfall. The sections below document the telemetry investigation, the tracing prototype, and session-level metrics.
 
@@ -8,7 +8,7 @@ Deploy Claude Code as a containerized agent on Red Hat OpenShift AI and wire it 
 
 There are two ways to wire up MLflow tracing with Claude Code on RHOAI:
 
-| | Python hook (MLflow 3.12) | npm plugin (MLflow 3.14+) |
+| | Python hook (MLflow 3.12) | MLflow Claude Code plugin (MLflow 3.14+) |
 |---|---|---|
 | **How it works** | Python stop-hook processes the session file and sends traces via the Python SDK | Node.js stop-hook (Claude Code plugin) processes the session file and sends traces via the TypeScript SDK |
 | **Auth** | `kubernetes-namespaced` plugin handles token and workspace automatically | `MLFLOW_TRACKING_TOKEN` and `MLFLOW_WORKSPACE` must be set manually (entrypoint injects these from the pod's service account) |
@@ -16,9 +16,9 @@ There are two ways to wire up MLflow tracing with Claude Code on RHOAI:
 | **Workspace header** | Handled by Python SDK (`X-MLFLOW-WORKSPACE`) | Added upstream in [mlflow#23927](https://github.com/mlflow/mlflow/pull/23927), included in MLflow 3.14 |
 | **Status** | Default, works out of the box | Requires building plugin from upstream master until a new plugin version is released |
 
-Both approaches produce the same trace schema and capture the same data (tool calls, token counts, latency, session metadata). The npm plugin is the recommended approach once the plugin bundle is officially released with workspace support, as it adds write-ahead-log durability and lower latency. For setup instructions, see the [MLflow Tracing section of the deployment guide](README.md#mlflow-tracing-optional).
+Both approaches produce the same trace schema and capture the same data (tool calls, token counts, latency, session metadata). The MLflow Claude Code plugin is the recommended approach once the plugin bundle is officially released with workspace support, as it adds write-ahead-log durability and lower latency. For setup instructions, see the [MLflow Tracing section of the deployment guide](README.md#mlflow-tracing-optional).
 
-To use the npm plugin, uncomment Option B in the [Containerfile](deployment/Containerfile) and the npm plugin env var in your deployment manifest.
+To use the MLflow Claude Code plugin, uncomment Option B in the [Containerfile](deployment/Containerfile) and the plugin env vars in your deployment manifest. See the [MLflow version options](README.md#mlflow-version-options) section for the full list of required env vars.
 
 ---
 

--- a/agents/claude-code/mlflow-tracing.md
+++ b/agents/claude-code/mlflow-tracing.md
@@ -1,6 +1,6 @@
 # MLflow Tracing for Claude Code Agent Runtimes on RHOAI
 
-> **Setup instructions:** For how to enable MLflow tracing in your Claude Code deployment, see the [MLflow Tracing section of the deployment guide](README.md#mlflow-tracing-optional). For TLS and RBAC configuration on RHOAI, see [MLflow on OpenShift: Authentication and TLS](../docs/mlflow-openshift-auth-and-tls.md). This document covers the investigation and validation of the tracing stack.
+> **Setup instructions:** For how to enable MLflow tracing in your Claude Code deployment, see the [MLflow Tracing section of the deployment guide](README.md#mlflow-tracing-optional). For TLS and RBAC configuration on RHOAI, see [MLflow on OpenShift: Authentication and TLS](../../docs/mlflow-openshift-auth-and-tls.md). This document covers the investigation and validation of the tracing stack.
 
 Deploy Claude Code as a containerized agent on Red Hat OpenShift AI and wire it up to the MLflow instance running on the same cluster. To validate the full tracing stack, the same prompt, **"build me a tetris game"**, was run through three different backends: Vertex AI (Google Cloud), vLLM directly, and OGX routing to vLLM. In all three cases, MLflow captured the complete session trace including every tool call, token usage, latency, and the full execution waterfall. The sections below document the telemetry investigation, the tracing prototype, and session-level metrics.
 

--- a/agents/openclaw/deployment/README.md
+++ b/agents/openclaw/deployment/README.md
@@ -94,7 +94,7 @@ oc apply -k manifests/
 | Document | Description |
 |----------|-------------|
 | [docs/raw-deployment.md](docs/raw-deployment.md) | Full deployment guide: configuration, validation, troubleshooting |
-| [docs/mlflow-tracing.md](docs/mlflow-tracing.md) | MLflow tracing with OTel collector sidecar (see also [shared TLS/RBAC guide](../../docs/mlflow-openshift-auth-and-tls.md)) |
+| [docs/mlflow-tracing.md](docs/mlflow-tracing.md) | MLflow tracing with OTel collector sidecar (see also [shared TLS/RBAC guide](../../../docs/mlflow-openshift-auth-and-tls.md)) |
 | [docs/model-compatibility.md](docs/model-compatibility.md) | Model testing results for agentic tool-calling |
 | [docs/troubleshooting.md](docs/troubleshooting.md) | Common issues and fixes |
 | [docs/installer-deployment.md](docs/installer-deployment.md) | Alternative deployment via [claw-installer](https://github.com/sallyom/claw-installer) |

--- a/agents/openclaw/deployment/README.md
+++ b/agents/openclaw/deployment/README.md
@@ -94,7 +94,7 @@ oc apply -k manifests/
 | Document | Description |
 |----------|-------------|
 | [docs/raw-deployment.md](docs/raw-deployment.md) | Full deployment guide: configuration, validation, troubleshooting |
-| [docs/mlflow-tracing.md](docs/mlflow-tracing.md) | MLflow tracing with OTel collector sidecar |
+| [docs/mlflow-tracing.md](docs/mlflow-tracing.md) | MLflow tracing with OTel collector sidecar (see also [shared TLS/RBAC guide](../../docs/mlflow-openshift-auth-and-tls.md)) |
 | [docs/model-compatibility.md](docs/model-compatibility.md) | Model testing results for agentic tool-calling |
 | [docs/troubleshooting.md](docs/troubleshooting.md) | Common issues and fixes |
 | [docs/installer-deployment.md](docs/installer-deployment.md) | Alternative deployment via [claw-installer](https://github.com/sallyom/claw-installer) |

--- a/agents/openclaw/deployment/docs/mlflow-tracing.md
+++ b/agents/openclaw/deployment/docs/mlflow-tracing.md
@@ -2,7 +2,9 @@
 
 > Tested: 2026-06-17 on OpenShift 4.19 (ROSA) with `ghcr.io/openclaw/openclaw@sha256:037f49ba1595be9502fb345138d727cd0cfaecf1392cbe0cfe053fb4681386cd`, vLLM `gpt-oss-120b`, RHOAI MLflow 3.x
 
-OpenClaw natively emits OpenTelemetry (OTLP) traces via its `diagnostics-otel` plugin — no custom instrumentation, no Python hooks, no stop scripts. This overlay deploys OpenClaw with an OTel collector sidecar that forwards spans to RHOAI's shared MLflow instance over TLS with bearer token auth and scoped RBAC. A multi-turn coding task with 8 model calls and 8 tool executions produced a 19-span trace with full tool names, latencies, request/response sizes, and context window stats — all visible in the MLflow UI.
+OpenClaw natively emits OpenTelemetry (OTLP) traces via its `diagnostics-otel` plugin — no custom instrumentation, no Python hooks, no stop scripts. The [`overlays/mlflow-tracing/`](../overlays/mlflow-tracing/) Kustomize overlay in this repo deploys OpenClaw with an OTel collector sidecar that forwards spans to RHOAI's shared MLflow instance using standard OpenShift authentication and TLS. A multi-turn coding task with 8 model calls and 8 tool executions produced a 19-span trace with full tool names, latencies, request/response sizes, and context window stats — all visible in the MLflow UI.
+
+For background on how RHOAI MLflow handles TLS and RBAC, see [MLflow on OpenShift: Authentication and TLS](../../../../docs/mlflow-openshift-auth-and-tls.md). This document covers the OpenClaw-specific OTel collector integration.
 
 ## Architecture
 
@@ -28,7 +30,7 @@ OpenClaw natively emits OpenTelemetry (OTLP) traces via its `diagnostics-otel` p
                               └──────────────────────────────┘
 ```
 
-The collector runs as a sidecar in the OpenClaw pod, receiving spans on localhost and forwarding to RHOAI's shared MLflow over the cluster network. Authentication uses a ServiceAccount token with a scoped ClusterRole (`openclaw-mlflow-traces`) that only grants access to MLflow API groups — no access to core Kubernetes resources.
+The collector runs as a sidecar in the OpenClaw pod, receiving spans on localhost and forwarding to RHOAI's shared MLflow over the cluster network. Authentication uses the pod's ServiceAccount token as a bearer token — the same RBAC mechanism described in the [shared guide](../../../../docs/mlflow-openshift-auth-and-tls.md#rbac-setup).
 
 ### Component versions
 
@@ -38,11 +40,16 @@ The collector runs as a sidecar in the OpenClaw pod, receiving spans on localhos
 | OTel Collector (0.120.0) | `ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib@sha256:85ac41c2db88d0df9bd6145e608a3cb023f5d8443868adbfbbf66efb51087917` |
 | MLflow | RHOAI-managed (3.x) |
 
-### Security model
+### RBAC and TLS
 
-The overlay creates a dedicated `openclaw-tracing` ServiceAccount bound to the pre-existing `openclaw-mlflow-traces` ClusterRole. This role is scoped to `mlflow.kubeflow.org` and `mlflow.opendatahub.io` API groups only — it cannot read secrets, modify deployments, or access any core Kubernetes resources.
+The overlay's [`rbac.yaml`](../overlays/mlflow-tracing/rbac.yaml) creates:
 
-TLS verification uses the OpenShift Service CA certificate, injected automatically via the [`service.beta.openshift.io/inject-cabundle` annotation](https://docs.openshift.com/container-platform/4.17/security/certificates/service-serving-certificate.html) on the `service-ca-bundle` ConfigMap.
+- A dedicated `openclaw-tracing` **ServiceAccount** for the OpenClaw pod
+- A **RoleBinding** to the operator-provided `mlflow-integration` ClusterRole (see [RBAC Setup](../../../../docs/mlflow-openshift-auth-and-tls.md#rbac-setup) for details)
+
+The OTel collector reads the SA token from `/var/run/secrets/kubernetes.io/serviceaccount/token` via its `bearertokenauth` extension and sends it as a bearer token with every request.
+
+For TLS, it uses the service CA certificate at `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`, which OpenShift auto-mounts into every pod. This is the same auth and TLS that the MLflow Python SDK handles via `MLFLOW_TRACKING_AUTH` and `MLFLOW_TRACKING_SERVER_CERT_PATH` — but since the OTel collector is not an MLflow SDK client, it's configured directly in the collector's [`config.yaml`](../overlays/mlflow-tracing/otel-collector-config.yaml).
 
 ---
 
@@ -116,7 +123,8 @@ The `openclaw.model.call` spans capture `time_to_first_byte_ms` (40–294ms), `r
 
 ### Prerequisites
 
-- **RHOAI with MLflow** — the `mlflow` service must be running in `redhat-ods-applications` with `--enable-workspaces`. The `openclaw-mlflow-traces` ClusterRole must exist (created by the RHOAI operator).
+- **RHOAI with MLflow** — the `mlflow` service must be running in `redhat-ods-applications` with `--enable-workspaces`
+- **The `mlflow-integration` ClusterRole** — shipped by the MLflow operator. Run `oc get clusterroles | grep mlflow-integration` to find the exact name (it may be prefixed, e.g. `mlflow-operator-mlflow-integration`). See [RBAC Setup](../../../../docs/mlflow-openshift-auth-and-tls.md#rbac-setup).
 - **OpenShift 4.17+** with namespace-scoped access (`oc login`)
 - **A vLLM-compatible model endpoint** (see [model-compatibility.md](model-compatibility.md))
 
@@ -131,6 +139,7 @@ Replace every `YOUR-*` placeholder across these files:
 | File | What to change |
 |---|---|
 | `kustomization.yaml` | `YOUR-NAMESPACE` |
+| `rbac.yaml` | `YOUR-MLFLOW-INTEGRATION-CLUSTERROLE` (the name from the prerequisite step above) |
 | `configmap-patch.yaml` | `YOUR-MODEL-ID`, `YOUR-VLLM-OR-OGX-ENDPOINT` |
 | `otel-collector-config.yaml` | `YOUR-NAMESPACE` and `YOUR-EXPERIMENT-ID` (set after Step 3) |
 
@@ -148,17 +157,8 @@ oc apply -f overlays/my-tracing/rbac.yaml -n YOUR-NAMESPACE
 
 This creates:
 
-- **`openclaw-tracing` ServiceAccount** — used by the OpenClaw pod, scoped to MLflow API groups only
-- **`openclaw-tracing-mlflow` RoleBinding** — binds the pre-existing `openclaw-mlflow-traces` ClusterRole
-- **`service-ca-bundle` ConfigMap** — auto-populated with the OpenShift Service CA certificate for TLS verification
-
-Verify the Service CA bundle was injected:
-
-```bash
-oc get configmap service-ca-bundle -o jsonpath='{.data.service-ca\.crt}' | head -1
-```
-
-You should see `-----BEGIN CERTIFICATE-----`.
+- **`openclaw-tracing` ServiceAccount** — used by the OpenClaw pod
+- **RoleBinding** — binds the `mlflow-integration` ClusterRole to the ServiceAccount
 
 ### Step 3: Create an MLflow experiment
 
@@ -166,7 +166,7 @@ RHOAI MLflow uses workspaces — your namespace maps to a workspace. Create an e
 
 ```bash
 MLFLOW_ROUTE=$(oc get route mlflow -n redhat-ods-applications -o jsonpath='{.spec.host}')
-TOKEN=$(oc whoami -t)
+TOKEN=$(oc create token openclaw-tracing)
 
 curl -s -X POST "https://${MLFLOW_ROUTE}/mlflow/api/2.0/mlflow/experiments/create" \
   -H "Authorization: Bearer ${TOKEN}" \
@@ -244,6 +244,7 @@ The OpenShift Route terminates TLS at HAProxy, which disrupts the persistent Web
 
 | Resource | URL |
 |---|---|
+| MLflow on OpenShift: Auth and TLS | [docs/mlflow-openshift-auth-and-tls.md](../../../../docs/mlflow-openshift-auth-and-tls.md) |
 | OpenClaw OTel Documentation | <https://docs.openclaw.ai/gateway/opentelemetry> |
 | OpenClaw Deployment Guide | [raw-deployment.md](raw-deployment.md) |
 | OTel Collector Contrib | <https://github.com/open-telemetry/opentelemetry-collector-contrib> |

--- a/agents/openclaw/deployment/docs/raw-deployment.md
+++ b/agents/openclaw/deployment/docs/raw-deployment.md
@@ -174,6 +174,10 @@ Open <http://localhost:18789> in your browser. Paste the gateway token from Step
 
 On first connect, device pairing is auto-approved for local connections. You should see the chat interface ready to use.
 
+## Next: Enable tracing (optional)
+
+To send OpenTelemetry traces to RHOAI MLflow, see [mlflow-tracing.md](mlflow-tracing.md).
+
 ## References
 
 | Resource | URL |

--- a/agents/openclaw/deployment/overlays/mlflow-tracing/deployment-patch.yaml
+++ b/agents/openclaw/deployment/overlays/mlflow-tracing/deployment-patch.yaml
@@ -29,9 +29,6 @@ spec:
           volumeMounts:
             - name: otel-config
               mountPath: /etc/otel
-            - name: service-ca-bundle
-              mountPath: /etc/ssl/service-ca
-              readOnly: true
           resources:
             requests:
               cpu: 100m
@@ -54,6 +51,3 @@ spec:
             items:
               - key: config.yaml
                 path: config.yaml
-        - name: service-ca-bundle
-          configMap:
-            name: service-ca-bundle

--- a/agents/openclaw/deployment/overlays/mlflow-tracing/otel-collector-config.yaml
+++ b/agents/openclaw/deployment/overlays/mlflow-tracing/otel-collector-config.yaml
@@ -46,7 +46,7 @@ data:
       otlphttp:
         endpoint: "https://mlflow.redhat-ods-applications.svc.cluster.local:8443"
         tls:
-          ca_file: /etc/ssl/service-ca/service-ca.crt
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
         headers:
           X-MLFLOW-WORKSPACE: YOUR-NAMESPACE
           x-mlflow-experiment-id: "YOUR-EXPERIMENT-ID"

--- a/agents/openclaw/deployment/overlays/mlflow-tracing/rbac.yaml
+++ b/agents/openclaw/deployment/overlays/mlflow-tracing/rbac.yaml
@@ -1,9 +1,12 @@
-# RBAC and TLS resources for connecting to RHOAI shared MLflow
+# RBAC resources for connecting to RHOAI shared MLflow
 #
-# - ServiceAccount: used by the OpenClaw pod (scoped to MLflow API groups only)
-# - RoleBinding: binds the pre-existing openclaw-mlflow-traces ClusterRole
-# - ConfigMap: injected with the OpenShift Service CA for TLS verification
+# - ServiceAccount: used by the OpenClaw pod
+# - RoleBinding: binds the operator-provided mlflow-integration ClusterRole
 #
+# Find the exact ClusterRole name on your cluster:
+#   oc get clusterroles | grep mlflow-integration
+# Then replace YOUR-MLFLOW-INTEGRATION-CLUSTERROLE below.
+# See docs/mlflow-openshift-auth-and-tls.md for details.
 
 ---
 apiVersion: v1
@@ -22,16 +25,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: openclaw-mlflow-traces
+  name: YOUR-MLFLOW-INTEGRATION-CLUSTERROLE
 subjects:
   - kind: ServiceAccount
     name: openclaw-tracing
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: service-ca-bundle
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
-  labels:
-    app: openclaw

--- a/docs/mlflow-openshift-auth-and-tls.md
+++ b/docs/mlflow-openshift-auth-and-tls.md
@@ -18,6 +18,7 @@ For how the Python agents in this repo set up MLflow tracing, see [tracing.md](.
 - [Authentication](#authentication)
 - [Complete .env Examples](#complete-env-examples)
 - [TypeScript SDK: What's Different](#typescript-sdk-whats-different)
+- [Agent Implementations](#agent-implementations)
 
 ---
 
@@ -131,9 +132,30 @@ oc -n <namespace> create rolebinding <name>-mlflow-integration \
   --serviceaccount=<namespace>:<service-account-name>
 ```
 
-### Who needs a RoleBinding?
+### Which service account?
 
-The service account your agent uses. Create the RoleBinding above before deploying or generating tokens — without it, MLflow returns 403. See [Authentication](#authentication) for how to generate and configure the token.
+Every pod uses the identity of a service account. If your deployment doesn't set `serviceAccountName`, it uses the namespace's `default` SA — this is the simplest option and works well when the namespace is dedicated to a single agent:
+
+```bash
+# Bind the mlflow-integration role to the default SA
+oc -n <namespace> create rolebinding <namespace>-mlflow-integration \
+  --clusterrole=<mlflow-integration-clusterrole> \
+  --serviceaccount=<namespace>:default
+```
+
+If the namespace runs other pods that should not have MLflow access, create a dedicated service account:
+
+```bash
+oc -n <namespace> create sa <agent-name>-tracing
+
+oc -n <namespace> create rolebinding <agent-name>-mlflow-integration \
+  --clusterrole=<mlflow-integration-clusterrole> \
+  --serviceaccount=<namespace>:<agent-name>-tracing
+```
+
+Then set `serviceAccountName: <agent-name>-tracing` in your deployment spec.
+
+Create the RoleBinding before deploying or generating tokens — without it, MLflow returns 403. See [Authentication](#authentication) for how to generate and configure the token.
 
 ---
 
@@ -247,4 +269,12 @@ MLFLOW_WORKSPACE=<injected by entrypoint>
 NODE_EXTRA_CA_CERTS=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
 ```
 
-> A follow-up PR will demonstrate these workarounds with a concrete TS agent implementation (claude-code with the MLflow TS plugin).
+---
+
+## Agent Implementations
+
+Different agents use different clients to send traces to MLflow — the auth and TLS concepts above apply to all of them:
+
+- **react_agent** (MLflow Python SDK) — [tracing setup](../agents/langgraph/templates/react_agent/README.md#tracing-optional), reference implementation for Python framework agents
+- **claude-code** (MLflow TS SDK + Python hook) — [tracing setup](../agents/claude-code/README.md#mlflow-tracing-optional)
+- **openclaw** (OTel collector sidecar) — [tracing setup](../agents/openclaw/deployment/docs/mlflow-tracing.md)


### PR DESCRIPTION
## Summary

[RHAIENG-5739](https://redhat.atlassian.net/browse/RHAIENG-5739) created the shared reference guide (`docs/mlflow-openshift-auth-and-tls.md`) and updated `react_agent` as the reference Python Langgraph-agent implementation ([PR #226](https://github.com/red-hat-data-services/agentic-starter-kits/pull/226)).

This PR brings the two harness agents — **claude-code** and **openclaw** — into alignment: replace inline TLS/RBAC documentation with references to the shared guide, fix inconsistencies, and remove redundancy.

### claude-code
- Replace broad `edit` RBAC with scoped `mlflow-integration` ClusterRole
- Fix `ca.crt` → `service-ca.crt` in all four deployment manifests
- Add `MLFLOW_TRACKING_SERVER_CERT_PATH`, demote `INSECURE_TLS` to dev-only fallback
- Point README to deployment YAMLs as config source of truth (no duplicated env var blocks)
- Fix `workspace/projects` permissions for fresh PVCs (from [#244](https://github.com/red-hat-data-services/agentic-starter-kits/pull/244))

### openclaw
- Replace `openclaw-mlflow-traces` with operator-provided `mlflow-integration` ClusterRole
- Remove unnecessary `service-ca-bundle` ConfigMap — the same cert is already auto-mounted at `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`
- Use the more restrictive approach with `oc create token`
- Rename "Security model" → "RBAC and TLS" for consistency with shared guide

## Testing Approach

- [x] Walked through each doc (claude-code README, openclaw mlflow-tracing.md, shared guide) sequentially as a new reader — verified the reading flow is coherent, cross-references resolve, and no jargon appears before it's introduced


## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket

## Related PRs

- #226 — shared guide + react_agent reference implementation (merged)
- #244 — workspace/projects permissions fix (cherry-picked into this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHAIENG-5739]: https://redhat.atlassian.net/browse/RHAIENG-5739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ