### PR TITLE
feat: add integration test for A2A LangGraph-CrewAI agent (RHAIENG-4031)

### DIFF
--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -65,6 +65,7 @@ jobs:
           - { name: langgraph-db-memory-agent, dir: agents/langgraph/templates/react_with_database_memory }
           - { name: autogen-mcp-agent, dir: agents/autogen/templates/mcp_agent }
           - { name: vanilla-python-openai-responses-agent, dir: agents/vanilla_python/templates/openai_responses_agent }
+          - { name: a2a-langgraph-crewai, dir: agents/a2a/templates/langgraph_crewai_agent }
         include:
           - agent: { name: langgraph-db-memory-agent, dir: agents/langgraph/templates/react_with_database_memory }
             POSTGRES_HOST: ${{ vars.POSTGRES_HOST }}
@@ -76,6 +77,8 @@ jobs:
           - agent: { name: vanilla-python-openai-responses-agent, dir: agents/vanilla_python/templates/openai_responses_agent }
             BASE_URL: ${{ vars.OPENAI_BASE_URL }}
             MODEL_ID: ${{ vars.OPENAI_MODEL_ID }}
+          - agent: { name: a2a-langgraph-crewai, dir: agents/a2a/templates/langgraph_crewai_agent }
+            CONTAINER_IMAGE: ${{ vars.CONTAINER_IMAGE_A2A_LANGGRAPH_CREWAI }}
     env:
       API_KEY: ${{ vars.API_KEY }}
       BASE_URL: ${{ vars.BASE_URL }}
@@ -103,6 +106,7 @@ jobs:
           POSTGRES_USER: ${{ matrix.POSTGRES_USER }}
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           MCP_SERVER_URL: ${{ matrix.MCP_SERVER_URL }}
+          CONTAINER_IMAGE: ${{ matrix.CONTAINER_IMAGE }}
         run: make test-integration
 
       - name: Upload test results

--- a/agents/a2a/templates/langgraph_crewai_agent/Makefile
+++ b/agents/a2a/templates/langgraph_crewai_agent/Makefile
@@ -4,7 +4,7 @@ CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 
-.PHONY: init re-init env test run-app run-app-fresh run-crew run-langgraph build push deploy undeploy dry-run help
+.PHONY: init re-init env test run-app run-app-fresh run-crew run-langgraph build push deploy undeploy dry-run test-integration help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-18s %s\n", $$1, $$2}'
@@ -188,6 +188,11 @@ deploy: _check-env ## Two-phase Helm deploy (Routes first, then Deployments with
 
 undeploy: ## Remove Helm release (all resources)
 	helm uninstall $(AGENT_NAME) --ignore-not-found
+
+test-integration: ## Run integration deployment test
+	PYTHONPATH=$$(git rev-parse --show-toplevel)/tests \
+	  uv run --extra dev python -m pytest tests/integration/test_deployment.py \
+	    -v --tb=long --junitxml=results.xml
 
 dry-run: _check-env ## Render Helm manifests (secrets redacted)
 	@set -a && source .env && set +a && \

--- a/agents/a2a/templates/langgraph_crewai_agent/pyproject.toml
+++ b/agents/a2a/templates/langgraph_crewai_agent/pyproject.toml
@@ -18,6 +18,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "requests>=2.28",
+]
 tracing = [
     "mlflow>=3.11.0",
 ]

--- a/agents/a2a/templates/langgraph_crewai_agent/pyproject.toml
+++ b/agents/a2a/templates/langgraph_crewai_agent/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",
-    "requests>=2.28",
 ]
 tracing = [
     "mlflow>=3.11.0",

--- a/agents/a2a/templates/langgraph_crewai_agent/tests/integration/conftest.py
+++ b/agents/a2a/templates/langgraph_crewai_agent/tests/integration/conftest.py
@@ -20,6 +20,7 @@ _REQUIRED_ENV = ("BASE_URL", "MODEL_ID", "CONTAINER_IMAGE")
 
 _DEPLOYMENT_NAMES = ["a2a-crew-agent", "a2a-langgraph-agent"]
 
+# Populated by deployed_agent, consumed by all_routes (both module-scoped).
 _discovered_routes = {}
 
 
@@ -43,6 +44,9 @@ def _write_env_file(agent_dir):
             "Set them in the CI workflow or export locally."
         )
     env_path = agent_dir / ".env"
+    orig_env = None
+    if env_path.exists():
+        orig_env = env_path.read_text(encoding="utf-8")
     env_path.touch(mode=0o600)
     env_path.write_text(
         f"API_KEY={os.environ.get('API_KEY', 'not-needed')}\n"
@@ -51,7 +55,7 @@ def _write_env_file(agent_dir):
         f"CONTAINER_IMAGE={os.environ['CONTAINER_IMAGE']}\n",
         encoding="utf-8",
     )
-    return env_path
+    return env_path, orig_env
 
 
 @pytest.fixture(scope="module")
@@ -63,9 +67,8 @@ def all_routes(deployed_agent):
 @pytest.fixture(scope="module")
 def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
     namespace = cluster_auth["namespace"]
-    env_path = _write_env_file(agent_dir)
+    env_path, orig_env = _write_env_file(agent_dir)
 
-    deployed = False
     try:
         try:
             logger.info("Building container image locally...")
@@ -76,7 +79,6 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
 
             logger.info("Deploying to cluster (two-phase Helm)...")
             run_make("deploy", cwd=agent_dir, timeout=600)
-            deployed = True
 
             for deploy_name in _DEPLOYMENT_NAMES:
                 _discovered_routes[deploy_name] = get_route(
@@ -97,13 +99,18 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
         yield primary
 
     finally:
-        if deployed:
-            logger.info("Tearing down deployment...")
+        logger.info("Tearing down deployment...")
+        try:
+            run_make("undeploy", cwd=agent_dir, timeout=120)
+        except MakeTargetError:
+            logger.warning(
+                "Cleanup failed — manual undeploy may be needed",
+                exc_info=True,
+            )
+        if orig_env is not None:
             try:
-                run_make("undeploy", cwd=agent_dir, timeout=120)
-            except MakeTargetError:
-                logger.warning(
-                    "Cleanup failed — manual undeploy may be needed",
-                    exc_info=True,
-                )
-        env_path.unlink(missing_ok=True)
+                env_path.write_text(orig_env, encoding="utf-8")
+            except Exception:
+                logger.exception("Failed to restore pre-existing .env at %s", env_path)
+        else:
+            env_path.unlink(missing_ok=True)

--- a/agents/a2a/templates/langgraph_crewai_agent/tests/integration/conftest.py
+++ b/agents/a2a/templates/langgraph_crewai_agent/tests/integration/conftest.py
@@ -61,7 +61,7 @@ def all_routes(deployed_agent):
 
 
 @pytest.fixture(scope="module")
-def deployed_agent(cluster_auth, agent_dir, agent_name):
+def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
     namespace = cluster_auth["namespace"]
     env_path = _write_env_file(agent_dir)
 

--- a/agents/a2a/templates/langgraph_crewai_agent/tests/integration/conftest.py
+++ b/agents/a2a/templates/langgraph_crewai_agent/tests/integration/conftest.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+from integration.conftest import cluster_auth, repo_root  # noqa: F401
+from integration.utils import (
+    MakeTargetError,
+    RouteNotFoundError,
+    get_route,
+    load_agent_name,
+    resolve_agent_dir,
+    run_make,
+)
+
+logger = logging.getLogger(__name__)
+
+_REQUIRED_ENV = ("BASE_URL", "MODEL_ID", "CONTAINER_IMAGE")
+
+_DEPLOYMENT_NAMES = ["a2a-crew-agent", "a2a-langgraph-agent"]
+
+_discovered_routes = {}
+
+
+@pytest.fixture(scope="module")
+def agent_dir():
+    return resolve_agent_dir(__file__)
+
+
+@pytest.fixture(scope="module")
+def agent_name(agent_dir):
+    return load_agent_name(agent_dir)
+
+
+def _write_env_file(agent_dir):
+    """Write a .env from env vars. CONTAINER_IMAGE comes from environment (external registry)."""
+    missing = [v for v in _REQUIRED_ENV if v not in os.environ]
+    if missing:
+        pytest.fail(
+            f"Missing required env vars for A2A multi-agent deployment: "
+            f"{', '.join(missing)}. "
+            "Set them in the CI workflow or export locally."
+        )
+    env_path = agent_dir / ".env"
+    env_path.write_text(
+        f"API_KEY={os.environ.get('API_KEY', 'not-needed')}\n"
+        f"BASE_URL={os.environ['BASE_URL']}\n"
+        f"MODEL_ID={os.environ['MODEL_ID']}\n"
+        f"CONTAINER_IMAGE={os.environ['CONTAINER_IMAGE']}\n",
+        encoding="utf-8",
+    )
+    return env_path
+
+
+@pytest.fixture(scope="module")
+def all_routes(deployed_agent):
+    """Routes for all deployments, populated by deployed_agent fixture."""
+    return _discovered_routes
+
+
+@pytest.fixture(scope="module")
+def deployed_agent(cluster_auth, agent_dir, agent_name):
+    namespace = cluster_auth["namespace"]
+    env_path = _write_env_file(agent_dir)
+
+    deployed = False
+    try:
+        try:
+            logger.info("Building container image locally...")
+            run_make("build", cwd=agent_dir, timeout=600)
+
+            logger.info("Pushing image to external registry...")
+            run_make("push", cwd=agent_dir, timeout=300)
+
+            logger.info("Deploying to cluster (two-phase Helm)...")
+            run_make("deploy", cwd=agent_dir, timeout=600)
+            deployed = True
+
+            for deploy_name in _DEPLOYMENT_NAMES:
+                _discovered_routes[deploy_name] = get_route(
+                    deploy_name, namespace=namespace
+                )
+                logger.info(
+                    "Deployment %s at %s",
+                    deploy_name,
+                    _discovered_routes[deploy_name],
+                )
+
+            primary = next(iter(_discovered_routes.values()))
+        except (MakeTargetError, RouteNotFoundError) as exc:
+            pytest.fail(f"Deployment failed: {exc}")
+        except Exception:
+            pytest.fail("Deployment failed — see logs")
+
+        yield primary
+
+    finally:
+        if deployed:
+            logger.info("Tearing down deployment...")
+            try:
+                run_make("undeploy", cwd=agent_dir, timeout=120)
+            except MakeTargetError:
+                logger.warning(
+                    "Cleanup failed — manual undeploy may be needed",
+                    exc_info=True,
+                )
+        env_path.unlink(missing_ok=True)

--- a/agents/a2a/templates/langgraph_crewai_agent/tests/integration/conftest.py
+++ b/agents/a2a/templates/langgraph_crewai_agent/tests/integration/conftest.py
@@ -43,6 +43,7 @@ def _write_env_file(agent_dir):
             "Set them in the CI workflow or export locally."
         )
     env_path = agent_dir / ".env"
+    env_path.touch(mode=0o600)
     env_path.write_text(
         f"API_KEY={os.environ.get('API_KEY', 'not-needed')}\n"
         f"BASE_URL={os.environ['BASE_URL']}\n"
@@ -90,8 +91,8 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
             primary = next(iter(_discovered_routes.values()))
         except (MakeTargetError, RouteNotFoundError) as exc:
             pytest.fail(f"Deployment failed: {exc}")
-        except Exception:
-            pytest.fail("Deployment failed — see logs")
+        except Exception as exc:
+            pytest.fail(f"Deployment failed — {exc}")
 
         yield primary
 

--- a/agents/a2a/templates/langgraph_crewai_agent/tests/integration/test_deployment.py
+++ b/agents/a2a/templates/langgraph_crewai_agent/tests/integration/test_deployment.py
@@ -9,7 +9,9 @@ _AGENT_CARD_FIELDS = ("name", "url", "version", "capabilities", "skills")
 @pytest.mark.integration
 def test_health_endpoint(deployed_agent):
     route_url = deployed_agent
-    card = health_check(f"{route_url}/.well-known/agent-card.json", retries=12, backoff=5.0)
+    card = health_check(
+        f"{route_url}/.well-known/agent-card.json", retries=12, backoff=5.0
+    )
 
     for field in _AGENT_CARD_FIELDS:
         assert field in card, f"Agent card missing '{field}' field"

--- a/agents/a2a/templates/langgraph_crewai_agent/tests/integration/test_deployment.py
+++ b/agents/a2a/templates/langgraph_crewai_agent/tests/integration/test_deployment.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import pytest
 from integration.utils import health_check
 
-_AGENT_CARD_FIELDS = ("name", "url", "version", "capabilities", "skills")
+_AGENT_CARD_FIELDS = (
+    "name",
+    "supportedInterfaces",
+    "version",
+    "capabilities",
+    "skills",
+)
 
 
 @pytest.mark.integration

--- a/agents/a2a/templates/langgraph_crewai_agent/tests/integration/test_deployment.py
+++ b/agents/a2a/templates/langgraph_crewai_agent/tests/integration/test_deployment.py
@@ -1,51 +1,33 @@
 from __future__ import annotations
 
-import os
-import time
-
 import pytest
-import requests
+from integration.utils import health_check
+
+_AGENT_CARD_FIELDS = ("name", "url", "version", "capabilities", "skills")
 
 
 @pytest.mark.integration
 def test_health_endpoint(deployed_agent):
     route_url = deployed_agent
-    url = f"{route_url}/.well-known/agent-card.json"
-    verify = os.getenv("CLUSTER_CA_BUNDLE", False)
-    last_exc = None
-    for attempt in range(12):
-        try:
-            resp = requests.get(url, timeout=30, verify=verify)
-            if resp.status_code == 200:
-                card = resp.json()
-                assert "name" in card, "Agent card missing 'name' field"
-                return
-        except requests.RequestException as exc:
-            last_exc = exc
-        time.sleep(5.0)
-    pytest.fail(
-        f"Agent card not available after 12 retries: {last_exc or resp.status_code}"
-    )
+    card = health_check(f"{route_url}/.well-known/agent-card.json", retries=12, backoff=5.0)
+
+    for field in _AGENT_CARD_FIELDS:
+        assert field in card, f"Agent card missing '{field}' field"
 
 
 @pytest.mark.integration
 def test_all_deployments_healthy(all_routes):
     """Verify every deployment in the multi-component agent is healthy."""
     assert all_routes, "No routes discovered — deployment may have failed"
-    verify = os.getenv("CLUSTER_CA_BUNDLE", False)
+    cards = {}
     for name, route_url in all_routes.items():
-        url = f"{route_url}/.well-known/agent-card.json"
-        last_exc = None
-        for attempt in range(12):
-            try:
-                resp = requests.get(url, timeout=30, verify=verify)
-                if resp.status_code == 200:
-                    break
-            except requests.RequestException as exc:
-                last_exc = exc
-            time.sleep(5.0)
-        else:
-            pytest.fail(
-                f"Deployment {name} health check failed after 12 retries: "
-                f"{last_exc or resp.status_code}"
-            )
+        card = health_check(
+            f"{route_url}/.well-known/agent-card.json", retries=12, backoff=5.0
+        )
+        assert "name" in card, f"Deployment {name}: agent card missing 'name' field"
+        cards[name] = card
+
+    names = [c["name"] for c in cards.values()]
+    assert len(set(names)) == len(names), (
+        f"Expected distinct agent names per deployment, got: {names}"
+    )

--- a/agents/a2a/templates/langgraph_crewai_agent/tests/integration/test_deployment.py
+++ b/agents/a2a/templates/langgraph_crewai_agent/tests/integration/test_deployment.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+import requests
+
+
+@pytest.mark.integration
+def test_health_endpoint(deployed_agent):
+    route_url = deployed_agent
+    url = f"{route_url}/.well-known/agent-card.json"
+    verify = os.getenv("CLUSTER_CA_BUNDLE", False)
+    last_exc = None
+    for attempt in range(12):
+        try:
+            resp = requests.get(url, timeout=30, verify=verify)
+            if resp.status_code == 200:
+                card = resp.json()
+                assert "name" in card, "Agent card missing 'name' field"
+                return
+        except requests.RequestException as exc:
+            last_exc = exc
+        time.sleep(5.0)
+    pytest.fail(
+        f"Agent card not available after 12 retries: {last_exc or resp.status_code}"
+    )
+
+
+@pytest.mark.integration
+def test_all_deployments_healthy(all_routes):
+    """Verify every deployment in the multi-component agent is healthy."""
+    assert all_routes, "No routes discovered — deployment may have failed"
+    verify = os.getenv("CLUSTER_CA_BUNDLE", False)
+    for name, route_url in all_routes.items():
+        url = f"{route_url}/.well-known/agent-card.json"
+        last_exc = None
+        for attempt in range(12):
+            try:
+                resp = requests.get(url, timeout=30, verify=verify)
+                if resp.status_code == 200:
+                    break
+            except requests.RequestException as exc:
+                last_exc = exc
+            time.sleep(5.0)
+        else:
+            pytest.fail(
+                f"Deployment {name} health check failed after 12 retries: "
+                f"{last_exc or resp.status_code}"
+            )

--- a/agents/a2a/templates/langgraph_crewai_agent/uv.lock
+++ b/agents/a2a/templates/langgraph_crewai_agent/uv.lock
@@ -25,6 +25,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "requests" },
+]
 tracing = [
     { name = "mlflow" },
 ]
@@ -39,11 +43,13 @@ requires-dist = [
     { name = "langgraph-prebuilt", specifier = ">=1.0.8" },
     { name = "litellm", specifier = ">=1.83.0" },
     { name = "mlflow", marker = "extra == 'tracing'", specifier = ">=3.11.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "requests", marker = "extra == 'dev'", specifier = ">=2.28" },
     { name = "starlette", specifier = ">=1.0.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]
-provides-extras = ["tracing"]
+provides-extras = ["dev", "tracing"]
 
 [[package]]
 name = "a2a-sdk"
@@ -1473,6 +1479,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -2964,6 +2979,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "portalocker"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3462,6 +3486,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]

--- a/agents/a2a/templates/langgraph_crewai_agent/uv.lock
+++ b/agents/a2a/templates/langgraph_crewai_agent/uv.lock
@@ -27,7 +27,6 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "pytest" },
-    { name = "requests" },
 ]
 tracing = [
     { name = "mlflow" },
@@ -45,7 +44,6 @@ requires-dist = [
     { name = "mlflow", marker = "extra == 'tracing'", specifier = ">=3.11.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
-    { name = "requests", marker = "extra == 'dev'", specifier = ">=2.28" },
     { name = "starlette", specifier = ">=1.0.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]


### PR DESCRIPTION
## Summary

- Adds QG4 integration deployment test for the A2A LangGraph-CrewAI agent (Tier 3)
- External-registry pattern: `make build` → `make push` → `make deploy` (two-phase Helm)
- Multi-deployment health checks via `/.well-known/agent-card.json` for both `a2a-crew-agent` and `a2a-langgraph-agent`
- Adds `test-integration` Makefile target and CI workflow matrix entry

## Key differences from standard agents

| Trait | Standard (Tier 1) | This agent (Tier 3) |
|---|---|---|
| Deploy method | `build-openshift` | `build` + `push` (external registry) |
| Health endpoint | `/health` | `/.well-known/agent-card.json` |
| Deployments | Single | Two (`a2a-crew-agent`, `a2a-langgraph-agent`) |
| Health assertion | `status == "healthy"` | Agent card JSON with `name` field |

## CI prerequisite

Set `CONTAINER_IMAGE_A2A_LANGGRAPH_CREWAI` as a GitHub Actions variable (e.g., `quay.io/your-org/a2a-langgraph-crewai:latest`).

## Test plan

- [x] `pytest --collect-only` passes (2 tests collected)
- [x] CI workflow YAML syntax valid
- [x] Cross-agent consistency check passes
- [x] Live cluster test — health check assertions validated against live A2A deployment (`adonheis-testing` namespace)

Jira: [RHAIENG-4031](https://redhat.atlassian.net/browse/RHAIENG-4031)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHAIENG-4031]: https://redhat.atlassian.net/browse/RHAIENG-4031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ