### PR TITLE
fix: fix /workspace/projects permissions for fresh PVC deployments

### DIFF
--- a/agents/claude-code/README.md
+++ b/agents/claude-code/README.md
@@ -439,7 +439,7 @@ Session history and memory persist across pod restarts via the workspace PVC. Th
 |   |-- skills/                  <- ConfigMap mount
 |   |-- memory/                  <- Persisted (global memory)
 |   +-- projects/                <- Persisted (session history)
-+-- projects/                    <- WORKDIR (where users run Claude)
++-- projects/                    <- Working directory (where users run Claude)
     +-- .claude/                 <- Local auto-memory (separate from global)
 ```
 

--- a/agents/claude-code/deployment/Containerfile
+++ b/agents/claude-code/deployment/Containerfile
@@ -164,11 +164,6 @@ COPY --chmod=755 entrypoint.sh /usr/local/bin/entrypoint.sh
 # Disable Claude Code auto-updater (we control versions via image builds)
 ENV DISABLE_AUTOUPDATER=1
 
-# Default working directory
-# Set to /workspace/projects to separate from global config at /workspace/.claude
-# This prevents overlap between CLAUDE_CONFIG_DIR and local auto-memory
-WORKDIR /workspace/projects
-
 # =============================================================================
 # Runtime Configuration
 # =============================================================================

--- a/agents/claude-code/deployment/entrypoint.sh
+++ b/agents/claude-code/deployment/entrypoint.sh
@@ -159,14 +159,12 @@ setup_config_dir() {
     # Ensure the config directory exists and is group-writable.
     # On OpenShift, fresh PVCs are owned by root with the pod's fsGroup.
     # The non-root container user writes via group membership, so directories
-    # must be group-writable (g+w).
-    mkdir -p "${CLAUDE_CONFIG_DIR}"
-    chmod g+w "${CLAUDE_CONFIG_DIR}" 2>/dev/null || true
+    # must be group-writable (2775 = rwxrwsr-x).
+    install -d -m 2775 "${CLAUDE_CONFIG_DIR}" 2>/dev/null || mkdir -p "${CLAUDE_CONFIG_DIR}"
 
-    # Ensure the projects directory exists (WORKDIR is /workspace/projects)
+    # Ensure the projects directory exists
     # This separates global config (/workspace/.claude) from local auto-memory (/workspace/projects/.claude)
-    mkdir -p /workspace/projects
-    chmod g+w /workspace/projects 2>/dev/null || true
+    install -d -m 2775 /workspace/projects 2>/dev/null || mkdir -p /workspace/projects
 
     # Create symlink from ~/.claude to the config dir for user convenience
     # Users expect to find settings/skills at ~/.claude/
@@ -412,6 +410,11 @@ WRAPPER
         echo 'export PATH="${HOME}/.claude:${PATH}"' >> "${HOME}/.bashrc"
     fi
 
+    # Set working directory for interactive shells
+    if ! grep -q 'cd /workspace/projects' "${HOME}/.bashrc" 2>/dev/null; then
+        echo 'cd /workspace/projects 2>/dev/null || true' >> "${HOME}/.bashrc"
+    fi
+
     log_info "Claude args persisted to ${claude_dir}/env.sh"
     log_info "Wrapper script available: claude-run (or ~/.claude/claude-run)"
 }
@@ -433,6 +436,9 @@ main() {
     setup_mlflow
     setup_skills
     build_claude_args
+
+    # Change to projects directory (separates global config from local auto-memory)
+    cd /workspace/projects || log_warn "Failed to cd to /workspace/projects"
 
     # If no arguments provided, show help
     if [[ $# -eq 0 ]]; then

--- a/agents/claude-code/deployment/entrypoint.sh
+++ b/agents/claude-code/deployment/entrypoint.sh
@@ -160,11 +160,11 @@ setup_config_dir() {
     # On OpenShift, fresh PVCs are owned by root with the pod's fsGroup.
     # The non-root container user writes via group membership, so directories
     # must be group-writable (2775 = rwxrwsr-x).
-    install -d -m 2775 "${CLAUDE_CONFIG_DIR}" 2>/dev/null || mkdir -p "${CLAUDE_CONFIG_DIR}"
+    install -d -m 2775 "${CLAUDE_CONFIG_DIR}" 2>/dev/null || { mkdir -p "${CLAUDE_CONFIG_DIR}" && chmod 2775 "${CLAUDE_CONFIG_DIR}"; }
 
     # Ensure the projects directory exists
     # This separates global config (/workspace/.claude) from local auto-memory (/workspace/projects/.claude)
-    install -d -m 2775 /workspace/projects 2>/dev/null || mkdir -p /workspace/projects
+    install -d -m 2775 /workspace/projects 2>/dev/null || { mkdir -p /workspace/projects && chmod 2775 /workspace/projects; }
 
     # Create symlink from ~/.claude to the config dir for user convenience
     # Users expect to find settings/skills at ~/.claude/

--- a/agents/claude-code/deployment/entrypoint.sh
+++ b/agents/claude-code/deployment/entrypoint.sh
@@ -164,7 +164,7 @@ setup_config_dir() {
 
     # Ensure the projects directory exists
     # This separates global config (/workspace/.claude) from local auto-memory (/workspace/projects/.claude)
-    install -d -m 2775 /workspace/projects 2>/dev/null || { mkdir -p /workspace/projects && chmod 2775 /workspace/projects; }
+    install -d -m 2775 /workspace/projects 2>/dev/null || { mkdir -p /workspace/projects && chmod 2775 /workspace/projects; } || log_warn "Failed to create /workspace/projects with correct permissions"
 
     # Create symlink from ~/.claude to the config dir for user convenience
     # Users expect to find settings/skills at ~/.claude/

--- a/agents/claude-code/deployment/entrypoint.sh
+++ b/agents/claude-code/deployment/entrypoint.sh
@@ -160,7 +160,7 @@ setup_config_dir() {
     # On OpenShift, fresh PVCs are owned by root with the pod's fsGroup.
     # The non-root container user writes via group membership, so directories
     # must be group-writable (2775 = rwxrwsr-x).
-    install -d -m 2775 "${CLAUDE_CONFIG_DIR}" 2>/dev/null || { mkdir -p "${CLAUDE_CONFIG_DIR}" && chmod 2775 "${CLAUDE_CONFIG_DIR}"; }
+    install -d -m 2775 "${CLAUDE_CONFIG_DIR}" 2>/dev/null || { mkdir -p "${CLAUDE_CONFIG_DIR}" && chmod 2775 "${CLAUDE_CONFIG_DIR}"; } || log_warn "Failed to create ${CLAUDE_CONFIG_DIR} with correct permissions"
 
     # Ensure the projects directory exists
     # This separates global config (/workspace/.claude) from local auto-memory (/workspace/projects/.claude)


### PR DESCRIPTION
## Description

- Remove WORKDIR directive from Containerfile (causes root-owned directory creation)
- Use install -d -m 2775 in entrypoint for atomic permission setting
- Add cd /workspace/projects in entrypoint for main process
- Add cd to .bashrc for interactive shells
- Update README to remove WORKDIR reference"

## Testing

- [ ] Create a fresh deployment and run claude tests as before (see README for examples)
- [ ] oc exec into pod and verify that /workspace/projects directory is writable