### PR TITLE
feat(opencode): consolidate kustomize manifests from opencode-openshift

### DIFF
--- a/agents/opencode/deployment/DEPLOYMENT.md
+++ b/agents/opencode/deployment/DEPLOYMENT.md
@@ -35,7 +35,7 @@ This guide covers deploying [OpenCode](https://opencode.ai) as a coding agent on
 
 ## Project Structure
 
-```
+```text
 deployment/
 ├── manifests/                    # Base kustomize manifests (web mode + OAuth)
 │   ├── kustomization.yaml        # Kustomize entrypoint
@@ -128,6 +128,7 @@ The web mode deployment runs a two-container pod:
 2. **opencode-web** — OpenCode application serving the web UI on port 8003
 
 The entrypoint script (`manifests/entrypoint.sh`) handles:
+
 - Git workspace initialization
 - Config template variable substitution (BASE_URL, API_KEY, MODEL_NAME)
 - Optional MCP server config injection from a ConfigMap

--- a/agents/opencode/deployment/DEPLOYMENT.md
+++ b/agents/opencode/deployment/DEPLOYMENT.md
@@ -6,8 +6,8 @@ This guide covers deploying [OpenCode](https://opencode.ai) as a coding agent on
 
 | Field | Value |
 |-------|-------|
-| Image | `quay.io/opendatahub/odh-opencode-rhel9:1.4.4` |
-| OpenCode version | 1.4.4 (built from [opendatahub-io/opencode](https://github.com/opendatahub-io/opencode)) |
+| Image | `quay.io/opendatahub/odh-opencode-rhel9:latest` |
+| OpenCode version | Built from [opendatahub-io/opencode](https://github.com/opendatahub-io/opencode) |
 | Base | UBI 9 minimal |
 | License | MIT (OpenCode), Apache 2.0 (deployment manifests) |
 
@@ -16,16 +16,16 @@ This guide covers deploying [OpenCode](https://opencode.ai) as a coding agent on
 | Layer | Purpose |
 |-------|---------|
 | UBI 9 minimal | RHEL-compatible base |
-| OpenCode v1.4.4 | Go binary built from source |
+| OpenCode | Go binary built from source |
 | git, jq, make, vim-minimal, diffutils, findutils, openssh-clients, patch, procps-ng, tar, gzip, which | CLI tools for development workflows |
 | Python 3 + [uv](https://github.com/astral-sh/uv) | Python environment and package manager |
 
 ### Version pinning strategy
 
-- **OpenCode**: pinned to a tagged release (currently `v1.4.4`) in the Containerfile `ARG`. Upgrades require a new image build and manifest update.
+- **OpenCode**: pinned to a tagged release in the Containerfile `ARG`. Upgrades require a new image build and manifest update.
 - **Go runtime**: build-time only; not present in the final image (multi-stage build).
 - **Base image**: `registry.access.redhat.com/ubi9/ubi-minimal`, pulled at build time. Pin to a specific tag for reproducible builds.
-- **Image tag in manifests**: pinned to a specific tag or digest. Avoid `:latest` in production.
+- **Image tag in manifests**: pin to a specific tag or digest in production. Avoid `:latest`.
 
 ## Prerequisites
 
@@ -33,15 +33,38 @@ This guide covers deploying [OpenCode](https://opencode.ai) as a coding agent on
 - A model serving endpoint — vLLM, KServe, RHOAI model serving, or OGX — exposing an OpenAI-compatible API on a cluster-internal Service
 - Block storage class (gp3-csi, managed-csi, thin-csi) for the workspace PVC
 
-## Deployment
+## Project Structure
 
-Full kustomize manifests, overlays, and configuration are maintained in the [opencode-openshift](https://github.com/aicatalyst-team/opencode-openshift) repository.
+```
+deployment/
+├── manifests/                    # Base kustomize manifests (web mode + OAuth)
+│   ├── kustomization.yaml        # Kustomize entrypoint
+│   ├── namespace.yaml
+│   ├── serviceaccount.yaml
+│   ├── deployment.yaml           # Two-container pod (oauth-proxy + opencode)
+│   ├── service.yaml
+│   ├── route.yaml
+│   ├── pvc.yaml
+│   ├── entrypoint.sh             # Container entrypoint (config, MCP, mode switching)
+│   └── config-template.json      # OpenCode provider config (vLLM + OGX)
+├── overlays/
+│   ├── cli/                      # CLI mode (no OAuth, no Route, oc exec)
+│   ├── example/                  # Template for custom environments
+│   └── mlflow-tracing/           # MLflow tracing integration
+├── Containerfile.openshell       # OpenShell sandbox variant
+├── Containerfile.mlflow          # MLflow tracing image variant
+├── README.md                     # OpenShell sandbox guide
+├── DEPLOYMENT.md                 # This file
+└── docs/                         # MLflow tracing documentation
+```
+
+## Deployment
 
 ### Quick start (web mode with OAuth)
 
 ```bash
-git clone https://github.com/aicatalyst-team/opencode-openshift.git
-cd opencode-openshift
+# From the repo root
+cd agents/opencode/deployment
 
 # Edit manifests/kustomization.yaml with your vLLM endpoint, API key, and model name
 oc apply -k manifests/
@@ -71,6 +94,14 @@ cp -r overlays/example overlays/my-env
 oc apply -k overlays/my-env
 ```
 
+### MLflow tracing
+
+```bash
+oc apply -k overlays/mlflow-tracing
+```
+
+See [docs/mlflow-tracing-setup.md](docs/mlflow-tracing-setup.md) for full configuration details.
+
 ## Configuration
 
 | Setting | Where to change | Notes |
@@ -80,8 +111,7 @@ oc apply -k overlays/my-env
 | Model name | `manifests/kustomization.yaml` (`MODEL_NAME`) | Must match the model loaded in vLLM |
 | Storage class | `manifests/kustomization.yaml` (patch section) | Default PVC is 10Gi |
 | MCP servers | ConfigMap `opencode-web-mcp` | Optional; merged into config at startup |
-| Skills | ConfigMap (volume mount) | Optional; injectable skills via ConfigMap |
-| Provider (vLLM vs OGX) | `manifests/config-template.json` (`enabled_providers`) | Default: `["vllm"]` |
+| Provider (vLLM vs OGX) | `manifests/config-template.json` (`enabled_providers`) | Both enabled by default |
 
 ## Security
 
@@ -90,17 +120,29 @@ oc apply -k overlays/my-env
 - **RBAC**: OAuth proxy enforces Subject Access Review — users must have `get` on `services` in the deployment namespace.
 - **Secrets**: Inline secrets in `kustomization.yaml` are for convenience only. For production, use Sealed Secrets, External Secrets Operator, or Secrets Store CSI Driver.
 
+## Architecture
+
+The web mode deployment runs a two-container pod:
+
+1. **oauth-proxy** — OpenShift OAuth proxy sidecar handling authentication via TLS on port 8443
+2. **opencode-web** — OpenCode application serving the web UI on port 8003
+
+The entrypoint script (`manifests/entrypoint.sh`) handles:
+- Git workspace initialization
+- Config template variable substitution (BASE_URL, API_KEY, MODEL_NAME)
+- Optional MCP server config injection from a ConfigMap
+- Mode switching between web and CLI
+
 ## Comparison: OpenShell sandbox vs kustomize deployment
 
 | | OpenShell sandbox | Kustomize deployment |
 |--|-------------------|---------------------|
 | **Image** | `openshell-base` + npm flavor | `odh-opencode-rhel9` (Go binary) |
-| **OpenCode version** | 1.17.1 (npm) | 1.4.4 (built from source) |
 | **Runtime** | Inside OpenShell gateway | Standalone pod on OpenShift |
 | **Auth** | OpenShell gateway | OpenShift OAuth proxy |
 | **Use case** | Sandboxed experimentation | Production RHOAI deployment |
-| **Manifests** | N/A (OpenShell manages lifecycle) | [opencode-openshift](https://github.com/aicatalyst-team/opencode-openshift) |
+| **Manifests** | N/A (OpenShell manages lifecycle) | `manifests/` in this directory |
 
 ## Related resources
 
-- [opencode-openshift](https://github.com/aicatalyst-team/opencode-openshift) — kustomize manifests, overlays, and full README
+- [opendatahub-io/opencode](https://github.com/opendatahub-io/opencode) — container image source and CI

--- a/agents/opencode/deployment/DEPLOYMENT.md
+++ b/agents/opencode/deployment/DEPLOYMENT.md
@@ -6,7 +6,7 @@ This guide covers deploying [OpenCode](https://opencode.ai) as a coding agent on
 
 | Field | Value |
 |-------|-------|
-| Image | `quay.io/opendatahub/odh-opencode-rhel9:latest` |
+| Image | `quay.io/opendatahub/odh-opencode-rhel9:20260619-194847e` |
 | OpenCode version | Built from [opendatahub-io/opencode](https://github.com/opendatahub-io/opencode) |
 | Base | UBI 9 minimal |
 | License | MIT (OpenCode), Apache 2.0 (deployment manifests) |

--- a/agents/opencode/deployment/manifests/config-template.json
+++ b/agents/opencode/deployment/manifests/config-template.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "vllm": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "vLLM",
+      "options": {
+        "baseURL": "${BASE_URL}",
+        "apiKey": "${API_KEY}"
+      },
+      "models": {
+        "${MODEL_NAME}": {
+          "name": "${MODEL_NAME}"
+        }
+      }
+    },
+    "ogx": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "OGX",
+      "options": {
+        "baseURL": "${BASE_URL}",
+        "apiKey": "${API_KEY}"
+      },
+      "models": {
+        "${MODEL_NAME}": {
+          "name": "${MODEL_NAME}"
+        }
+      }
+    }
+  },
+  "model": "${MODEL_NAME}",
+  "small_model": "${MODEL_NAME}",
+  "enabled_providers": ["vllm", "ogx"]
+}

--- a/agents/opencode/deployment/manifests/deployment.yaml
+++ b/agents/opencode/deployment/manifests/deployment.yaml
@@ -7,11 +7,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: opencode
+      app.kubernetes.io/name: opencode
   template:
     metadata:
       labels:
-        app: opencode
+        app.kubernetes.io/name: opencode
     spec:
       serviceAccountName: opencode-web
       containers:

--- a/agents/opencode/deployment/manifests/deployment.yaml
+++ b/agents/opencode/deployment/manifests/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: opencode-web
       containers:
         - name: oauth-proxy
-          image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:latest
+          image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:v4.17
           args:
             - --https-address=:8443
             - --provider=openshift
@@ -25,7 +25,7 @@ spec:
             - --tls-cert=/etc/tls/private/tls.crt
             - --tls-key=/etc/tls/private/tls.key
             - --cookie-secret-file=/etc/proxy/secrets/session_secret
-            - --openshift-sar={"namespace":"opencode","resource":"services","verb":"get"}
+            - --openshift-sar={"resource":"services","verb":"get"}
           ports:
             - containerPort: 8443
               name: oauth-proxy
@@ -49,7 +49,7 @@ spec:
             capabilities:
               drop: [ALL]
         - name: opencode-web
-          image: quay.io/opendatahub/odh-opencode-rhel9:latest
+          image: quay.io/opendatahub/odh-opencode-rhel9:20260619-194847e
           workingDir: /opt/app-root/
           command: ["/bin/bash", "/entrypoint/entrypoint.sh"]
           ports:

--- a/agents/opencode/deployment/manifests/deployment.yaml
+++ b/agents/opencode/deployment/manifests/deployment.yaml
@@ -1,0 +1,128 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opencode-web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: opencode
+  template:
+    metadata:
+      labels:
+        app: opencode
+    spec:
+      serviceAccountName: opencode-web
+      containers:
+        - name: oauth-proxy
+          image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:latest
+          args:
+            - --https-address=:8443
+            - --provider=openshift
+            - --openshift-service-account=opencode-web
+            - --upstream=http://localhost:8003
+            - --tls-cert=/etc/tls/private/tls.crt
+            - --tls-key=/etc/tls/private/tls.key
+            - --cookie-secret-file=/etc/proxy/secrets/session_secret
+            - --openshift-sar={"namespace":"opencode","resource":"services","verb":"get"}
+          ports:
+            - containerPort: 8443
+              name: oauth-proxy
+          volumeMounts:
+            - name: proxy-tls
+              mountPath: /etc/tls/private
+            - name: proxy-cookie-secret
+              mountPath: /etc/proxy/secrets
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: [ALL]
+        - name: opencode-web
+          image: quay.io/opendatahub/odh-opencode-rhel9:latest
+          workingDir: /opt/app-root/
+          command: ["/bin/bash", "/entrypoint/entrypoint.sh"]
+          ports:
+            - containerPort: 8003
+          env:
+            - name: BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: opencode-web-secret
+                  key: BASE_URL
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: opencode-web-secret
+                  key: API_KEY
+            - name: MODEL_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: opencode-web-secret
+                  key: MODEL_NAME
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: [ALL]
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8003
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8003
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - name: opencode-web-pvc
+              mountPath: /opt/app-root/workspace
+            - name: config-template
+              mountPath: /config-template
+            - name: entrypoint
+              mountPath: /entrypoint
+            - name: mcp-config
+              mountPath: /mcp-config
+      volumes:
+        - name: opencode-web-pvc
+          persistentVolumeClaim:
+            claimName: opencode-web-pvc
+        - name: config-template
+          configMap:
+            name: opencode-web-config
+        - name: entrypoint
+          configMap:
+            name: opencode-web-entrypoint
+            defaultMode: 0755
+        - name: mcp-config
+          configMap:
+            name: opencode-web-mcp
+            optional: true
+        - name: proxy-tls
+          secret:
+            secretName: opencode-web-tls
+        - name: proxy-cookie-secret
+          secret:
+            secretName: opencode-web-proxy-cookie

--- a/agents/opencode/deployment/manifests/entrypoint.sh
+++ b/agents/opencode/deployment/manifests/entrypoint.sh
@@ -14,11 +14,8 @@ if [ ! -d .git ]; then
   git commit --allow-empty -m "init"
 fi
 
-# Build OpenCode config from template
-CONFIG=$(cat /config-template/config-template.json)
-CONFIG=${CONFIG//\$\{BASE_URL\}/$BASE_URL}
-CONFIG=${CONFIG//\$\{API_KEY\}/$API_KEY}
-CONFIG=${CONFIG//\$\{MODEL_NAME\}/$MODEL_NAME}
+# Build OpenCode config from template (envsubst handles special chars safely)
+CONFIG=$(envsubst '${BASE_URL} ${API_KEY} ${MODEL_NAME}' < /config-template/config-template.json)
 
 # Merge MCP config if mounted
 if [ -f /mcp-config/mcp-servers.json ]; then
@@ -27,6 +24,7 @@ if [ -f /mcp-config/mcp-servers.json ]; then
 fi
 
 export OPENCODE_CONFIG_CONTENT="$CONFIG"
+unset API_KEY BASE_URL MODEL_NAME
 
 MODE="${OPENCODE_MODE:-web}"
 

--- a/agents/opencode/deployment/manifests/entrypoint.sh
+++ b/agents/opencode/deployment/manifests/entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+# Git configuration
+git config --global init.defaultBranch main
+git config --global user.email "opencode@openshift.local"
+git config --global user.name "OpenCode"
+git config --global --add safe.directory /opt/app-root/workspace
+
+# Initialize workspace if needed
+cd /opt/app-root/workspace
+if [ ! -d .git ]; then
+  git init
+  git commit --allow-empty -m "init"
+fi
+
+# Build OpenCode config from template
+CONFIG=$(cat /config-template/config-template.json)
+CONFIG=${CONFIG//\$\{BASE_URL\}/$BASE_URL}
+CONFIG=${CONFIG//\$\{API_KEY\}/$API_KEY}
+CONFIG=${CONFIG//\$\{MODEL_NAME\}/$MODEL_NAME}
+
+# Merge MCP config if mounted
+if [ -f /mcp-config/mcp-servers.json ]; then
+  MCP_SERVERS=$(cat /mcp-config/mcp-servers.json)
+  CONFIG=$(echo "$CONFIG" | jq --argjson mcp "$MCP_SERVERS" '. + {mcp: $mcp}')
+fi
+
+export OPENCODE_CONFIG_CONTENT="$CONFIG"
+
+MODE="${OPENCODE_MODE:-web}"
+
+case "$MODE" in
+  web)
+    exec opencode web --hostname 0.0.0.0 --port 8003
+    ;;
+  cli)
+    echo "[entrypoint] CLI mode — attach with: oc exec -it deployment/opencode-web -c opencode-web -- opencode"
+    exec sleep infinity
+    ;;
+  *)
+    echo "[entrypoint] Unknown mode: $MODE (expected 'web' or 'cli')"
+    exit 1
+    ;;
+esac

--- a/agents/opencode/deployment/manifests/kustomization.yaml
+++ b/agents/opencode/deployment/manifests/kustomization.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: opencode
+
+commonLabels:
+  app: opencode
+
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - route.yaml
+
+configMapGenerator:
+  - name: opencode-web-config
+    files:
+      - config-template.json
+    options:
+      disableNameSuffixHash: true
+  - name: opencode-web-entrypoint
+    files:
+      - entrypoint.sh
+    options:
+      disableNameSuffixHash: true
+
+patches:
+  - target:
+      kind: PersistentVolumeClaim
+      name: opencode-web-pvc
+    patch: |-
+      - op: add
+        path: /spec/storageClassName
+        value: <your-storage-class>
+
+secretGenerator:
+  - name: opencode-web-secret
+    literals:
+      - BASE_URL=http://<vllm-service>.<namespace>.svc.cluster.local/v1
+      - API_KEY=<your-api-key>
+      - MODEL_NAME=<your-model-name>
+    options:
+      disableNameSuffixHash: true
+  - name: opencode-web-proxy-cookie
+    type: Opaque
+    literals:
+      - session_secret=<your-generated-secret>
+    options:
+      disableNameSuffixHash: true

--- a/agents/opencode/deployment/manifests/kustomization.yaml
+++ b/agents/opencode/deployment/manifests/kustomization.yaml
@@ -5,7 +5,8 @@ kind: Kustomization
 namespace: opencode
 
 commonLabels:
-  app: opencode
+  app.kubernetes.io/name: opencode
+  app.kubernetes.io/part-of: opencode-on-openshift
 
 resources:
   - namespace.yaml
@@ -34,7 +35,7 @@ patches:
     patch: |-
       - op: add
         path: /spec/storageClassName
-        value: <your-storage-class>
+        value: gp3-csi  # Change to your cluster's storage class
 
 secretGenerator:
   - name: opencode-web-secret

--- a/agents/opencode/deployment/manifests/namespace.yaml
+++ b/agents/opencode/deployment/manifests/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opencode

--- a/agents/opencode/deployment/manifests/pvc.yaml
+++ b/agents/opencode/deployment/manifests/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: opencode-web-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/agents/opencode/deployment/manifests/route.yaml
+++ b/agents/opencode/deployment/manifests/route.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: opencode-web
+spec:
+  to:
+    kind: Service
+    name: opencode-web
+    weight: 100
+  port:
+    targetPort: oauth-proxy
+  tls:
+    termination: reencrypt

--- a/agents/opencode/deployment/manifests/service.yaml
+++ b/agents/opencode/deployment/manifests/service.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opencode-web
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: opencode-web-tls
+spec:
+  ports:
+    - name: oauth-proxy
+      port: 8443
+      targetPort: 8443
+      protocol: TCP
+    - name: app
+      port: 8003
+      targetPort: 8003
+      protocol: TCP
+  selector:
+    app: opencode
+  type: ClusterIP

--- a/agents/opencode/deployment/manifests/service.yaml
+++ b/agents/opencode/deployment/manifests/service.yaml
@@ -11,10 +11,6 @@ spec:
       port: 8443
       targetPort: 8443
       protocol: TCP
-    - name: app
-      port: 8003
-      targetPort: 8003
-      protocol: TCP
   selector:
-    app: opencode
+    app.kubernetes.io/name: opencode
   type: ClusterIP

--- a/agents/opencode/deployment/manifests/serviceaccount.yaml
+++ b/agents/opencode/deployment/manifests/serviceaccount.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: opencode-web
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirectreference.opencode-web: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"opencode-web"}}'

--- a/agents/opencode/deployment/overlays/cli/deployment-patch.yaml
+++ b/agents/opencode/deployment/overlays/cli/deployment-patch.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opencode-web
+spec:
+  template:
+    spec:
+      $patch: replace
+      serviceAccountName: opencode-web
+      containers:
+        - name: opencode-web
+          image: quay.io/opendatahub/odh-opencode-rhel9:latest
+          workingDir: /opt/app-root/
+          command: ["/bin/bash", "/entrypoint/entrypoint.sh"]
+          env:
+            - name: BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: opencode-web-secret
+                  key: BASE_URL
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: opencode-web-secret
+                  key: API_KEY
+            - name: MODEL_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: opencode-web-secret
+                  key: MODEL_NAME
+            - name: OPENCODE_MODE
+              value: "cli"
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: opencode-web-pvc
+              mountPath: /opt/app-root/workspace
+            - name: config-template
+              mountPath: /config-template
+            - name: entrypoint
+              mountPath: /entrypoint
+            - name: mcp-config
+              mountPath: /mcp-config
+      volumes:
+        - name: opencode-web-pvc
+          persistentVolumeClaim:
+            claimName: opencode-web-pvc
+        - name: config-template
+          configMap:
+            name: opencode-web-config
+        - name: entrypoint
+          configMap:
+            name: opencode-web-entrypoint
+            defaultMode: 0755
+        - name: mcp-config
+          configMap:
+            name: opencode-web-mcp
+            optional: true

--- a/agents/opencode/deployment/overlays/cli/deployment-patch.yaml
+++ b/agents/opencode/deployment/overlays/cli/deployment-patch.yaml
@@ -5,66 +5,17 @@ metadata:
 spec:
   template:
     spec:
-      $patch: replace
-      serviceAccountName: opencode-web
       containers:
+        - name: oauth-proxy
+          $patch: delete
         - name: opencode-web
-          image: quay.io/opendatahub/odh-opencode-rhel9:20260619-194847e
-          workingDir: /opt/app-root/
-          command: ["/bin/bash", "/entrypoint/entrypoint.sh"]
           env:
-            - name: BASE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: opencode-web-secret
-                  key: BASE_URL
-            - name: API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: opencode-web-secret
-                  key: API_KEY
-            - name: MODEL_NAME
-              valueFrom:
-                secretKeyRef:
-                  name: opencode-web-secret
-                  key: MODEL_NAME
             - name: OPENCODE_MODE
               value: "cli"
-          resources:
-            requests:
-              cpu: 500m
-              memory: 512Mi
-            limits:
-              cpu: "2"
-              memory: 2Gi
-          securityContext:
-            runAsNonRoot: true
-            allowPrivilegeEscalation: false
-            seccompProfile:
-              type: RuntimeDefault
-            capabilities:
-              drop: [ALL]
-          volumeMounts:
-            - name: opencode-web-pvc
-              mountPath: /opt/app-root/workspace
-            - name: config-template
-              mountPath: /config-template
-            - name: entrypoint
-              mountPath: /entrypoint
-            - name: mcp-config
-              mountPath: /mcp-config
+          livenessProbe: null
+          readinessProbe: null
       volumes:
-        - name: opencode-web-pvc
-          persistentVolumeClaim:
-            claimName: opencode-web-pvc
-        - name: config-template
-          configMap:
-            name: opencode-web-config
-        - name: entrypoint
-          configMap:
-            name: opencode-web-entrypoint
-            defaultMode: 0755
-        - name: mcp-config
-          configMap:
-            name: opencode-web-mcp
-            optional: true
+        - name: proxy-tls
+          $patch: delete
+        - name: proxy-cookie-secret
+          $patch: delete

--- a/agents/opencode/deployment/overlays/cli/deployment-patch.yaml
+++ b/agents/opencode/deployment/overlays/cli/deployment-patch.yaml
@@ -9,7 +9,7 @@ spec:
       serviceAccountName: opencode-web
       containers:
         - name: opencode-web
-          image: quay.io/opendatahub/odh-opencode-rhel9:latest
+          image: quay.io/opendatahub/odh-opencode-rhel9:20260619-194847e
           workingDir: /opt/app-root/
           command: ["/bin/bash", "/entrypoint/entrypoint.sh"]
           env:

--- a/agents/opencode/deployment/overlays/cli/kustomization.yaml
+++ b/agents/opencode/deployment/overlays/cli/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../manifests
+
+namespace: opencode
+
+patches:
+  - path: deployment-patch.yaml
+  - path: remove-route.yaml

--- a/agents/opencode/deployment/overlays/cli/kustomization.yaml
+++ b/agents/opencode/deployment/overlays/cli/kustomization.yaml
@@ -9,3 +9,4 @@ namespace: opencode
 patches:
   - path: deployment-patch.yaml
   - path: remove-route.yaml
+  - path: remove-service.yaml

--- a/agents/opencode/deployment/overlays/cli/remove-route.yaml
+++ b/agents/opencode/deployment/overlays/cli/remove-route.yaml
@@ -1,0 +1,5 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: opencode-web
+$patch: delete

--- a/agents/opencode/deployment/overlays/cli/remove-service.yaml
+++ b/agents/opencode/deployment/overlays/cli/remove-service.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: opencode-web
+$patch: delete

--- a/agents/opencode/deployment/overlays/example/kustomization.yaml
+++ b/agents/opencode/deployment/overlays/example/kustomization.yaml
@@ -1,0 +1,36 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Choose your base:
+#   ../../manifests        — web mode (default, OAuth proxy + browser UI)
+#   ../cli                 — CLI mode (oc exec, no OAuth proxy)
+resources:
+  - ../../manifests
+
+namespace: my-opencode
+
+patches:
+  - target:
+      kind: PersistentVolumeClaim
+      name: opencode-web-pvc
+    patch: |-
+      - op: replace
+        path: /spec/storageClassName
+        value: gp3-csi  # Change to your cluster's storage class
+
+secretGenerator:
+  - name: opencode-web-secret
+    behavior: replace
+    literals:
+      - BASE_URL=http://vllm-svc.vllm.svc.cluster.local/v1
+      - API_KEY=not-needed
+      - MODEL_NAME=gpt-oss-120b
+    options:
+      disableNameSuffixHash: true
+  - name: opencode-web-proxy-cookie
+    behavior: replace
+    type: Opaque
+    literals:
+      - session_secret=CHANGE-ME
+    options:
+      disableNameSuffixHash: true

--- a/agents/opencode/deployment/overlays/example/kustomization.yaml
+++ b/agents/opencode/deployment/overlays/example/kustomization.yaml
@@ -31,6 +31,6 @@ secretGenerator:
     behavior: replace
     type: Opaque
     literals:
-      - session_secret=CHANGE-ME  # generate with: openssl rand -base64 32
+      - session_secret=<generate-with-openssl-rand-base64-32>
     options:
       disableNameSuffixHash: true

--- a/agents/opencode/deployment/overlays/example/kustomization.yaml
+++ b/agents/opencode/deployment/overlays/example/kustomization.yaml
@@ -31,6 +31,6 @@ secretGenerator:
     behavior: replace
     type: Opaque
     literals:
-      - session_secret=CHANGE-ME
+      - session_secret=CHANGE-ME  # generate with: openssl rand -base64 32
     options:
       disableNameSuffixHash: true

--- a/agents/opencode/deployment/overlays/mlflow-tracing/kustomization.yaml
+++ b/agents/opencode/deployment/overlays/mlflow-tracing/kustomization.yaml
@@ -1,11 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# Base OpenCode manifests + MLflow tracing
-# Clone https://github.com/aicatalyst-team/opencode-openshift and adjust
-# the path below to point to its manifests/ directory.
 resources:
-  - ../../manifests  # adjust to your local opencode-openshift/manifests path
+  - ../../manifests
 
 namespace: YOUR-NAMESPACE
 


### PR DESCRIPTION
## Summary

- Moves the full kustomize deployment manifests from `aicatalyst-team/opencode-openshift` into `agents/opencode/deployment/` so all coding agent deployment content lives in one repo
- Adds base `manifests/` (namespace, ServiceAccount, Deployment, Service, Route, PVC, entrypoint.sh, config-template with vLLM + OGX providers)
- Adds `overlays/cli` (headless mode — no OAuth proxy, no Route, `oc exec` access)
- Adds `overlays/example` (user-customizable template with storage class, model endpoint, cookie secret)
- Updates `DEPLOYMENT.md` to be self-contained — no longer references the external repo
- Updates `overlays/mlflow-tracing` to point to local `manifests/` instead of requiring a separate clone

## Test plan

- [x] `oc kustomize` validates all four targets (manifests, cli, example, mlflow-tracing)
- [x] Deployed to `aduggal-opencode-dev` on ROSA cluster — pod 2/2 Running, OAuth proxy authenticated, OpenCode web UI serving against `vllm-120b` in `gpt-oss` namespace
- [ ] Review deployment structure matches openclaw pattern (`manifests/` + `overlays/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)