### PR TITLE
feat(ci): add Slack alerts for shared-branch workflow failures

### DIFF
--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -1,0 +1,105 @@
+name: "Notify Slack"
+description: "Render and send Slack CI notifications via incoming webhook"
+
+inputs:
+  github_token:
+    description: "GitHub token used to query the workflow run jobs API"
+    required: true
+  workflow_name:
+    description: "Display name of the GitHub Actions workflow"
+    required: true
+  event_name:
+    description: "GitHub event name for the current run"
+    required: true
+  ref_name:
+    description: "Branch or ref name associated with the run"
+    required: true
+  run_id:
+    description: "GitHub Actions run id"
+    required: true
+  repository:
+    description: "owner/repo for the workflow run"
+    required: true
+  run_url:
+    description: "Deep link to the workflow run"
+    required: true
+  dashboard_url:
+    description: "Link to the CI health dashboard"
+    required: true
+  status:
+    description: "Notification status label, for example failure or cancelled"
+    required: true
+  preview:
+    description: "If true, print the payload instead of sending it"
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Collect failed jobs
+      id: collect-failed-jobs
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        REPOSITORY: ${{ inputs.repository }}
+        RUN_ID: ${{ inputs.run_id }}
+      run: |
+        set -euo pipefail
+
+        failed_jobs_json='[]'
+        if [[ -n "${GITHUB_TOKEN}" ]]; then
+          api_url="https://api.github.com/repos/${REPOSITORY}/actions/runs/${RUN_ID}/jobs?per_page=100"
+          if response="$(curl -fsSL \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "${api_url}")"; then
+            failed_jobs_json="$(
+              bash "${GITHUB_ACTION_PATH}/extract_failed_jobs.sh" <<<"${response}"
+            )"
+          else
+            echo "::warning::Unable to query failed jobs for run ${RUN_ID}; sending Slack notification without job detail"
+          fi
+        else
+          echo "::warning::GITHUB_TOKEN not provided; sending Slack notification without job detail"
+        fi
+
+        echo "failed_jobs_json=${failed_jobs_json}" >> "${GITHUB_OUTPUT}"
+
+    - name: Render Slack payload
+      id: render-payload
+      shell: bash
+      env:
+        WORKFLOW_NAME: ${{ inputs.workflow_name }}
+        EVENT_NAME: ${{ inputs.event_name }}
+        REF_NAME: ${{ inputs.ref_name }}
+        STATUS: ${{ inputs.status }}
+        RUN_URL: ${{ inputs.run_url }}
+        DASHBOARD_URL: ${{ inputs.dashboard_url }}
+        REPOSITORY: ${{ inputs.repository }}
+        FAILED_JOBS_JSON: ${{ steps.collect-failed-jobs.outputs.failed_jobs_json }}
+      run: |
+        set -euo pipefail
+
+        payload_path="${RUNNER_TEMP}/slack-payload-${{ inputs.run_id }}.json"
+        TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+          bash "${GITHUB_ACTION_PATH}/render_payload.sh" > "${payload_path}"
+        echo "payload_path=${payload_path}" >> "${GITHUB_OUTPUT}"
+
+    - name: Send Slack notification
+      shell: bash
+      env:
+        PREVIEW: ${{ inputs.preview }}
+        PAYLOAD_PATH: ${{ steps.render-payload.outputs.payload_path }}
+      run: |
+        set -euo pipefail
+
+        args=()
+        if [[ "${PREVIEW}" == "true" ]]; then
+          args+=(--preview)
+        fi
+
+        if ! bash "${GITHUB_ACTION_PATH}/notify.sh" "${args[@]}" "${PAYLOAD_PATH}"; then
+          echo "::warning::Slack notification delivery failed"
+        fi

--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -55,9 +55,12 @@ runs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "${api_url}")"; then
-            failed_jobs_json="$(
+            if ! failed_jobs_json="$(
               bash "${GITHUB_ACTION_PATH}/extract_failed_jobs.sh" <<<"${response}"
-            )"
+            )"; then
+              echo "::warning::Failed to extract failed jobs; sending Slack notification without job detail"
+              failed_jobs_json='[]'
+            fi
           else
             echo "::warning::Unable to query failed jobs for run ${RUN_ID}; sending Slack notification without job detail"
           fi
@@ -71,6 +74,7 @@ runs:
       id: render-payload
       shell: bash
       env:
+        RUN_ID: ${{ inputs.run_id }}
         WORKFLOW_NAME: ${{ inputs.workflow_name }}
         EVENT_NAME: ${{ inputs.event_name }}
         REF_NAME: ${{ inputs.ref_name }}
@@ -82,10 +86,14 @@ runs:
       run: |
         set -euo pipefail
 
-        payload_path="${RUNNER_TEMP}/slack-payload-${{ inputs.run_id }}.json"
-        TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-          bash "${GITHUB_ACTION_PATH}/render_payload.sh" > "${payload_path}"
-        echo "payload_path=${payload_path}" >> "${GITHUB_OUTPUT}"
+        payload_path="${RUNNER_TEMP}/slack-payload-${RUN_ID}.json"
+        if ! TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+          bash "${GITHUB_ACTION_PATH}/render_payload.sh" > "${payload_path}"; then
+          echo "::warning::Failed to render Slack payload; skipping notification"
+          echo "payload_path=" >> "${GITHUB_OUTPUT}"
+        else
+          echo "payload_path=${payload_path}" >> "${GITHUB_OUTPUT}"
+        fi
 
     - name: Send Slack notification
       shell: bash
@@ -94,6 +102,11 @@ runs:
         PAYLOAD_PATH: ${{ steps.render-payload.outputs.payload_path }}
       run: |
         set -euo pipefail
+
+        if [[ -z "${PAYLOAD_PATH}" ]]; then
+          echo "No payload to send; skipping notification"
+          exit 0
+        fi
 
         args=()
         if [[ "${PREVIEW}" == "true" ]]; then

--- a/.github/actions/notify-slack/extract_failed_jobs.sh
+++ b/.github/actions/notify-slack/extract_failed_jobs.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Extract failed or cancelled job names from a GitHub Actions jobs API payload.
+
+set -euo pipefail
+
+command -v jq >/dev/null 2>&1 || {
+  echo "jq is required to parse failed job payloads" >&2
+  exit 1
+}
+
+INPUT_PATH="${1:-}"
+
+if [[ -n "${INPUT_PATH}" ]]; then
+  jq -c '[.jobs[]? | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out") | .name]' "${INPUT_PATH}"
+else
+  jq -c '[.jobs[]? | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out") | .name]'
+fi

--- a/.github/actions/notify-slack/notify.sh
+++ b/.github/actions/notify-slack/notify.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Send a Slack payload via incoming webhook.
+# Usage: ./notify.sh [--preview] PAYLOAD_PATH
+
+set -euo pipefail
+
+command -v jq >/dev/null 2>&1 || {
+  echo "jq is required to send Slack payloads" >&2
+  exit 1
+}
+
+PREVIEW=false
+if [[ "${1:-}" == "--preview" ]]; then
+  PREVIEW=true
+  shift
+fi
+
+PAYLOAD_PATH="${1:?Usage: $0 [--preview] PAYLOAD_PATH}"
+
+if [[ ! -f "${PAYLOAD_PATH}" ]]; then
+  echo "Payload file not found: ${PAYLOAD_PATH}" >&2
+  exit 1
+fi
+
+jq empty "${PAYLOAD_PATH}" >/dev/null
+
+if [[ "${PREVIEW}" == true ]]; then
+  echo "::group::Slack payload preview (not sent)"
+  jq . "${PAYLOAD_PATH}"
+  echo "::endgroup::"
+  exit 0
+fi
+
+WEBHOOK_URL="${SLACK_WEBHOOK_URL:-}"
+
+if [[ -z "${WEBHOOK_URL}" ]]; then
+  echo "Slack webhook not configured, skipping notification"
+  exit 0
+fi
+
+PAYLOAD="$(jq -c . "${PAYLOAD_PATH}")"
+
+if [[ "${WEBHOOK_URL}" != https://* ]]; then
+  echo "Invalid webhook URL (must start with https://)" >&2
+  exit 1
+fi
+
+curl -fsS --connect-timeout 5 --max-time 10 \
+  -X POST \
+  -H 'Content-type: application/json' \
+  --data "${PAYLOAD}" \
+  "${WEBHOOK_URL}" >/dev/null
+
+echo "Slack notification sent"

--- a/.github/actions/notify-slack/render_payload.sh
+++ b/.github/actions/notify-slack/render_payload.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Render a Slack Block Kit payload for CI failure notifications.
+
+set -euo pipefail
+
+command -v jq >/dev/null 2>&1 || {
+  echo "jq is required to render Slack payloads" >&2
+  exit 1
+}
+
+WORKFLOW_NAME="${WORKFLOW_NAME:?WORKFLOW_NAME is required}"
+EVENT_NAME="${EVENT_NAME:?EVENT_NAME is required}"
+REF_NAME="${REF_NAME:?REF_NAME is required}"
+RUN_URL="${RUN_URL:?RUN_URL is required}"
+DASHBOARD_URL="${DASHBOARD_URL:?DASHBOARD_URL is required}"
+REPOSITORY="${REPOSITORY:?REPOSITORY is required}"
+STATUS="${STATUS:-failure}"
+TIMESTAMP="${TIMESTAMP:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+FAILED_JOBS_JSON="${FAILED_JOBS_JSON:-[]}"
+
+if ! jq -e 'type == "array"' <<<"${FAILED_JOBS_JSON}" >/dev/null 2>&1; then
+  FAILED_JOBS_JSON='[]'
+fi
+
+case "${STATUS}" in
+  failure | failed | timed_out)
+    COLOR="#d00000"
+    TITLE="CI Failure: ${WORKFLOW_NAME}"
+    STATUS_LABEL="Failed"
+    ;;
+  cancelled | canceled)
+    COLOR="#f2c744"
+    TITLE="CI Cancelled: ${WORKFLOW_NAME}"
+    STATUS_LABEL="Cancelled"
+    ;;
+  *)
+    COLOR="#d00000"
+    TITLE="CI Alert: ${WORKFLOW_NAME}"
+    STATUS_LABEL="${STATUS}"
+    ;;
+esac
+
+FAILED_JOBS_TEXT="$(
+  jq -nr --argjson jobs "${FAILED_JOBS_JSON}" '
+    if ($jobs | length) == 0 then
+      "*Failed jobs*\n- Job details unavailable"
+    elif ($jobs | length) <= 10 then
+      "*Failed jobs*\n" + ($jobs | map("- `" + . + "`") | join("\n"))
+    else
+      "*Failed jobs*\n"
+      + ($jobs[:10] | map("- `" + . + "`") | join("\n"))
+      + "\n- ... and \((($jobs | length) - 10)) more"
+    end
+  '
+)"
+
+LINKS_TEXT="<${RUN_URL}|View workflow run> | <${DASHBOARD_URL}|View CI dashboard>"
+FALLBACK_TEXT="CI ${STATUS_LABEL}: ${WORKFLOW_NAME} on ${REF_NAME}"
+
+jq -n \
+  --arg fallback_text "${FALLBACK_TEXT}" \
+  --arg color "${COLOR}" \
+  --arg title "${TITLE}" \
+  --arg workflow_name "${WORKFLOW_NAME}" \
+  --arg event_name "${EVENT_NAME}" \
+  --arg ref_name "${REF_NAME}" \
+  --arg repository "${REPOSITORY}" \
+  --arg timestamp "${TIMESTAMP}" \
+  --arg failed_jobs_text "${FAILED_JOBS_TEXT}" \
+  --arg links_text "${LINKS_TEXT}" \
+  '{
+    text: $fallback_text,
+    attachments: [
+      {
+        color: $color,
+        blocks: [
+          {
+            type: "header",
+            text: {
+              type: "plain_text",
+              text: $title,
+              emoji: true
+            }
+          },
+          {
+            type: "section",
+            fields: [
+              {
+                type: "mrkdwn",
+                text: ("*Workflow*\n" + $workflow_name)
+              },
+              {
+                type: "mrkdwn",
+                text: ("*Event*\n" + $event_name)
+              },
+              {
+                type: "mrkdwn",
+                text: ("*Ref*\n" + $ref_name)
+              },
+              {
+                type: "mrkdwn",
+                text: ("*Time (UTC)*\n" + $timestamp)
+              }
+            ]
+          },
+          {
+            type: "context",
+            elements: [
+              {
+                type: "mrkdwn",
+                text: ("Repository: `" + $repository + "`")
+              }
+            ]
+          },
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: $failed_jobs_text
+            }
+          },
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: $links_text
+            }
+          }
+        ]
+      }
+    ]
+  }'

--- a/.github/actions/notify-slack/should_notify.sh
+++ b/.github/actions/notify-slack/should_notify.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Decide whether a workflow run should emit a Slack notification.
+# Outputs key=value pairs suitable for appending to GITHUB_OUTPUT.
+
+set -euo pipefail
+
+command -v jq >/dev/null 2>&1 || {
+  echo "jq is required to evaluate Slack notification gates" >&2
+  exit 1
+}
+
+EVENT_NAME="${EVENT_NAME:?EVENT_NAME is required}"
+REF_NAME="${REF_NAME:?REF_NAME is required}"
+NEEDS_JSON="${NEEDS_JSON:-}"
+if [[ -z "${NEEDS_JSON}" ]]; then
+  NEEDS_JSON='{}'
+fi
+
+should_notify=false
+status="success"
+reason="all upstream jobs passed"
+
+if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+  reason="pull request runs do not notify"
+elif [[ "${EVENT_NAME}" == "workflow_dispatch" && "${REF_NAME}" != "main" ]]; then
+  reason="manual dispatch outside main does not notify"
+else
+  status="$(
+    jq -r '
+      [.[] | .result] as $results
+      | if any($results[]?; . == "failure") then "failure"
+        elif any($results[]?; . == "cancelled") then "cancelled"
+        else "success"
+        end
+    ' <<<"${NEEDS_JSON}"
+  )"
+  if [[ "${status}" != "success" ]]; then
+    should_notify=true
+    reason="workflow run failed"
+  fi
+fi
+
+printf 'should_notify=%s\n' "${should_notify}"
+printf 'status=%s\n' "${status}"
+printf 'reason=%s\n' "${reason}"

--- a/.github/actions/notify-slack/should_notify.sh
+++ b/.github/actions/notify-slack/should_notify.sh
@@ -29,6 +29,7 @@ else
     jq -r '
       [.[] | .result] as $results
       | if any($results[]?; . == "failure") then "failure"
+        elif any($results[]?; . == "timed_out") then "timed_out"
         elif any($results[]?; . == "cancelled") then "cancelled"
         else "success"
         end

--- a/.github/scripts/tests/test_notify_slack.py
+++ b/.github/scripts/tests/test_notify_slack.py
@@ -8,7 +8,6 @@ import os
 import subprocess
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[3]
 NOTIFY_DIR = REPO_ROOT / ".github" / "actions" / "notify-slack"
 RENDER_SCRIPT = NOTIFY_DIR / "render_payload.sh"
@@ -178,6 +177,34 @@ def test_should_notify_for_main_failure():
     assert output["status"] == "failure"
 
 
+def test_should_not_notify_on_all_success():
+    env = os.environ.copy()
+    env.update(
+        {
+            "EVENT_NAME": "push",
+            "REF_NAME": "main",
+            "NEEDS_JSON": json.dumps(
+                {
+                    "lint": {"result": "success"},
+                    "type-check": {"result": "success"},
+                }
+            ),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(SHOULD_NOTIFY_SCRIPT)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    output = parse_key_value_output(result.stdout)
+    assert output["should_notify"] == "false"
+    assert output["status"] == "success"
+
+
 def test_should_not_notify_for_pull_request_failure():
     env = os.environ.copy()
     env.update(
@@ -273,3 +300,26 @@ def test_should_notify_for_cancelled_run():
     output = parse_key_value_output(result.stdout)
     assert output["should_notify"] == "true"
     assert output["status"] == "cancelled"
+
+
+def test_should_notify_for_timed_out_run():
+    env = os.environ.copy()
+    env.update(
+        {
+            "EVENT_NAME": "push",
+            "REF_NAME": "main",
+            "NEEDS_JSON": json.dumps({"lint": {"result": "timed_out"}}),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(SHOULD_NOTIFY_SCRIPT)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    output = parse_key_value_output(result.stdout)
+    assert output["should_notify"] == "true"
+    assert output["status"] == "timed_out"

--- a/.github/scripts/tests/test_notify_slack.py
+++ b/.github/scripts/tests/test_notify_slack.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Tests for the Slack notification helper scripts."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+NOTIFY_DIR = REPO_ROOT / ".github" / "actions" / "notify-slack"
+RENDER_SCRIPT = NOTIFY_DIR / "render_payload.sh"
+NOTIFY_SCRIPT = NOTIFY_DIR / "notify.sh"
+SHOULD_NOTIFY_SCRIPT = NOTIFY_DIR / "should_notify.sh"
+EXTRACT_FAILED_JOBS_SCRIPT = NOTIFY_DIR / "extract_failed_jobs.sh"
+
+
+def parse_key_value_output(stdout: str) -> dict[str, str]:
+    pairs = {}
+    for line in stdout.strip().splitlines():
+        key, value = line.split("=", 1)
+        pairs[key] = value
+    return pairs
+
+
+def test_render_payload_includes_failed_jobs_and_links():
+    env = os.environ.copy()
+    env.update(
+        {
+            "WORKFLOW_NAME": "Code Quality",
+            "EVENT_NAME": "workflow_dispatch",
+            "REF_NAME": "main",
+            "STATUS": "failure",
+            "RUN_URL": "https://github.com/example/repo/actions/runs/123",
+            "DASHBOARD_URL": "https://red-hat-data-services.github.io/agentic-starter-kits/",
+            "REPOSITORY": "red-hat-data-services/agentic-starter-kits",
+            "FAILED_JOBS_JSON": json.dumps(["lint", "type-check"]),
+            "TIMESTAMP": "2026-07-09T07:30:00Z",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(RENDER_SCRIPT)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["attachments"][0]["color"] == "#d00000"
+
+    payload_text = json.dumps(payload)
+    assert "Code Quality" in payload_text
+    assert "workflow_dispatch" in payload_text
+    assert "main" in payload_text
+    assert "lint" in payload_text
+    assert "type-check" in payload_text
+    assert "https://github.com/example/repo/actions/runs/123" in payload_text
+    assert "https://red-hat-data-services.github.io/agentic-starter-kits/" in payload_text
+
+
+def test_notify_preview_prints_payload(tmp_path):
+    payload_path = tmp_path / "payload.json"
+    payload_path.write_text(
+        json.dumps({"text": "preview payload", "blocks": []}), encoding="utf-8"
+    )
+
+    result = subprocess.run(
+        ["bash", str(NOTIFY_SCRIPT), "--preview", str(payload_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=os.environ.copy(),
+    )
+
+    assert "Slack payload preview" in result.stdout
+    assert "preview payload" in result.stdout
+
+
+def test_notify_ignores_legacy_secret_env(tmp_path):
+    payload_path = tmp_path / "payload.json"
+    payload_path.write_text(
+        json.dumps({"text": "legacy secret should be ignored"}), encoding="utf-8"
+    )
+
+    env = os.environ.copy()
+    env.pop("SLACK_WEBHOOK_URL", None)
+    env.pop("SLACK_WEBHOOK_URLS", None)
+    env["WH_SLACK_TEAM_LLS_CORE"] = "https://hooks.slack.com/services/legacy/test/value"
+
+    result = subprocess.run(
+        ["bash", str(NOTIFY_SCRIPT), str(payload_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert "Slack webhook not configured" in result.stdout
+
+
+def test_notify_ignores_multi_webhook_env(tmp_path):
+    payload_path = tmp_path / "payload.json"
+    payload_path.write_text(
+        json.dumps({"text": "multi webhook env should be ignored"}), encoding="utf-8"
+    )
+
+    env = os.environ.copy()
+    env.pop("SLACK_WEBHOOK_URL", None)
+    env["SLACK_WEBHOOK_URLS"] = "https://hooks.slack.com/services/one,test"
+
+    result = subprocess.run(
+        ["bash", str(NOTIFY_SCRIPT), str(payload_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert "Slack webhook not configured" in result.stdout
+
+
+def test_extract_failed_jobs_filters_matrix_results(tmp_path):
+    payload_path = tmp_path / "jobs.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {"name": "verify-cluster-connection", "conclusion": "success"},
+                    {"name": "test-agent (langgraph-react-agent)", "conclusion": "failure"},
+                    {"name": "test-agent (google-adk-agent)", "conclusion": "cancelled"},
+                    {"name": "test-agent (crewai-websearch-agent)", "conclusion": "timed_out"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["bash", str(EXTRACT_FAILED_JOBS_SCRIPT), str(payload_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=os.environ.copy(),
+    )
+
+    failed_jobs = json.loads(result.stdout)
+    assert failed_jobs == [
+        "test-agent (langgraph-react-agent)",
+        "test-agent (google-adk-agent)",
+        "test-agent (crewai-websearch-agent)",
+    ]
+
+
+def test_should_notify_for_main_failure():
+    env = os.environ.copy()
+    env.update(
+        {
+            "EVENT_NAME": "push",
+            "REF_NAME": "main",
+            "NEEDS_JSON": json.dumps({"lint": {"result": "failure"}}),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(SHOULD_NOTIFY_SCRIPT)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    output = parse_key_value_output(result.stdout)
+    assert output["should_notify"] == "true"
+    assert output["status"] == "failure"
+
+
+def test_should_not_notify_for_pull_request_failure():
+    env = os.environ.copy()
+    env.update(
+        {
+            "EVENT_NAME": "pull_request",
+            "REF_NAME": "main",
+            "NEEDS_JSON": json.dumps({"lint": {"result": "failure"}}),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(SHOULD_NOTIFY_SCRIPT)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    output = parse_key_value_output(result.stdout)
+    assert output["should_notify"] == "false"
+    assert output["status"] == "success"
+
+
+def test_should_not_notify_for_feature_branch_manual_dispatch():
+    env = os.environ.copy()
+    env.update(
+        {
+            "EVENT_NAME": "workflow_dispatch",
+            "REF_NAME": "feature-branch",
+            "NEEDS_JSON": json.dumps({"test-agent": {"result": "failure"}}),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(SHOULD_NOTIFY_SCRIPT)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    output = parse_key_value_output(result.stdout)
+    assert output["should_notify"] == "false"
+    assert output["status"] == "success"
+
+
+def test_should_notify_for_matrix_failure():
+    env = os.environ.copy()
+    env.update(
+        {
+            "EVENT_NAME": "schedule",
+            "REF_NAME": "main",
+            "NEEDS_JSON": json.dumps(
+                {
+                    "verify-cluster-connection": {"result": "success"},
+                    "test-agent": {"result": "failure"},
+                }
+            ),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(SHOULD_NOTIFY_SCRIPT)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    output = parse_key_value_output(result.stdout)
+    assert output["should_notify"] == "true"
+    assert output["status"] == "failure"
+
+
+def test_should_notify_for_cancelled_run():
+    env = os.environ.copy()
+    env.update(
+        {
+            "EVENT_NAME": "workflow_dispatch",
+            "REF_NAME": "main",
+            "NEEDS_JSON": json.dumps({"lint": {"result": "cancelled"}}),
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(SHOULD_NOTIFY_SCRIPT)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    output = parse_key_value_output(result.stdout)
+    assert output["should_notify"] == "true"
+    assert output["status"] == "cancelled"

--- a/.github/scripts/tests/test_notify_slack.py
+++ b/.github/scripts/tests/test_notify_slack.py
@@ -58,7 +58,9 @@ def test_render_payload_includes_failed_jobs_and_links():
     assert "lint" in payload_text
     assert "type-check" in payload_text
     assert "https://github.com/example/repo/actions/runs/123" in payload_text
-    assert "https://red-hat-data-services.github.io/agentic-starter-kits/" in payload_text
+    assert (
+        "https://red-hat-data-services.github.io/agentic-starter-kits/" in payload_text
+    )
 
 
 def test_notify_preview_prints_payload(tmp_path):
@@ -129,9 +131,18 @@ def test_extract_failed_jobs_filters_matrix_results(tmp_path):
             {
                 "jobs": [
                     {"name": "verify-cluster-connection", "conclusion": "success"},
-                    {"name": "test-agent (langgraph-react-agent)", "conclusion": "failure"},
-                    {"name": "test-agent (google-adk-agent)", "conclusion": "cancelled"},
-                    {"name": "test-agent (crewai-websearch-agent)", "conclusion": "timed_out"},
+                    {
+                        "name": "test-agent (langgraph-react-agent)",
+                        "conclusion": "failure",
+                    },
+                    {
+                        "name": "test-agent (google-adk-agent)",
+                        "conclusion": "cancelled",
+                    },
+                    {
+                        "name": "test-agent (crewai-websearch-agent)",
+                        "conclusion": "timed_out",
+                    },
                 ]
             }
         ),

--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -115,3 +115,42 @@ jobs:
       - name: Logout
         if: always()
         run: oc logout || true
+
+  notify-slack:
+    name: Notify Slack
+    if: always() && github.repository == 'red-hat-data-services/agentic-starter-kits'
+    needs: [verify-cluster-connection, test-agent]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Decide notification status
+        id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          NEEDS_JSON: ${{ toJson(needs) }}
+        run: |
+          bash .github/actions/notify-slack/should_notify.sh >> "${GITHUB_OUTPUT}"
+
+      - name: Send Slack notification
+        if: steps.gate.outputs.should_notify == 'true'
+        uses: ./.github/actions/notify-slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          github_token: ${{ github.token }}
+          workflow_name: ${{ github.workflow }}
+          event_name: ${{ github.event_name }}
+          ref_name: ${{ github.ref_name }}
+          run_id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          dashboard_url: https://red-hat-data-services.github.io/agentic-starter-kits/
+          status: ${{ steps.gate.outputs.status }}

--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -118,7 +118,10 @@ jobs:
 
   notify-slack:
     name: Notify Slack
-    if: always() && github.repository == 'red-hat-data-services/agentic-starter-kits'
+    if: >-
+      !cancelled() &&
+      github.repository == 'red-hat-data-services/agentic-starter-kits' &&
+      (github.event_name != 'workflow_dispatch' || github.ref_name == 'main')
     needs: [verify-cluster-connection, test-agent]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/agent-tests.yml
+++ b/.github/workflows/agent-tests.yml
@@ -109,7 +109,11 @@ jobs:
 
   notify-slack:
     name: Notify Slack
-    if: always()
+    if: >-
+      !cancelled() &&
+      github.event_name != 'pull_request' &&
+      github.repository == 'red-hat-data-services/agentic-starter-kits' &&
+      (github.event_name != 'workflow_dispatch' || github.ref_name == 'main')
     needs: [test]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/agent-tests.yml
+++ b/.github/workflows/agent-tests.yml
@@ -106,3 +106,42 @@ jobs:
           check_name: Agent Test Results
           include_passed: true
           annotate_only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+
+  notify-slack:
+    name: Notify Slack
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Decide notification status
+        id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          NEEDS_JSON: ${{ toJson(needs) }}
+        run: |
+          bash .github/actions/notify-slack/should_notify.sh >> "${GITHUB_OUTPUT}"
+
+      - name: Send Slack notification
+        if: steps.gate.outputs.should_notify == 'true'
+        uses: ./.github/actions/notify-slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          github_token: ${{ github.token }}
+          workflow_name: ${{ github.workflow }}
+          event_name: ${{ github.event_name }}
+          ref_name: ${{ github.ref_name }}
+          run_id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          dashboard_url: https://red-hat-data-services.github.io/agentic-starter-kits/
+          status: ${{ steps.gate.outputs.status }}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -175,3 +175,42 @@ jobs:
           done < <(find ./agents ./components -name pyproject.toml \
                         ! -path '*/.venv/*' ! -path '*/egg-info/*' | sort)
           exit $failed
+
+  notify-slack:
+    name: Notify Slack
+    if: always()
+    needs: [lint, lockfile-check, secret-scanning, type-check]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Decide notification status
+        id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          NEEDS_JSON: ${{ toJson(needs) }}
+        run: |
+          bash .github/actions/notify-slack/should_notify.sh >> "${GITHUB_OUTPUT}"
+
+      - name: Send Slack notification
+        if: steps.gate.outputs.should_notify == 'true'
+        uses: ./.github/actions/notify-slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          github_token: ${{ github.token }}
+          workflow_name: ${{ github.workflow }}
+          event_name: ${{ github.event_name }}
+          ref_name: ${{ github.ref_name }}
+          run_id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          dashboard_url: https://red-hat-data-services.github.io/agentic-starter-kits/
+          status: ${{ steps.gate.outputs.status }}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -176,10 +176,40 @@ jobs:
                         ! -path '*/.venv/*' ! -path '*/egg-info/*' | sort)
           exit $failed
 
+  github-scripts-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3  # v8.3.0
+        with:
+          version: "0.11.21"
+
+      - name: Run GitHub script tests
+        run: |
+          uv sync --frozen --extra test
+          uv run --no-sync python -m pytest .github/scripts/tests -v
+
   notify-slack:
     name: Notify Slack
-    if: always()
-    needs: [lint, lockfile-check, secret-scanning, type-check]
+    if: >-
+      !cancelled() &&
+      github.event_name != 'pull_request' &&
+      github.repository == 'red-hat-data-services/agentic-starter-kits' &&
+      (github.event_name != 'workflow_dispatch' || github.ref_name == 'main')
+    needs: [lint, lockfile-check, secret-scanning, type-check, github-scripts-tests]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/eval-gating.yml
+++ b/.github/workflows/eval-gating.yml
@@ -210,7 +210,11 @@ jobs:
 
   notify-slack:
     name: Notify Slack
-    if: always()
+    if: >-
+      !cancelled() &&
+      github.event_name != 'pull_request' &&
+      github.repository == 'red-hat-data-services/agentic-starter-kits' &&
+      (github.event_name != 'workflow_dispatch' || github.ref_name == 'main')
     needs: [deterministic, cluster-btests]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/eval-gating.yml
+++ b/.github/workflows/eval-gating.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - ".github/workflows/eval-gating.yml"
       - ".github/actions/setup-cluster/action.yaml"
+      - ".github/actions/notify-slack/**"
       - "pyproject.toml"
       - "uv.lock"
       - "tests/behavioral/**"
@@ -21,6 +22,7 @@ on:
     paths:
       - ".github/workflows/eval-gating.yml"
       - ".github/actions/setup-cluster/action.yaml"
+      - ".github/actions/notify-slack/**"
       - "pyproject.toml"
       - "uv.lock"
       - "tests/behavioral/**"
@@ -205,3 +207,42 @@ jobs:
       - name: Logout
         if: always()
         run: oc logout || true
+
+  notify-slack:
+    name: Notify Slack
+    if: always()
+    needs: [deterministic, cluster-btests]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Decide notification status
+        id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          NEEDS_JSON: ${{ toJson(needs) }}
+        run: |
+          bash .github/actions/notify-slack/should_notify.sh >> "${GITHUB_OUTPUT}"
+
+      - name: Send Slack notification
+        if: steps.gate.outputs.should_notify == 'true'
+        uses: ./.github/actions/notify-slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          github_token: ${{ github.token }}
+          workflow_name: ${{ github.workflow }}
+          event_name: ${{ github.event_name }}
+          ref_name: ${{ github.ref_name }}
+          run_id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          dashboard_url: https://red-hat-data-services.github.io/agentic-starter-kits/
+          status: ${{ steps.gate.outputs.status }}

--- a/docs/ci-health-dashboard.md
+++ b/docs/ci-health-dashboard.md
@@ -26,6 +26,73 @@ Pull request runs are excluded from the summary to keep the page focused on shar
 - Manual refresh via **Actions → CI Health Pages → Run workflow**
 - Also rebuilds when dashboard generator or workflow files change on `main`
 
+## Slack alerts
+
+The same four workflows also send immediate Slack alerts when a shared-branch run fails:
+
+- `Code Quality`
+- `Agent Tests`
+- `Inner Loop Gating`
+- `QG4: Agent Deployment Integration Tests`
+
+The event list below is the union of the supported notification triggers across those workflows. Individual workflows do not all define the same trigger set.
+
+Included events:
+
+- `push` on `main`
+- `schedule`
+- `workflow_dispatch` when the selected ref is `main`
+
+Excluded events:
+
+- `pull_request`
+- `workflow_dispatch` on non-`main` branches
+- successful runs
+
+The Slack message complements this dashboard:
+
+- Slack is the fast failure signal
+- GitHub Actions is the source of full logs
+- the CI dashboard is the shared health summary and historical view
+
+### Secret setup
+
+Add this repository secret under **Settings → Secrets and variables → Actions**:
+
+- `SLACK_WEBHOOK_URL`
+
+This repo only supports `SLACK_WEBHOOK_URL` for Slack notifications. Do not store webhook URLs in workflow files, docs examples, or repository variables.
+
+### Local payload preview
+
+Render and preview the Slack payload without sending a message:
+
+```bash
+WORKFLOW_NAME="Code Quality" \
+EVENT_NAME="workflow_dispatch" \
+REF_NAME="main" \
+STATUS="failure" \
+RUN_URL="https://github.com/red-hat-data-services/agentic-starter-kits/actions/runs/123456789" \
+DASHBOARD_URL="https://red-hat-data-services.github.io/agentic-starter-kits/" \
+REPOSITORY="red-hat-data-services/agentic-starter-kits" \
+FAILED_JOBS_JSON='["lint", "type-check"]' \
+TIMESTAMP="2026-07-09T07:30:00Z" \
+bash .github/actions/notify-slack/render_payload.sh > /tmp/slack-payload.json
+
+bash .github/actions/notify-slack/notify.sh --preview /tmp/slack-payload.json
+```
+
+### Controlled validation
+
+To validate end-to-end delivery after the secret is present:
+
+1. Open one in-scope workflow from the **Actions** tab.
+2. Select the `main` branch in **Run workflow**.
+3. Trigger a controlled failure.
+4. Confirm exactly one Slack message arrives for the failed run.
+5. Confirm the message includes the failed job names, workflow run link, and dashboard link.
+6. Confirm a PR failure or a manual dispatch from a non-`main` branch does not post to Slack.
+
 ## Enable GitHub Pages before merge
 
 You can enable Pages while the PR is still in review:


### PR DESCRIPTION
  ## Description
  Adds a reusable GitHub Actions-based Slack notification path for shared-branch CI failures and wires it into the four QG8 workflows.
  Changes included in this PR:
  - Add `.github/actions/notify-slack/` with:
    - `action.yml` composite action wrapper
    - `should_notify.sh` for shared-branch gating
    - `extract_failed_jobs.sh` for failed job discovery from the Actions jobs API
    - `render_payload.sh` for rich Slack Block Kit payload rendering
    - `notify.sh` for webhook delivery and local preview
  - Wire terminal `notify-slack` fan-in jobs into:
    - `Code Quality`
    - `Agent Tests`
    - `Inner Loop Gating`
    - `QG4: Agent Deployment Integration Tests`
  - Restrict this repo to `SLACK_WEBHOOK_URL` only (Already configured as a GH Secret in this repo)
  - Keep Slack delivery best-effort so notification transport does not change workflow status
  - Add focused notifier tests for:
    - PR suppression
    - non-`main` manual dispatch suppression
    - cancelled-run behavior
    - matrix failed-job extraction
    - legacy / alternate webhook env rejection
  - Document secret setup, local preview, and validation steps in `docs/ci-health-dashboard.md`
  This stays within the ticket scope: immediate Slack visibility for shared-branch CI failures without alerting on routine PR failures.
  ## Jira Ticket
  RHAIENG-5937
  ## Testing
  - [ ] `make test` passes (run from the affected agent directory)
  - [x] Manual testing performed (describe steps below)
  - [ ] No testing required (documentation/config change only)
  Verification performed:
  - Ran `python -m pytest .github/scripts/tests/test_notify_slack.py .github/scripts/tests/test_generate_ci_health_page.py -v` (`19` tests passed)
  - Ran `bash -n .github/actions/notify-slack/*.sh`
  - Rendered and previewed Slack payloads locally for failure and cancelled cases
  - Parsed the reusable action YAML and the four updated workflow files locally
  End-to-end GitHub/Slack validation is still pending after the `SLACK_WEBHOOK_URL` Actions secret is configured:
  - trigger one controlled failing run from `main`
  - confirm exactly one Slack alert is posted
  - confirm a PR failure and a non-`main` manual dispatch do not post
  ## Checklist
  - [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
  - [x] No `.env` or secret files are included in this PR
  - [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)
  ## Review Guidance
  Focus review on:
  - `.github/actions/notify-slack/` for the secret contract and delivery behavior
  - `agent-deployment-test.yaml` fan-in notification path for QG4 matrix failure handling
  - `eval-gating.yml` path filter update so notifier changes still exercise that workflow
  - `docs/ci-health-dashboard.md` for operator setup and validation guidance
  Files that can be skimmed more lightly:
  - the repeated `notify-slack` job blocks in `code-quality.yml` and `agent-tests.yml`, since they follow the same pattern as the other workflow updates
  ## Related PRs
  None.
