### PR TITLE
docs: add upstream image warning to OpenClaw deployment

### DIFF
--- a/agents/openclaw/deployment/README.md
+++ b/agents/openclaw/deployment/README.md
@@ -2,6 +2,13 @@
 
 > Tested: 2026-04-13 on OpenShift 4.19 (ROSA) with vLLM model serving
 
+> **⚠ Important:** The container image used in this starter kit
+> (`ghcr.io/openclaw/openclaw`) is built and published by the
+> [OpenClaw upstream community](https://github.com/openclaw/openclaw),
+> **not by Red Hat**. It has not been built, scanned, or validated
+> according to Red Hat standards. Use it at your own discretion.
+> A Red Hat supported image may be provided in a future release.
+
 Deploy [OpenClaw](https://github.com/openclaw/openclaw) on Red Hat OpenShift with vLLM model serving — no cluster-admin required.
 
 For the full deployment guide, see [docs/raw-deployment.md](docs/raw-deployment.md).

--- a/agents/openclaw/deployment/README.md
+++ b/agents/openclaw/deployment/README.md
@@ -2,12 +2,12 @@
 
 > Tested: 2026-04-13 on OpenShift 4.19 (ROSA) with vLLM model serving
 
-> **⚠ Important:** The container image used in this starter kit
-> (`ghcr.io/openclaw/openclaw`) is built and published by the
-> [OpenClaw upstream community](https://github.com/openclaw/openclaw),
-> **not by Red Hat**. It has not been built, scanned, or validated
-> according to Red Hat standards. Use it at your own discretion.
-> A Red Hat supported image may be provided in a future release.
+**⚠ Important:** The container image used in this starter kit
+(`ghcr.io/openclaw/openclaw`) is built and published by the
+[OpenClaw upstream community](https://github.com/openclaw/openclaw),
+**not by Red Hat**. It has not been built, scanned, or validated
+according to Red Hat standards. Use it at your own discretion.
+A Red Hat supported image may be provided in a future release.
 
 Deploy [OpenClaw](https://github.com/openclaw/openclaw) on Red Hat OpenShift with vLLM model serving — no cluster-admin required.
 

--- a/agents/openclaw/deployment/manifests/04-deployment.yaml
+++ b/agents/openclaw/deployment/manifests/04-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         runAsNonRoot: true
       initContainers:
         - name: init-config
+          # WARNING: This is an upstream community image, not built or validated by Red Hat.
           image: ghcr.io/openclaw/openclaw@sha256:037f49ba1595be9502fb345138d727cd0cfaecf1392cbe0cfe053fb4681386cd
           command:
             - sh
@@ -44,6 +45,7 @@ spec:
                 - ALL
       containers:
         - name: gateway
+          # WARNING: This is an upstream community image, not built or validated by Red Hat.
           image: ghcr.io/openclaw/openclaw@sha256:037f49ba1595be9502fb345138d727cd0cfaecf1392cbe0cfe053fb4681386cd
           # Explicit entrypoint required — the image default doesn't start the gateway on OpenShift
           command:


### PR DESCRIPTION
## Summary

- Adds a visible warning banner in the OpenClaw deployment README stating that the `ghcr.io/openclaw/openclaw` container image is built by the upstream community, **not by Red Hat**, and has not been scanned or validated according to Red Hat standards.
- Adds inline `# WARNING` comments above both image references in `04-deployment.yaml` for the same reason.

## Context

Per discussion between Nehanth Narendrula and Bill Murdock: providing guidance for the upstream OpenClaw image is acceptable as long as documentation explicitly states it is upstream and not Red Hat validated, until a Red Hat supported version is released.

## Test plan

- [ ] Verify README renders the warning blockquote correctly on GitHub
- [ ] Verify `oc apply -k manifests/` still works (YAML comments don't affect behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)