### PR TITLE
fix(btest): align CrewAI known_tools, document experiment isolation

### DIFF
--- a/agents/crewai/templates/websearch_agent/tests/behavioral/conftest.py
+++ b/agents/crewai/templates/websearch_agent/tests/behavioral/conftest.py
@@ -71,7 +71,7 @@ def load_golden(category: str | None = None) -> list[dict[str, Any]]:
 @pytest.fixture
 def known_tools() -> list[str]:
     """Tools available on the CrewAI Websearch agent."""
-    return ["web_search", "Web Search"]
+    return ["Web Search"]
 
 
 @pytest.fixture

--- a/agents/crewai/templates/websearch_agent/tests/behavioral/conftest.py
+++ b/agents/crewai/templates/websearch_agent/tests/behavioral/conftest.py
@@ -71,7 +71,7 @@ def load_golden(category: str | None = None) -> list[dict[str, Any]]:
 @pytest.fixture
 def known_tools() -> list[str]:
     """Tools available on the CrewAI Websearch agent."""
-    return ["web_search"]
+    return ["web_search", "Web Search"]
 
 
 @pytest.fixture

--- a/agents/langgraph/templates/react_agent/tests/behavioral/conftest.py
+++ b/agents/langgraph/templates/react_agent/tests/behavioral/conftest.py
@@ -92,6 +92,16 @@ def run_eval(
 
     Overrides the root run_eval fixture to add MLflow trace data
     (tool calls, token usage) after each request.
+
+    NOTE: MLFLOW_EXPERIMENT_NAME isolation — all agents read this from the
+    same env var.  If multiple agents (react_agent, human_in_the_loop,
+    agentic_rag) share the same experiment name during a CI run, MLflow
+    enrichment may pull tool spans from sibling agents (e.g. ``create_file``
+    from HITL or ``retriever`` from agentic_rag), causing spurious
+    hallucinated-tool failures.  The ``since_ms`` timestamp filter mitigates
+    this for sequential runs, but concurrent execution is not safe.  Each
+    agent deployment should set a unique MLFLOW_EXPERIMENT_NAME to avoid
+    cross-contamination.
     """
     mlflow = None
     if MLflowTraceClient is not None:


### PR DESCRIPTION
## Summary
- Add `"Web Search"` to CrewAI websearch agent `known_tools` to match the actual tool registration name (`name: str = "Web Search"` in `custom_tool.py:22`)
- Document MLFLOW_EXPERIMENT_NAME isolation risk in react_agent conftest — shared experiment names across agents can cause trace cross-contamination

LlamaIndex `known_tools` confirmed correct (`dummy_web_search` matches function name used by `FunctionTool.from_defaults()`).

## Jira
- RHAIENG-6149
- Part of RHAIENG-6147 (Tune behavioral test suites for CI readiness)
- Tracking: RHAIENG-6227

## Test plan
- [ ] Deploy CrewAI websearch agent and run btests — hallucinated_tools test should pass
- [ ] Deploy react_agent and run btests — tool_selection tests should pass
- [ ] Verify LlamaIndex btests still pass (no changes made)

🤖 Generated with [Claude Code](https://claude.com/claude-code)