### PR TITLE
feat(opencode): add session persistence and skills injection

### DIFF
--- a/agents/opencode/deployment/DEPLOYMENT.md
+++ b/agents/opencode/deployment/DEPLOYMENT.md
@@ -109,6 +109,7 @@ See [docs/mlflow-tracing-setup.md](docs/mlflow-tracing-setup.md) for full config
 | Model endpoint URL | `manifests/kustomization.yaml` (`BASE_URL`) | Cluster-internal DNS, e.g. `http://vllm-svc.vllm.svc.cluster.local/v1` |
 | API key | `manifests/kustomization.yaml` (`API_KEY`) | Use `"token"` if auth is disabled |
 | Model name | `manifests/kustomization.yaml` (`MODEL_NAME`) | Must match the model loaded in vLLM |
+| Small model | `manifests/config-template.json` (`small_model`) | Defaults to `MODEL_NAME`; edit the template to use a separate placeholder (e.g. `${SMALL_MODEL_NAME}`) for lighter tasks |
 | Storage class | `manifests/kustomization.yaml` (patch section) | Default PVC is 10Gi |
 | MCP servers | ConfigMap `opencode-web-mcp` | Optional; merged into config at startup |
 | Provider (vLLM vs OGX) | `manifests/config-template.json` (`enabled_providers`) | Both enabled by default |

--- a/agents/opencode/deployment/DEPLOYMENT.md
+++ b/agents/opencode/deployment/DEPLOYMENT.md
@@ -125,9 +125,9 @@ OpenCode session history and workspace files persist across pod restarts. The co
 | `~/.local/share/opencode/` | `/opt/app-root/workspace/.opencode/data/opencode/`  | Session history, database |
 | `~/.local/state/opencode/` | `/opt/app-root/workspace/.opencode/state/opencode/` | Locks, runtime state      |
 
-The entrypoint creates symlinks from default XDG locations to PVC-backed paths. For config and data, this works automatically. For state, the deployment sets `XDG_STATE_HOME` explicitly (see note below).
+The entrypoint creates symlinks from default XDG locations to PVC-backed paths and exports `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, and `XDG_STATE_HOME` to point at the persistent directories.
 
-> **Note**: The container image creates `~/.local/state/` with 755 permissions, which prevents symlink creation under OpenShift's random UID (the root group cannot write to 755 directories). The deployment manifests set `XDG_STATE_HOME` as a workaround. If this is fixed upstream in the container image (by using 775 permissions), the environment variable can be removed.
+> **Note**: The container image creates `~/.local/state/` with 755 permissions, which prevents symlink creation under OpenShift's random UID (the root group cannot write to 755 directories). The entrypoint's `XDG_STATE_HOME` export works around this. If this is fixed upstream in the container image (by using 775 permissions), the workaround can be removed.
 
 #### Resuming Sessions (CLI Mode)
 
@@ -152,7 +152,7 @@ env:
     value: /opt/app-root/workspace/my-custom-dir
 ```
 
-The entrypoint creates `config/opencode/` and `data/opencode/` subdirectories within this path.
+The entrypoint creates `config/opencode/`, `data/opencode/`, and `state/opencode/` subdirectories within this path.
 
 ### Skills Injection
 

--- a/agents/opencode/deployment/DEPLOYMENT.md
+++ b/agents/opencode/deployment/DEPLOYMENT.md
@@ -113,6 +113,100 @@ See [docs/mlflow-tracing-setup.md](docs/mlflow-tracing-setup.md) for full config
 | MCP servers | ConfigMap `opencode-web-mcp` | Optional; merged into config at startup |
 | Provider (vLLM vs OGX) | `manifests/config-template.json` (`enabled_providers`) | Both enabled by default |
 
+### Session Persistence
+
+OpenCode session history and workspace files persist across pod restarts. The container's working directory is set to the PVC mount (`/opt/app-root/workspace`), so files created during a session are stored on persistent storage. The entrypoint additionally redirects OpenCode's internal data directories to PVC-backed paths.
+
+#### How It Works
+
+| Default Path               | Redirected To                                       | Purpose                   |
+|----------------------------|-----------------------------------------------------|---------------------------|
+| `~/.config/opencode/`      | `/opt/app-root/workspace/.opencode/config/opencode/`| Configuration, settings   |
+| `~/.local/share/opencode/` | `/opt/app-root/workspace/.opencode/data/opencode/`  | Session history, database |
+| `~/.local/state/opencode/` | `/opt/app-root/workspace/.opencode/state/opencode/` | Locks, runtime state      |
+
+The entrypoint creates symlinks from default XDG locations to PVC-backed paths. For config and data, this works automatically. For state, the deployment sets `XDG_STATE_HOME` explicitly (see note below).
+
+> **Note**: The container image creates `~/.local/state/` with 755 permissions, which prevents symlink creation under OpenShift's random UID (the root group cannot write to 755 directories). The deployment manifests set `XDG_STATE_HOME` as a workaround. If this is fixed upstream in the container image (by using 775 permissions), the environment variable can be removed.
+
+#### Resuming Sessions (CLI Mode)
+
+```bash
+# List previous sessions
+oc exec deployment/opencode-cli -- opencode session list
+
+# Resume the most recent session
+oc exec -it deployment/opencode-cli -- opencode --continue
+
+# Resume a specific session
+oc exec -it deployment/opencode-cli -- opencode --session <session-id>
+```
+
+#### Customizing the Data Directory
+
+Override the default location by setting the `OPENCODE_DATA_DIR` environment variable in the deployment:
+
+```yaml
+env:
+  - name: OPENCODE_DATA_DIR
+    value: /opt/app-root/workspace/my-custom-dir
+```
+
+The entrypoint creates `config/opencode/` and `data/opencode/` subdirectories within this path.
+
+### Skills Injection
+
+Skills extend OpenCode with custom instructions. No skills are included by default — you create and inject your own.
+
+Skills are auto-discovered from `~/.config/opencode/skills/`. The skills ConfigMap is mounted at `/etc/opencode-skills/` and the entrypoint symlinks it into the config directory. Each skill must be in a subdirectory containing a `SKILL.md` file with YAML frontmatter.
+
+#### Example: Creating a Code Review Skill
+
+**1. Create a `SKILL.md` file:**
+
+```markdown
+---
+name: code-review
+description: Analyze code for correctness, security, and performance issues
+---
+
+# Code Review
+
+When reviewing code, analyze for:
+
+1. **Correctness** - Logic errors, edge cases, off-by-one errors
+2. **Security** - Input validation, injection risks, hardcoded secrets
+3. **Performance** - Unnecessary loops, N+1 queries, missing indexes
+```
+
+**2. Create a ConfigMap from your skill files:**
+
+```bash
+oc create configmap opencode-web-skills \
+  --from-file=code-review-skill=./skills/code-review/SKILL.md
+```
+
+**3. Add an `items` mapping to the skills volume in your deployment manifest:**
+
+The `items` mapping creates the subdirectory structure OpenCode expects:
+
+```yaml
+volumes:
+  - name: skills
+    configMap:
+      name: opencode-web-skills
+      optional: true
+      items:
+        - key: code-review-skill
+          path: code-review/SKILL.md
+```
+
+**4. Restart the deployment:**
+
+```bash
+oc rollout restart deployment/opencode-web
+```
+
 ## Security
 
 - **SCC**: Runs under `restricted-v2` — `runAsNonRoot`, drop all capabilities, seccomp RuntimeDefault. No special SCC grants required.
@@ -129,8 +223,11 @@ The web mode deployment runs a two-container pod:
 
 The entrypoint script (`manifests/entrypoint.sh`) handles:
 
+- Persistence — working directory is `/opt/app-root/workspace` (PVC mount), so workspace files survive pod restarts
+- Session data redirection — symlinks OpenCode's config, data, and state directories from default XDG locations to PVC-backed paths under `.opencode/`
 - Git workspace initialization
 - Config template variable substitution (BASE_URL, API_KEY, MODEL_NAME)
+- Skills injection — symlinks ConfigMap-mounted skills into the config directory
 - Optional MCP server config injection from a ConfigMap
 - Mode switching between web and CLI
 

--- a/agents/opencode/deployment/manifests/deployment.yaml
+++ b/agents/opencode/deployment/manifests/deployment.yaml
@@ -70,12 +70,6 @@ spec:
                 secretKeyRef:
                   name: opencode-web-secret
                   key: MODEL_NAME
-            # XDG_STATE_HOME must be set explicitly because the container image
-            # creates ~/.local/state/ with 755 permissions, which prevents the
-            # entrypoint from creating a symlink under OpenShift's random UID.
-            # Config and data symlinks work because their parent dirs are 775.
-            - name: XDG_STATE_HOME
-              value: /opt/app-root/workspace/.opencode/state
           resources:
             requests:
               cpu: 500m

--- a/agents/opencode/deployment/manifests/deployment.yaml
+++ b/agents/opencode/deployment/manifests/deployment.yaml
@@ -50,7 +50,7 @@ spec:
               drop: [ALL]
         - name: opencode-web
           image: quay.io/opendatahub/odh-opencode-rhel9:20260619-194847e
-          workingDir: /opt/app-root/
+          workingDir: /opt/app-root/workspace
           command: ["/bin/bash", "/entrypoint/entrypoint.sh"]
           ports:
             - containerPort: 8003
@@ -70,6 +70,12 @@ spec:
                 secretKeyRef:
                   name: opencode-web-secret
                   key: MODEL_NAME
+            # XDG_STATE_HOME must be set explicitly because the container image
+            # creates ~/.local/state/ with 755 permissions, which prevents the
+            # entrypoint from creating a symlink under OpenShift's random UID.
+            # Config and data symlinks work because their parent dirs are 775.
+            - name: XDG_STATE_HOME
+              value: /opt/app-root/workspace/.opencode/state
           resources:
             requests:
               cpu: 500m
@@ -105,6 +111,9 @@ spec:
               mountPath: /entrypoint
             - name: mcp-config
               mountPath: /mcp-config
+            - name: skills
+              mountPath: /etc/opencode-skills
+              readOnly: true
       volumes:
         - name: opencode-web-pvc
           persistentVolumeClaim:
@@ -119,6 +128,10 @@ spec:
         - name: mcp-config
           configMap:
             name: opencode-web-mcp
+            optional: true
+        - name: skills
+          configMap:
+            name: opencode-web-skills
             optional: true
         - name: proxy-tls
           secret:

--- a/agents/opencode/deployment/manifests/entrypoint.sh
+++ b/agents/opencode/deployment/manifests/entrypoint.sh
@@ -1,11 +1,128 @@
 #!/bin/bash
 set -euo pipefail
 
+# =============================================================================
+# OpenCode Data Directory Setup (session persistence)
+# =============================================================================
+# OpenCode stores config in ~/.config/opencode and session data in
+# ~/.local/share/opencode. This function redirects both to a PVC-backed
+# location so sessions persist across pod restarts.
+# =============================================================================
+setup_opencode_dirs() {
+    export OPENCODE_DATA_DIR="${OPENCODE_DATA_DIR:-/opt/app-root/workspace/.opencode}"
+
+    mkdir -p "${OPENCODE_DATA_DIR}/config/opencode"
+    mkdir -p "${OPENCODE_DATA_DIR}/data/opencode"
+    mkdir -p "${OPENCODE_DATA_DIR}/state/opencode"
+
+    export XDG_CONFIG_HOME="${OPENCODE_DATA_DIR}/config"
+    export XDG_DATA_HOME="${OPENCODE_DATA_DIR}/data"
+    export XDG_STATE_HOME="${OPENCODE_DATA_DIR}/state"
+
+    local home_config="${HOME}/.config"
+    local home_data="${HOME}/.local/share"
+    local home_state="${HOME}/.local/state"
+
+    # Symlink ~/.config/opencode -> persistent config
+    mkdir -p "${home_config}"
+    if [[ -L "${home_config}/opencode" ]]; then
+        local current_target
+        current_target=$(readlink "${home_config}/opencode")
+        if [[ "${current_target}" != "${XDG_CONFIG_HOME}/opencode" ]]; then
+            ln -sfn "${XDG_CONFIG_HOME}/opencode" "${home_config}/opencode"
+        fi
+    else
+        if [[ -d "${home_config}/opencode" ]]; then
+            if [[ -n "$(ls -A "${home_config}/opencode" 2>/dev/null)" ]]; then
+                cp -rn "${home_config}/opencode/"* "${XDG_CONFIG_HOME}/opencode/" 2>/dev/null || true
+            fi
+            mv "${home_config}/opencode" "${home_config}/opencode.migrated" 2>/dev/null || rm -rf "${home_config}/opencode" 2>/dev/null || true
+        fi
+        ln -sfn "${XDG_CONFIG_HOME}/opencode" "${home_config}/opencode" 2>/dev/null || true
+    fi
+
+    # Symlink ~/.local/share/opencode -> persistent data
+    mkdir -p "${home_data}"
+    if [[ -L "${home_data}/opencode" ]]; then
+        local current_target
+        current_target=$(readlink "${home_data}/opencode")
+        if [[ "${current_target}" != "${XDG_DATA_HOME}/opencode" ]]; then
+            ln -sfn "${XDG_DATA_HOME}/opencode" "${home_data}/opencode"
+        fi
+    else
+        if [[ -d "${home_data}/opencode" ]]; then
+            if [[ -n "$(ls -A "${home_data}/opencode" 2>/dev/null)" ]]; then
+                cp -rn "${home_data}/opencode/"* "${XDG_DATA_HOME}/opencode/" 2>/dev/null || true
+            fi
+            mv "${home_data}/opencode" "${home_data}/opencode.migrated" 2>/dev/null || rm -rf "${home_data}/opencode" 2>/dev/null || true
+        fi
+        ln -sfn "${XDG_DATA_HOME}/opencode" "${home_data}/opencode" 2>/dev/null || true
+    fi
+
+    # Symlink ~/.local/state/opencode -> persistent state
+    mkdir -p "${home_state}"
+    if [[ -L "${home_state}/opencode" ]]; then
+        local current_target
+        current_target=$(readlink "${home_state}/opencode")
+        if [[ "${current_target}" != "${XDG_STATE_HOME}/opencode" ]]; then
+            ln -sfn "${XDG_STATE_HOME}/opencode" "${home_state}/opencode"
+        fi
+    else
+        if [[ -d "${home_state}/opencode" ]]; then
+            if [[ -n "$(ls -A "${home_state}/opencode" 2>/dev/null)" ]]; then
+                cp -rn "${home_state}/opencode/"* "${XDG_STATE_HOME}/opencode/" 2>/dev/null || true
+            fi
+            mv "${home_state}/opencode" "${home_state}/opencode.migrated" 2>/dev/null || rm -rf "${home_state}/opencode" 2>/dev/null || true
+        fi
+        ln -sfn "${XDG_STATE_HOME}/opencode" "${home_state}/opencode" 2>/dev/null || true
+    fi
+
+    echo "[entrypoint] OpenCode data directory: ${OPENCODE_DATA_DIR}"
+}
+
+# =============================================================================
+# Skills Configuration
+# =============================================================================
+# Skills are staged at /etc/opencode-skills/ (read-only ConfigMap mount)
+# and symlinked into the config directory so OpenCode discovers them.
+# =============================================================================
+setup_skills() {
+    local staged_skills="/etc/opencode-skills"
+    local skills_dir="${XDG_CONFIG_HOME}/opencode/skills"
+
+    if [[ -d "${staged_skills}" ]]; then
+        mkdir -p "$(dirname "${skills_dir}")"
+
+        if [[ -e "${skills_dir}" && ! -L "${skills_dir}" ]]; then
+            local backup_dir="${skills_dir}.bak"
+            local i=1
+            while [[ -e "${backup_dir}" ]]; do
+                backup_dir="${skills_dir}.bak.${i}"
+                ((i++))
+            done
+            mv "${skills_dir}" "${backup_dir}"
+            echo "[entrypoint] Moved existing skills directory to ${backup_dir}"
+        fi
+
+        ln -sfn "${staged_skills}" "${skills_dir}"
+
+        local skill_count
+        skill_count=$(find "${skills_dir}" -name "SKILL.md" -type f 2>/dev/null | wc -l)
+        if [[ ${skill_count} -gt 0 ]]; then
+            echo "[entrypoint] Found ${skill_count} skill(s) in ${skills_dir}"
+        fi
+    fi
+}
+
 # Git configuration
 git config --global init.defaultBranch main
 git config --global user.email "opencode@openshift.local"
 git config --global user.name "OpenCode"
 git config --global --add safe.directory /opt/app-root/workspace
+
+# Setup persistent directories BEFORE config generation
+setup_opencode_dirs
+setup_skills
 
 # Initialize workspace if needed
 cd /opt/app-root/workspace
@@ -14,8 +131,19 @@ if [ ! -d .git ]; then
   git commit --allow-empty -m "init"
 fi
 
-# Build OpenCode config from template (envsubst handles special chars safely)
-CONFIG=$(envsubst '${BASE_URL} ${API_KEY} ${MODEL_NAME}' < /config-template/config-template.json)
+# Exclude OpenCode internal data from git tracking
+if ! grep -q "^\.opencode$" .gitignore 2>/dev/null; then
+    echo ".opencode" >> .gitignore
+fi
+
+# Build OpenCode config from template (jq handles special chars safely)
+CONFIG=$(jq --arg base "$BASE_URL" --arg key "$API_KEY" --arg model "$MODEL_NAME" '
+  .provider[].options.baseURL = $base |
+  .provider[].options.apiKey = $key |
+  .provider[].models = {($model): {name: $model}} |
+  .model = $model |
+  .small_model = $model
+' /config-template/config-template.json)
 
 # Merge MCP config if mounted
 if [ -f /mcp-config/mcp-servers.json ]; then
@@ -23,17 +151,22 @@ if [ -f /mcp-config/mcp-servers.json ]; then
   CONFIG=$(echo "$CONFIG" | jq --argjson mcp "$MCP_SERVERS" '. + {mcp: $mcp}')
 fi
 
-export OPENCODE_CONFIG_CONTENT="$CONFIG"
 unset API_KEY BASE_URL MODEL_NAME
 
 MODE="${OPENCODE_MODE:-web}"
 
 case "$MODE" in
   web)
+    export OPENCODE_CONFIG_CONTENT="$CONFIG"
     exec opencode web --hostname 0.0.0.0 --port 8003
     ;;
   cli)
-    echo "[entrypoint] CLI mode — attach with: oc exec -it deployment/opencode-web -c opencode-web -- opencode"
+    # Write config to persistent location for oc exec sessions
+    echo "$CONFIG" > "${XDG_CONFIG_HOME}/opencode/opencode.json"
+    echo "[entrypoint] CLI mode — config written to ${XDG_CONFIG_HOME}/opencode/opencode.json"
+    echo "[entrypoint] Sessions persist in ${XDG_DATA_HOME}/opencode/"
+    echo "[entrypoint] Attach with: oc exec -it deployment/opencode-cli -c opencode -- opencode"
+    echo "[entrypoint] Resume last session: opencode --continue"
     exec sleep infinity
     ;;
   *)

--- a/agents/opencode/deployment/manifests/entrypoint.sh
+++ b/agents/opencode/deployment/manifests/entrypoint.sh
@@ -29,7 +29,7 @@ redirect_xdg_dir() {
             if [[ -n "$(ls -A "${source_dir}" 2>/dev/null)" ]]; then
                 cp -rn "${source_dir}/." "${target_dir}/" 2>/dev/null || true
             fi
-            mv "${source_dir}" "${source_dir}.migrated" 2>/dev/null || rm -rf "${source_dir}" 2>/dev/null || true
+            mv "${source_dir}" "${source_dir}.migrated" 2>/dev/null || { echo "[entrypoint] Warning: could not move ${source_dir}, removing"; rm -rf "${source_dir}" 2>/dev/null || true; }
         fi
         ln -sfn "${target_dir}" "${source_dir}" 2>/dev/null || true
     fi
@@ -109,13 +109,18 @@ if ! grep -q "^\.opencode$" .gitignore 2>/dev/null; then
     echo ".opencode" >> .gitignore
 fi
 
-# Build OpenCode config from template (jq handles special chars safely)
-CONFIG=$(jq --arg base "$BASE_URL" --arg key "$API_KEY" --arg model "$MODEL_NAME" '
-  .provider[].options.baseURL = $base |
-  .provider[].options.apiKey = $key |
-  .provider[].models = {($model): {name: $model}} |
-  .model = $model |
-  .small_model = $model
+# Build OpenCode config from template (jq-based envsubst — replaces ${VAR}
+# placeholders with matching environment variables, safely handling special chars)
+CONFIG=$(jq '
+  def envsubst:
+    reduce ($ENV | to_entries[]) as $e (.;
+      gsub("\\$\\{" + $e.key + "\\}"; $e.value)
+    );
+  walk(
+    if type == "string" then envsubst
+    elif type == "object" then with_entries(.key |= envsubst)
+    else . end
+  )
 ' /config-template/config-template.json)
 
 # Merge MCP config if mounted
@@ -138,7 +143,7 @@ case "$MODE" in
     (umask 077 && echo "$CONFIG" > "${XDG_CONFIG_HOME}/opencode/opencode.json")
     echo "[entrypoint] CLI mode — config written to ${XDG_CONFIG_HOME}/opencode/opencode.json"
     echo "[entrypoint] Sessions persist in ${XDG_DATA_HOME}/opencode/"
-    echo "[entrypoint] Attach with: oc exec -it deployment/opencode-cli -c opencode -- opencode"
+    echo "[entrypoint] Attach with: oc exec -it deployment/opencode-web -c opencode-web -- opencode"
     echo "[entrypoint] Resume last session: opencode --continue"
     exec sleep infinity
     ;;

--- a/agents/opencode/deployment/manifests/entrypoint.sh
+++ b/agents/opencode/deployment/manifests/entrypoint.sh
@@ -7,7 +7,34 @@ set -euo pipefail
 # OpenCode stores config in ~/.config/opencode and session data in
 # ~/.local/share/opencode. This function redirects both to a PVC-backed
 # location so sessions persist across pod restarts.
+#
+# XDG_STATE_HOME is exported here (not in the deployment manifest) so that
+# all three XDG dirs are managed consistently. This also works around
+# the container image creating ~/.local/state/ with 755 permissions,
+# which prevents symlink creation under OpenShift's random UID.
 # =============================================================================
+redirect_xdg_dir() {
+    local source_dir="$1"
+    local target_dir="$2"
+
+    mkdir -p "$(dirname "${source_dir}")"
+    if [[ -L "${source_dir}" ]]; then
+        local current_target
+        current_target=$(readlink "${source_dir}")
+        if [[ "${current_target}" != "${target_dir}" ]]; then
+            ln -sfn "${target_dir}" "${source_dir}"
+        fi
+    else
+        if [[ -d "${source_dir}" ]]; then
+            if [[ -n "$(ls -A "${source_dir}" 2>/dev/null)" ]]; then
+                cp -rn "${source_dir}/." "${target_dir}/" 2>/dev/null || true
+            fi
+            mv "${source_dir}" "${source_dir}.migrated" 2>/dev/null || rm -rf "${source_dir}" 2>/dev/null || true
+        fi
+        ln -sfn "${target_dir}" "${source_dir}" 2>/dev/null || true
+    fi
+}
+
 setup_opencode_dirs() {
     export OPENCODE_DATA_DIR="${OPENCODE_DATA_DIR:-/opt/app-root/workspace/.opencode}"
 
@@ -19,63 +46,9 @@ setup_opencode_dirs() {
     export XDG_DATA_HOME="${OPENCODE_DATA_DIR}/data"
     export XDG_STATE_HOME="${OPENCODE_DATA_DIR}/state"
 
-    local home_config="${HOME}/.config"
-    local home_data="${HOME}/.local/share"
-    local home_state="${HOME}/.local/state"
-
-    # Symlink ~/.config/opencode -> persistent config
-    mkdir -p "${home_config}"
-    if [[ -L "${home_config}/opencode" ]]; then
-        local current_target
-        current_target=$(readlink "${home_config}/opencode")
-        if [[ "${current_target}" != "${XDG_CONFIG_HOME}/opencode" ]]; then
-            ln -sfn "${XDG_CONFIG_HOME}/opencode" "${home_config}/opencode"
-        fi
-    else
-        if [[ -d "${home_config}/opencode" ]]; then
-            if [[ -n "$(ls -A "${home_config}/opencode" 2>/dev/null)" ]]; then
-                cp -rn "${home_config}/opencode/"* "${XDG_CONFIG_HOME}/opencode/" 2>/dev/null || true
-            fi
-            mv "${home_config}/opencode" "${home_config}/opencode.migrated" 2>/dev/null || rm -rf "${home_config}/opencode" 2>/dev/null || true
-        fi
-        ln -sfn "${XDG_CONFIG_HOME}/opencode" "${home_config}/opencode" 2>/dev/null || true
-    fi
-
-    # Symlink ~/.local/share/opencode -> persistent data
-    mkdir -p "${home_data}"
-    if [[ -L "${home_data}/opencode" ]]; then
-        local current_target
-        current_target=$(readlink "${home_data}/opencode")
-        if [[ "${current_target}" != "${XDG_DATA_HOME}/opencode" ]]; then
-            ln -sfn "${XDG_DATA_HOME}/opencode" "${home_data}/opencode"
-        fi
-    else
-        if [[ -d "${home_data}/opencode" ]]; then
-            if [[ -n "$(ls -A "${home_data}/opencode" 2>/dev/null)" ]]; then
-                cp -rn "${home_data}/opencode/"* "${XDG_DATA_HOME}/opencode/" 2>/dev/null || true
-            fi
-            mv "${home_data}/opencode" "${home_data}/opencode.migrated" 2>/dev/null || rm -rf "${home_data}/opencode" 2>/dev/null || true
-        fi
-        ln -sfn "${XDG_DATA_HOME}/opencode" "${home_data}/opencode" 2>/dev/null || true
-    fi
-
-    # Symlink ~/.local/state/opencode -> persistent state
-    mkdir -p "${home_state}"
-    if [[ -L "${home_state}/opencode" ]]; then
-        local current_target
-        current_target=$(readlink "${home_state}/opencode")
-        if [[ "${current_target}" != "${XDG_STATE_HOME}/opencode" ]]; then
-            ln -sfn "${XDG_STATE_HOME}/opencode" "${home_state}/opencode"
-        fi
-    else
-        if [[ -d "${home_state}/opencode" ]]; then
-            if [[ -n "$(ls -A "${home_state}/opencode" 2>/dev/null)" ]]; then
-                cp -rn "${home_state}/opencode/"* "${XDG_STATE_HOME}/opencode/" 2>/dev/null || true
-            fi
-            mv "${home_state}/opencode" "${home_state}/opencode.migrated" 2>/dev/null || rm -rf "${home_state}/opencode" 2>/dev/null || true
-        fi
-        ln -sfn "${XDG_STATE_HOME}/opencode" "${home_state}/opencode" 2>/dev/null || true
-    fi
+    redirect_xdg_dir "${HOME}/.config/opencode"     "${XDG_CONFIG_HOME}/opencode"
+    redirect_xdg_dir "${HOME}/.local/share/opencode" "${XDG_DATA_HOME}/opencode"
+    redirect_xdg_dir "${HOME}/.local/state/opencode" "${XDG_STATE_HOME}/opencode"
 
     echo "[entrypoint] OpenCode data directory: ${OPENCODE_DATA_DIR}"
 }
@@ -162,7 +135,7 @@ case "$MODE" in
     ;;
   cli)
     # Write config to persistent location for oc exec sessions
-    echo "$CONFIG" > "${XDG_CONFIG_HOME}/opencode/opencode.json"
+    (umask 077 && echo "$CONFIG" > "${XDG_CONFIG_HOME}/opencode/opencode.json")
     echo "[entrypoint] CLI mode — config written to ${XDG_CONFIG_HOME}/opencode/opencode.json"
     echo "[entrypoint] Sessions persist in ${XDG_DATA_HOME}/opencode/"
     echo "[entrypoint] Attach with: oc exec -it deployment/opencode-cli -c opencode -- opencode"


### PR DESCRIPTION
## Description

- Redirect OpenCode config, data, and state directories to PVC-backed paths via XDG symlinks so sessions survive pod restarts
- Set workingDir to PVC mount (/opt/app-root/workspace) so workspace files also persist across restarts
- Add skills injection via ConfigMap mounted at /etc/opencode-skills/ and symlinked into the OpenCode config directory
- Set XDG_STATE_HOME explicitly to work around 755 permissions on ~/.local/state/ under OpenShift's random UID
- Add skills volume and mount to deployment.yaml
- Replace envsubst with jq for config template substitution (envsubst is not available in the container image)
- Write config to persistent file in CLI mode instead of env var
- Update DEPLOYMENT.md with session persistence and skills injection documentation


## Testing

- [ ] Ask OpenCode to create a file and verify it lands on the PVC (/opt/app-root/workspace/)
- [ ] Restart pod and verify workspace files survive
- [ ] List sessions before and after pod restart — confirm they match
- [ ] Resume a previous session with opencode --continue after pod restart
- [ ] Inject a skill via ConfigMap and verify OpenCode discovers and uses it (→ Skill in output)

