### PR TITLE
docs: add catalog README files for coding agent templates

### DIFF
--- a/agents/claude-code/templates/claude_code_agent/README.md
+++ b/agents/claude-code/templates/claude_code_agent/README.md
@@ -1,0 +1,26 @@
+# Claude Code
+
+## What this agent does
+
+Anthropic's Claude Code CLI running as a containerized coding agent. Provides AI-powered code generation, editing, debugging, and repository exploration through a terminal interface. Supports multi-file edits, git operations, and MCP tool integration.
+
+## Supported backends
+
+| Backend | Description |
+|---------|-------------|
+| Anthropic API | Direct access via API key |
+| Google Vertex AI | GCP-managed Claude endpoints |
+| vLLM | Self-hosted OpenAI-compatible model serving |
+| vLLM via OGX | vLLM routed through an OGX gateway |
+
+## Key features
+
+- Interactive terminal-based coding assistant
+- Multi-file code generation and refactoring
+- Git-aware operations (commit, diff, blame)
+- MCP server integration for extended tool use
+- MLflow tracing support for observability
+
+## Deployment
+
+For full deployment instructions, see the [deployment guide](../../README.md).

--- a/agents/openclaw/templates/openclaw_agent/README.md
+++ b/agents/openclaw/templates/openclaw_agent/README.md
@@ -1,0 +1,20 @@
+# OpenClaw
+
+## What this agent does
+
+Open-source AI coding assistant with gateway-based model routing and multi-channel support. OpenClaw provides a web-based interface for code generation, editing, and debugging tasks, routing requests through a configurable gateway to any OpenAI-compatible model endpoint.
+
+## Architecture
+
+OpenClaw runs as a single container with a built-in gateway on port 18789. It connects to any vLLM, KServe, or external API endpoint for model serving, and uses persistent storage for session data.
+
+## Key features
+
+- Web-based coding assistant interface
+- Gateway-based model routing to any OpenAI-compatible endpoint
+- Persistent storage for session and workspace data
+- Config-driven deployment (no API keys required by default)
+
+## Deployment
+
+For full deployment instructions, see the [deployment guide](../../deployment/README.md).

--- a/agents/openclaw/templates/openclaw_agent/README.md
+++ b/agents/openclaw/templates/openclaw_agent/README.md
@@ -2,18 +2,23 @@
 
 ## What this agent does
 
-Open-source AI coding assistant with gateway-based model routing and multi-channel support. OpenClaw provides a web-based interface for code generation, editing, and debugging tasks, routing requests through a configurable gateway to any OpenAI-compatible model endpoint.
+Open-source AI coding assistant built on [OpenClaw](https://github.com/openclaw/openclaw) with gateway-based model routing. Provides a web-based interface for code generation, editing, and debugging, routing requests through a built-in gateway to any OpenAI-compatible model endpoint.
 
-## Architecture
+## Supported backends
 
-OpenClaw runs as a single container with a built-in gateway on port 18789. It connects to any vLLM, KServe, or external API endpoint for model serving, and uses persistent storage for session data.
+| Backend | Description |
+|---------|-------------|
+| vLLM | Self-hosted OpenAI-compatible model serving |
+| vLLM via OGX | vLLM routed through an OGX gateway |
 
 ## Key features
 
-- Web-based coding assistant interface
+- Web-based coding assistant with built-in gateway (port 18789)
 - Gateway-based model routing to any OpenAI-compatible endpoint
 - Persistent storage for session and workspace data
-- Config-driven deployment (no API keys required by default)
+- Config-driven deployment via kustomize overlays
+- MLflow tracing support via OTel collector sidecar
+- OpenShell sandbox mode for experimentation
 
 ## Deployment
 

--- a/agents/opencode/templates/opencode_agent/README.md
+++ b/agents/opencode/templates/opencode_agent/README.md
@@ -2,15 +2,24 @@
 
 ## What this agent does
 
-AI-powered terminal-based coding agent built on [OpenCode](https://github.com/sst/opencode). Provides code generation, editing, and debugging through an interactive CLI. Uses any OpenAI-compatible API endpoint for model inference.
+AI-powered terminal-based coding agent built on [OpenCode](https://github.com/sst/opencode). Provides code generation, multi-file editing, code review, and debugging capabilities. Deploys in web mode (OAuth-secured browser UI) or headless CLI mode for terminal sessions and CI pipelines.
+
+## Supported backends
+
+| Backend | Description |
+|---------|-------------|
+| vLLM | Self-hosted OpenAI-compatible model serving |
+| vLLM via OGX | vLLM routed through an OGX gateway |
 
 ## Key features
 
-- Interactive terminal-based coding assistant
-- Code generation, editing, and debugging
-- Works with any OpenAI-compatible model endpoint (vLLM, OGX, external APIs)
-- Lightweight Node.js-based runtime
+- Two deployment modes: web (OAuth + browser UI) and CLI (headless, `oc exec`)
+- Works with any OpenAI-compatible model endpoint
+- Session persistence across pod restarts
+- MCP server integration for extended tool use
+- MLflow tracing support for observability
+- Enterprise-ready container image (UBI 9, non-root, restricted-v2 SCC)
 
 ## Deployment
 
-For full deployment instructions, see the [deployment guide](../../deployment/README.md).
+For full deployment instructions, see the [deployment guide](../../README.md).

--- a/agents/opencode/templates/opencode_agent/README.md
+++ b/agents/opencode/templates/opencode_agent/README.md
@@ -1,0 +1,16 @@
+# OpenCode
+
+## What this agent does
+
+AI-powered terminal-based coding agent built on [OpenCode](https://github.com/sst/opencode). Provides code generation, editing, and debugging through an interactive CLI. Uses any OpenAI-compatible API endpoint for model inference.
+
+## Key features
+
+- Interactive terminal-based coding assistant
+- Code generation, editing, and debugging
+- Works with any OpenAI-compatible model endpoint (vLLM, OGX, external APIs)
+- Lightweight Node.js-based runtime
+
+## Deployment
+
+For full deployment instructions, see the [deployment guide](../../deployment/README.md).


### PR DESCRIPTION
## Summary

- Add `README.md` files to each coding agent's template directory for the agent catalog
- Follows the same directory convention as existing agents (e.g., `agents/crewai/templates/websearch_agent/README.md`)
- Describes what each agent does, key features, and links to full deployment docs

## Files Added

| File | Agent |
|------|-------|
| `agents/claude-code/templates/claude_code_agent/README.md` | Claude Code |
| `agents/openclaw/templates/openclaw_agent/README.md` | OpenClaw |
| `agents/opencode/templates/opencode_agent/README.md` | OpenCode |

## Context

Follow-up from discussion in `#forum-aaiet-tooling-experience` — the agent catalog needs a `README.md` in the same directory as `agent.yaml` to display on the agent page. The existing READMEs for coding harnesses are deployment-focused and live in different directories, so these new files provide brief catalog-friendly descriptions.

Related: opendatahub-io/model-metadata-collection#174

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope