### PR TITLE
feat(opencode): add optional SMALL_MODEL_NAME env var

### DIFF
--- a/agents/opencode/deployment/manifests/config-template.json
+++ b/agents/opencode/deployment/manifests/config-template.json
@@ -29,6 +29,6 @@
     }
   },
   "model": "${MODEL_NAME}",
-  "small_model": "${MODEL_NAME}",
+  "small_model": "${SMALL_MODEL_NAME}",
   "enabled_providers": ["vllm", "ogx"]
 }

--- a/agents/opencode/deployment/manifests/entrypoint.sh
+++ b/agents/opencode/deployment/manifests/entrypoint.sh
@@ -109,6 +109,9 @@ if ! grep -q "^\.opencode$" .gitignore 2>/dev/null; then
     echo ".opencode" >> .gitignore
 fi
 
+# Default SMALL_MODEL_NAME to MODEL_NAME if not set
+export SMALL_MODEL_NAME="${SMALL_MODEL_NAME:-$MODEL_NAME}"
+
 # Build OpenCode config from template (jq-based envsubst — replaces ${VAR}
 # placeholders with matching environment variables, safely handling special chars)
 CONFIG=$(jq '


### PR DESCRIPTION
## Summary

- Add `${SMALL_MODEL_NAME}` placeholder to `config-template.json` for the `small_model` field
- Default `SMALL_MODEL_NAME` to `MODEL_NAME` in the entrypoint when not set
- Allows users to configure a lighter model for summarization, commit messages, and other quick tasks while keeping the primary model for coding and reasoning

## Test plan

- [ ] Deploy without `SMALL_MODEL_NAME` set — verify `small_model` defaults to `MODEL_NAME` in the generated config
- [ ] Deploy with `SMALL_MODEL_NAME` set to a different model — verify `small_model` reflects the override
- [ ] Run opencode tasks and verify the model responds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)