### PR TITLE
fix(opencode): register small model in provider model list when set

### DIFF
--- a/agents/opencode/README.md
+++ b/agents/opencode/README.md
@@ -79,6 +79,8 @@ deployment/overlays/mlflow-tracing/  # Overlay: MLflow tracing integration
 
 Edit `manifests/kustomization.yaml` to configure the model endpoint, API key, model name, and storage class. Apply overlays with `oc apply -k overlays/<mode>`.
 
+To use a lighter model for summarization, commit messages, and other quick tasks, set `SMALL_MODEL_NAME` in the deployment environment. If not set, it defaults to `MODEL_NAME`. Both models must be reachable through the configured provider endpoint.
+
 ## Extending OpenCode at startup
 
 - **MCP servers** — Inject MCP server configuration at startup via ConfigMap (`opencode-web-mcp`), extending the agent with additional tools without rebuilding the image.

--- a/agents/opencode/deployment/manifests/entrypoint.sh
+++ b/agents/opencode/deployment/manifests/entrypoint.sh
@@ -126,13 +126,20 @@ CONFIG=$(jq '
   )
 ' /config-template/config-template.json)
 
+# Register small model in provider model lists if different from primary
+if [ -n "${SMALL_MODEL_NAME:-}" ] && [ "$SMALL_MODEL_NAME" != "$MODEL_NAME" ]; then
+    CONFIG=$(echo "$CONFIG" | jq --arg sm "$SMALL_MODEL_NAME" '
+      .provider[].models[$sm] = {name: $sm}
+    ')
+fi
+
 # Merge MCP config if mounted
 if [ -f /mcp-config/mcp-servers.json ]; then
   MCP_SERVERS=$(cat /mcp-config/mcp-servers.json)
   CONFIG=$(echo "$CONFIG" | jq --argjson mcp "$MCP_SERVERS" '. + {mcp: $mcp}')
 fi
 
-unset API_KEY BASE_URL MODEL_NAME
+unset API_KEY BASE_URL MODEL_NAME SMALL_MODEL_NAME
 
 MODE="${OPENCODE_MODE:-web}"
 


### PR DESCRIPTION
## Summary

- Conditionally register `SMALL_MODEL_NAME` in provider model lists when it differs from `MODEL_NAME`, so OpenCode can resolve both models
- Add `SMALL_MODEL_NAME` to env var cleanup after config generation
- Add `SMALL_MODEL_NAME` documentation to the top-level OpenCode README

## Test plan

- [ ] Deploy without `SMALL_MODEL_NAME` set — verify `small_model` defaults to `MODEL_NAME` and only one model appears in the provider models list
- [ ] Deploy with `SMALL_MODEL_NAME` set to a different model — verify both models appear in the provider models list
- [ ] Run opencode tasks and verify the model responds correctly in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)