### PR TITLE
feat(google-adk): add OpenShell sandbox integration

### DIFF
--- a/agents/google/templates/adk/Containerfile.openshell
+++ b/agents/google/templates/adk/Containerfile.openshell
@@ -3,7 +3,8 @@
 # BYOC (Bring Your Own Container) image following the OpenShell pattern:
 # https://github.com/NVIDIA/OpenShell/tree/main/examples/bring-your-own-container
 #
-# Build:
+# Build (copy repo-level images/ into context first):
+#   cp -r ../../../../images ./images && trap 'rm -rf ./images' EXIT
 #   podman build --platform linux/amd64 -t adk-sandbox:latest -f Containerfile.openshell .
 #
 # Run (OpenShell replaces CMD -- pass the start command after --):
@@ -29,11 +30,12 @@ WORKDIR /sandbox
 # Install Python dependencies using the image's Python 3.12
 COPY --chown=1001:0 pyproject.toml .
 COPY --chown=1001:0 src/ ./src/
-RUN uv pip install --python /opt/app-root/bin/python3 --no-cache "."
+RUN uv pip install --python /opt/app-root/bin/python3 --no-cache ".[tracing]"
 
-# Application code
+# Application code and assets
 COPY --chown=1001:0 main.py .
 COPY --chown=1001:0 playground/ ./playground/
+COPY --chown=1001:0 images/ ./images/
 
 USER 1001
 

--- a/agents/google/templates/adk/Containerfile.openshell
+++ b/agents/google/templates/adk/Containerfile.openshell
@@ -1,0 +1,48 @@
+# Google ADK agent for NVIDIA OpenShell sandbox
+#
+# BYOC (Bring Your Own Container) image following the OpenShell pattern:
+# https://github.com/NVIDIA/OpenShell/tree/main/examples/bring-your-own-container
+#
+# Build:
+#   podman build --platform linux/amd64 -t adk-sandbox:latest -f Containerfile.openshell .
+#
+# Run (OpenShell replaces CMD -- pass the start command after --):
+#   openshell sandbox create --from adk-sandbox:latest --forward 8080 \
+#     -e API_KEY=<key> -e BASE_URL=<url> -e MODEL_ID=<model> \
+#     -- uvicorn main:app --host 0.0.0.0 --port 8080
+
+FROM registry.access.redhat.com/ubi9/python-312:latest
+
+USER 0
+
+# iproute: required by OpenShell for network namespace management
+# nftables: optional, enables bypass detection (log + reject for direct connections)
+RUN dnf install -y --nodocs iproute nftables && dnf clean all && rm -rf /var/cache/dnf
+
+# uv for fast dependency installation
+COPY --from=ghcr.io/astral-sh/uv@sha256:fc93e9ecd7218e9ec8fba117af89348eef8fd2463c50c13347478769aaedd0ce /uv /usr/local/bin/uv
+
+# Application directory (OpenShell convention: /sandbox)
+RUN install -d -o 1001 -g 0 -m 775 /sandbox
+WORKDIR /sandbox
+
+# Install Python dependencies using the image's Python 3.12
+COPY --chown=1001:0 pyproject.toml .
+COPY --chown=1001:0 src/ ./src/
+RUN uv pip install --python /opt/app-root/bin/python3 --no-cache "."
+
+# Application code
+COPY --chown=1001:0 main.py .
+COPY --chown=1001:0 playground/ ./playground/
+
+USER 1001
+
+ENV PORT=8080 \
+    PYTHONPATH=/sandbox \
+    PATH="/opt/app-root/bin:${PATH}"
+
+EXPOSE 8080
+
+# NOTE: OpenShell's sandbox supervisor replaces CMD at runtime.
+# Pass the start command explicitly on the CLI after --.
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/agents/google/templates/adk/Containerfile.openshell
+++ b/agents/google/templates/adk/Containerfile.openshell
@@ -12,7 +12,7 @@
 #     -e API_KEY=<key> -e BASE_URL=<url> -e MODEL_ID=<model> \
 #     -- uvicorn main:app --host 0.0.0.0 --port 8080
 
-FROM registry.access.redhat.com/ubi9/python-312:latest
+FROM registry.access.redhat.com/ubi9/python-312@sha256:e95978812895b9abb2bdc109b501078da2a47c8dbb9fa23758af40ed50ab6023
 
 USER 0
 

--- a/agents/google/templates/adk/OPENSHELL.md
+++ b/agents/google/templates/adk/OPENSHELL.md
@@ -41,6 +41,7 @@ openshell sandbox create \
 ```
 
 Flags:
+
 - `--forward 8080` opens an SSH tunnel so `localhost:8080` on your machine reaches the agent inside the sandbox
 - `-e` injects environment variables via OpenShell providers (never written to disk)
 - `-- <command>` is the process the supervisor executes via SSH once the sandbox is ready

--- a/agents/google/templates/adk/OPENSHELL.md
+++ b/agents/google/templates/adk/OPENSHELL.md
@@ -14,6 +14,11 @@ This follows the [Bring Your Own Container](https://github.com/NVIDIA/OpenShell/
 
 ```bash
 cd agents/google/templates/adk
+
+# Copy repo-level images into build context (playground UI assets)
+cp -r ../../../../images ./images
+trap 'rm -rf ./images' EXIT
+
 podman build --platform linux/amd64 -t quay.io/<your-org>/adk-sandbox:latest -f Containerfile.openshell .
 podman push quay.io/<your-org>/adk-sandbox:latest
 ```

--- a/agents/google/templates/adk/OPENSHELL.md
+++ b/agents/google/templates/adk/OPENSHELL.md
@@ -1,0 +1,99 @@
+# Google ADK Agent — OpenShell Sandbox Deployment
+
+Run the Google ADK 2.0 agent inside an [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) sandbox with policy-enforced network isolation and filesystem constraints.
+
+This follows the [Bring Your Own Container](https://github.com/NVIDIA/OpenShell/tree/main/examples/bring-your-own-container) pattern: a standard Linux container image with no OpenShell-specific dependencies.
+
+## Prerequisites
+
+- [Podman](https://podman.io/) or Docker installed
+- [OpenShell CLI](https://github.com/NVIDIA/OpenShell) installed and connected to a gateway
+- An OGX-compatible inference endpoint reachable from the sandbox (vLLM, Ollama, or remote API)
+
+## Build
+
+```bash
+cd agents/google/templates/adk
+podman build --platform linux/amd64 -t quay.io/<your-org>/adk-sandbox:latest -f Containerfile.openshell .
+podman push quay.io/<your-org>/adk-sandbox:latest
+```
+
+Ensure the quay.io repository is public so the cluster can pull without imagePullSecrets.
+
+## Run
+
+OpenShell's sandbox supervisor replaces the image's CMD/ENTRYPOINT at runtime. You **must** pass the application start command explicitly after `--`:
+
+```bash
+openshell sandbox create \
+  --name adk-agent \
+  --from quay.io/<your-org>/adk-sandbox:latest \
+  --forward 8080 \
+  -e API_KEY=not-needed-for-local \
+  -e BASE_URL=http://vllm-svc.my-ns.svc.cluster.local:8000/v1 \
+  -e MODEL_ID=llama3.1:8b \
+  -- uvicorn main:app --host 0.0.0.0 --port 8080
+```
+
+Flags:
+- `--forward 8080` opens an SSH tunnel so `localhost:8080` on your machine reaches the agent inside the sandbox
+- `-e` injects environment variables via OpenShell providers (never written to disk)
+- `-- <command>` is the process the supervisor executes via SSH once the sandbox is ready
+
+## Verify
+
+```bash
+# Health check (should return {"status": "healthy", "agent_initialized": true})
+curl -s http://localhost:8080/health | python3 -m json.tool
+
+# Chat completion
+curl -s -X POST http://localhost:8080/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"role":"user","content":"What is OpenShift?"}],"stream":false}' \
+  | python3 -m json.tool
+```
+
+## Network Policy
+
+The ADK agent only needs outbound access to the configured LLM endpoint. Apply a restrictive policy:
+
+```yaml
+sandbox:
+  network:
+    egress:
+      - host: "vllm-svc.my-ns.svc.cluster.local"
+        port: 8000
+        methods: ["POST"]
+        paths:
+          - "/v1/chat/completions"
+          - "/v1/completions"
+```
+
+```bash
+openshell policy set adk-agent --policy policy.yaml --wait
+```
+
+## Cleanup
+
+```bash
+openshell sandbox delete adk-agent
+```
+
+## How It Works
+
+OpenShell isolates the sandbox container and routes all outbound traffic through its policy engine. The ADK agent runs as a normal FastAPI/uvicorn process inside the container — no code changes required. The key differences from a standard Helm deployment:
+
+| Aspect | Standard (Helm) | OpenShell Sandbox |
+|--------|----------------|-------------------|
+| Base image | UBI9 Python 3.12 | Same (UBI9 Python 3.12) |
+| Network isolation | K8s NetworkPolicy | OpenShell L7 policy engine |
+| Credential injection | Helm secrets / env vars | OpenShell providers (`-e` flags) |
+| Process supervision | Container runtime PID 1 | OpenShell supervisor via SSH |
+| Start command | Dockerfile CMD | Explicit `-- <command>` |
+
+## Notes
+
+- The ADK agent is a long-running FastAPI server. Unlike CLI agents (Claude Code, Codex), it does not need interactive terminal access.
+- `BASE_URL` must be reachable from within the sandbox. Use cluster-internal DNS for in-cluster endpoints.
+- If the model endpoint is unreachable, `/health` still returns healthy but `/chat/completions` will fail with a 500.
+- Build with `--platform linux/amd64` when targeting x86_64 clusters from Apple Silicon machines.


### PR DESCRIPTION
## Summary

- Add `Containerfile.openshell` for running the Google ADK agent inside an NVIDIA OpenShell sandbox
- Add `OPENSHELL.md` with build/run instructions, network policy configuration, and testing guide

Follows the official [BYOC pattern](https://github.com/NVIDIA/OpenShell/tree/main/examples/bring-your-own-container) from NVIDIA/OpenShell.

## Motivation

All other sandboxed agent deployments in this repo (Claude Code, Codex, OpenCode, OpenClaw) already have `Containerfile.openshell` files. The Google ADK agent currently deploys only as a standard FastAPI service via Helm. Adding OpenShell support enables:

- **Security isolation**: Sandboxed execution with Landlock filesystem policies and L7 network enforcement
- **Credential management**: API keys injected via OpenShell providers (never written to disk)
- **Egress control**: Only the configured LLM endpoint is reachable from within the sandbox

## Key Design Decisions

- Uses UBI9/python-312 base (same as the standard ADK Dockerfile) rather than `openshell-base` since ADK is a Python service
- Installs `iproute` + `nftables` for network namespace isolation and bypass detection
- No baked-in sandbox user (OpenShell compute driver injects UID at runtime per BYOC docs)
- `/sandbox` workdir follows OpenShell convention
- CMD documents the start command but is replaced by the supervisor at runtime

## Test plan

Tested on OpenShift 4.18 cluster with OpenShell v0.0.80 gateway:

- [x] Image builds successfully via `oc start-build` (95 packages installed)
- [x] Agent starts: `/health` returns `{"status":"healthy","agent_initialized":true}`
- [x] End-to-end chat completion with `gemini/models/gemini-2.5-flash` via Llama Stack endpoint:
  - Agent called `dummy_web_search` tool
  - Generated final answer from tool result
  - Full response: `"Red Hat OpenShift is a comprehensive platform for building, deploying, and managing applications in a hybrid cloud environment."`