### PR TITLE
fix(ci): correct stale version comments and sync pre-commit markdownlint

### DIFF
--- a/.github/workflows/ci-health-pages.yml
+++ b/.github/workflows/ci-health-pages.yml
@@ -56,12 +56,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v5.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -38,7 +38,7 @@ jobs:
         run: ruff format --check .
 
       - name: Markdownlint
-        # v24.0.0 bundles markdownlint-cli2 0.23.0 — keep in sync with .pre-commit-config.yaml
+        # v24.1.0 bundles markdownlint-cli2 0.23.1 — keep in sync with .pre-commit-config.yaml
         uses: DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe  # v24.1.0
         with:
           globs: "**/*.md"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
   # Markdownlint — Markdown linting
   # Rules are defined in .markdownlint.jsonc at the repo root
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.23.0
+    rev: v0.23.1
     hooks:
       - id: markdownlint-cli2
         args: [--fix]


### PR DESCRIPTION
## Summary
- Fix stale version comments in `ci-health-pages.yml` that drifted from their pinned SHAs (`actions/checkout` said `v4.2.2` → corrected to `v7.0.1`, `actions/setup-python` said `v5.3.0` → corrected to `v7.0.0`)
- Update `markdownlint-cli2-action` comment in `code-quality.yml` to reflect v24.1.0 / markdownlint-cli2 0.23.1
- Bump `markdownlint-cli2` pre-commit hook from `v0.23.0` → `v0.23.1` to stay in sync with CI

Follow-up from Dependabot PRs:
- #273 — bump actions/checkout from 7.0.0 to 7.0.1
- #274 — bump markdownlint-cli2-action from 24.0.0 to 24.1.0
- #275 — bump actions/setup-python from 6.3.0 to 7.0.0

## Test plan
- [x] `pre-commit run markdownlint-cli2 --all-files` passes with v0.23.1
- [x] All pre-commit hooks pass on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)