### PR TITLE
fix(ci): resolve Langflow QG4 route wiring failure (RHAIENG-6284)

### DIFF
--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -82,6 +82,8 @@ jobs:
             MODEL_ID: ${{ vars.OPENAI_MODEL_ID }}
           - agent: { name: a2a-langgraph-crewai, dir: agents/a2a/templates/langgraph_crewai_agent }
             CONTAINER_IMAGE: ${{ vars.CONTAINER_IMAGE_A2A_LANGGRAPH_CREWAI }}
+          - agent: { name: langflow-simple-tool-calling-agent, dir: agents/langflow/templates/simple_tool_calling_agent }
+            DEPLOYED_AGENT_URL: ${{ vars.LANGFLOW_DEPLOYED_AGENT_URL }}
     env:
       API_KEY: ${{ vars.API_KEY }}
       BASE_URL: ${{ vars.BASE_URL }}
@@ -110,6 +112,7 @@ jobs:
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           MCP_SERVER_URL: ${{ matrix.MCP_SERVER_URL }}
           CONTAINER_IMAGE: ${{ matrix.CONTAINER_IMAGE }}
+          DEPLOYED_AGENT_URL: ${{ matrix.DEPLOYED_AGENT_URL }}
         run: make test-integration
 
       - name: Upload test results

--- a/agents/langflow/templates/simple_tool_calling_agent/tests/integration/conftest.py
+++ b/agents/langflow/templates/simple_tool_calling_agent/tests/integration/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 
 import pytest
 from integration.conftest import cluster_auth, repo_root  # noqa: F401
@@ -26,6 +27,14 @@ def agent_name(agent_dir):
 
 @pytest.fixture(scope="module")
 def deployed_agent(cluster_auth, agent_name):  # noqa: F811
+    # Allow a direct URL override for pre-deployed agents whose route lives
+    # in a namespace the CI service account cannot read (e.g. langflow-agent).
+    override_url = os.environ.get("DEPLOYED_AGENT_URL", "").strip()
+    if override_url:
+        logger.info("Using DEPLOYED_AGENT_URL override: %s", override_url)
+        yield override_url
+        return
+
     namespace = cluster_auth["namespace"]
     try:
         route_url = get_route(agent_name, namespace=namespace)


### PR DESCRIPTION
## Summary

- Adds `DEPLOYED_AGENT_URL` env-var override to the Langflow pre-deployed test fixture, bypassing `oc get route` when the route lives in a namespace the CI service account cannot reach
- Wires the new variable through the CI workflow matrix via `vars.LANGFLOW_DEPLOYED_AGENT_URL` (already set in repo settings)
- No changes to shared test infrastructure or other agents

### Root cause

The nightly QG4 `langflow-simple-tool-calling-agent` job fails because:
1. The fixture looks for route `langflow-simple-tool-calling-agent` in `ci-testing`
2. The actual Langflow instance is route `langflow` in namespace `langflow-agent`
3. The CI SA (`system:serviceaccount:ci-testing:github-actions`) lacks RBAC to read routes in `langflow-agent`

Since the Langflow endpoint is publicly accessible, we pass the URL directly via a GitHub Actions variable, skipping the route lookup entirely.

### Files changed

| File | Change |
|---|---|
| `agents/langflow/.../conftest.py` | Check `DEPLOYED_AGENT_URL` env var before falling back to `oc get route` |
| `.github/workflows/agent-deployment-test.yaml` | Add `DEPLOYED_AGENT_URL` to langflow `include:` block and test step env |

### Relation to RHAIENG-6228

This is a bridge fix. [RHAIENG-6228](https://redhat.atlassian.net/browse/RHAIENG-6228) will add full OpenShift deployment support for Langflow (deploying into `ci-testing`), at which point the `DEPLOYED_AGENT_URL` override can be removed and the standard `oc get route` flow will work.

## Test plan

- [x] `make test-integration` passes locally with `DEPLOYED_AGENT_URL` set to the live Langflow endpoint
- [x] Health check returns `{"status":"ok","chat":"ok","db":"ok"}`
- [x] `LANGFLOW_DEPLOYED_AGENT_URL` GitHub Actions variable set in repo settings
- [ ] Nightly CI run passes on demo cluster (post-merge)

Fixes: [RHAIENG-6284](https://redhat.atlassian.net/browse/RHAIENG-6284)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHAIENG-6228]: https://redhat.atlassian.net/browse/RHAIENG-6228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ