### PR TITLE
fix(ci): resolve Langflow QG4 route wiring failure (RHAIENG-6284)

### DIFF
--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -80,6 +80,8 @@ jobs:
           - agent: { name: vanilla-python-openai-responses-agent, dir: agents/vanilla_python/templates/openai_responses_agent }
             BASE_URL: ${{ vars.OPENAI_BASE_URL }}
             MODEL_ID: ${{ vars.OPENAI_MODEL_ID }}
+          - agent: { name: langflow-simple-tool-calling-agent, dir: agents/langflow/templates/simple_tool_calling_agent }
+            LANGFLOW_AGENT_URL: ${{ vars.LANGFLOW_AGENT_URL }}
     env:
       API_KEY: ${{ vars.API_KEY }}
       BASE_URL: ${{ vars.BASE_URL }}
@@ -107,6 +109,7 @@ jobs:
           POSTGRES_USER: ${{ matrix.POSTGRES_USER }}
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           MCP_SERVER_URL: ${{ matrix.MCP_SERVER_URL }}
+          LANGFLOW_AGENT_URL: ${{ matrix.LANGFLOW_AGENT_URL }}
         run: make test-integration
 
       - name: Upload test results

--- a/agents/langflow/templates/simple_tool_calling_agent/tests/integration/conftest.py
+++ b/agents/langflow/templates/simple_tool_calling_agent/tests/integration/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 
 import pytest
 from integration.conftest import cluster_auth, repo_root  # noqa: F401
@@ -26,6 +27,14 @@ def agent_name(agent_dir):
 
 @pytest.fixture(scope="module")
 def deployed_agent(cluster_auth, agent_name):  # noqa: F811
+    # Allow a direct URL override for pre-deployed agents whose route lives
+    # in a namespace the CI service account cannot read (e.g. langflow-agent).
+    override_url = os.environ.get("DEPLOYED_AGENT_URL", "").strip()
+    if override_url:
+        logger.info("Using DEPLOYED_AGENT_URL override: %s", override_url)
+        yield override_url
+        return
+
     namespace = cluster_auth["namespace"]
     try:
         route_url = get_route(agent_name, namespace=namespace)

--- a/agents/langflow/templates/simple_tool_calling_agent/tests/integration/conftest.py
+++ b/agents/langflow/templates/simple_tool_calling_agent/tests/integration/conftest.py
@@ -27,11 +27,13 @@ def agent_name(agent_dir):
 
 @pytest.fixture(scope="module")
 def deployed_agent(cluster_auth, agent_name):  # noqa: F811
-    # Allow a direct URL override for pre-deployed agents whose route lives
-    # in a namespace the CI service account cannot read (e.g. langflow-agent).
-    override_url = os.environ.get("DEPLOYED_AGENT_URL", "").strip()
+    # Allow a direct URL override when the Langflow route lives in a namespace
+    # the CI service account cannot read (e.g. langflow-agent).
+    override_url = os.environ.get("LANGFLOW_AGENT_URL", "").strip()
     if override_url:
-        logger.info("Using DEPLOYED_AGENT_URL override: %s", override_url)
+        if not override_url.startswith("https://"):
+            pytest.fail(f"LANGFLOW_AGENT_URL must use https://: {override_url}")
+        logger.info("Using LANGFLOW_AGENT_URL override: %s", override_url)
         yield override_url
         return
 

--- a/agents/langflow/templates/simple_tool_calling_agent/tests/integration/conftest.py
+++ b/agents/langflow/templates/simple_tool_calling_agent/tests/integration/conftest.py
@@ -15,6 +15,17 @@ from integration.utils import (
 logger = logging.getLogger(__name__)
 
 
+def resolve_langflow_url(agent_name: str, namespace: str) -> str:
+    """Return the Langflow agent URL from env override or route lookup."""
+    override_url = os.environ.get("LANGFLOW_AGENT_URL", "").strip()
+    if override_url:
+        if not override_url.startswith("https://"):
+            raise ValueError(f"LANGFLOW_AGENT_URL must use https://: {override_url}")
+        return override_url.rstrip("/").removesuffix("/health_check")
+
+    return get_route(agent_name, namespace=namespace)
+
+
 @pytest.fixture(scope="module")
 def agent_dir():
     return resolve_agent_dir(__file__)
@@ -27,23 +38,14 @@ def agent_name(agent_dir):
 
 @pytest.fixture(scope="module")
 def deployed_agent(cluster_auth, agent_name):  # noqa: F811
-    # Allow a direct URL override when the Langflow route lives in a namespace
-    # the CI service account cannot read (e.g. langflow-agent).
-    override_url = os.environ.get("LANGFLOW_AGENT_URL", "").strip()
-    if override_url:
-        if not override_url.startswith("https://"):
-            pytest.fail(f"LANGFLOW_AGENT_URL must use https://: {override_url}")
-        logger.info("Using LANGFLOW_AGENT_URL override: %s", override_url)
-        yield override_url
-        return
-
-    namespace = cluster_auth["namespace"]
     try:
-        route_url = get_route(agent_name, namespace=namespace)
+        route_url = resolve_langflow_url(agent_name, cluster_auth["namespace"])
+    except ValueError as exc:
+        pytest.fail(str(exc))
     except RouteNotFoundError as exc:
         pytest.fail(
             f"Pre-deployed agent route not found: {exc}. "
             "Ensure the agent is deployed before running integration tests."
         )
-    logger.info("Pre-deployed agent at %s", route_url)
+    logger.info("Langflow agent at %s", route_url)
     yield route_url

--- a/agents/langflow/templates/simple_tool_calling_agent/tests/integration/test_conftest.py
+++ b/agents/langflow/templates/simple_tool_calling_agent/tests/integration/test_conftest.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+from conftest import resolve_langflow_url
+
+
+class TestResolveLangflowUrl:
+    """Verify LANGFLOW_AGENT_URL override, validation, and fallback."""
+
+    def test_uses_override_when_set(self, monkeypatch):
+        monkeypatch.setenv("LANGFLOW_AGENT_URL", "https://langflow.example.com")
+        url = resolve_langflow_url("ignored", "ci-testing")
+        assert url == "https://langflow.example.com"
+
+    def test_strips_trailing_slash(self, monkeypatch):
+        monkeypatch.setenv("LANGFLOW_AGENT_URL", "https://langflow.example.com/")
+        url = resolve_langflow_url("ignored", "ci-testing")
+        assert url == "https://langflow.example.com"
+
+    def test_strips_trailing_health_check(self, monkeypatch):
+        monkeypatch.setenv(
+            "LANGFLOW_AGENT_URL", "https://langflow.example.com/health_check"
+        )
+        url = resolve_langflow_url("ignored", "ci-testing")
+        assert url == "https://langflow.example.com"
+
+    def test_rejects_http_scheme(self, monkeypatch):
+        monkeypatch.setenv("LANGFLOW_AGENT_URL", "http://langflow.example.com")
+        with pytest.raises(ValueError, match="must use https://"):
+            resolve_langflow_url("ignored", "ci-testing")
+
+    def test_falls_back_to_get_route(self, monkeypatch):
+        monkeypatch.delenv("LANGFLOW_AGENT_URL", raising=False)
+        monkeypatch.setattr(
+            "conftest.get_route",
+            lambda name, namespace: f"https://{name}.apps.example.com",
+        )
+        url = resolve_langflow_url("my-agent", "ci-testing")
+        assert url == "https://my-agent.apps.example.com"
+
+    def test_empty_var_falls_back_to_get_route(self, monkeypatch):
+        monkeypatch.setenv("LANGFLOW_AGENT_URL", "  ")
+        monkeypatch.setattr(
+            "conftest.get_route",
+            lambda name, namespace: f"https://{name}.apps.example.com",
+        )
+        url = resolve_langflow_url("my-agent", "ci-testing")
+        assert url == "https://my-agent.apps.example.com"

--- a/agents/langflow/templates/simple_tool_calling_agent/tests/integration/test_deployment.py
+++ b/agents/langflow/templates/simple_tool_calling_agent/tests/integration/test_deployment.py
@@ -8,3 +8,5 @@ from integration.utils import health_check
 def test_health_endpoint(deployed_agent):
     result = health_check(f"{deployed_agent}/health_check", retries=12, backoff=5.0)
     assert result["status"] == "ok"
+    assert result["chat"] == "ok"
+    assert result["db"] == "ok"


### PR DESCRIPTION
## Summary

- Adds `LANGFLOW_AGENT_URL` env-var override to the Langflow pre-deployed test fixture, bypassing `oc get route` when the route lives in a namespace the CI service account cannot reach
- Validates the URL scheme (must be `https://`)
- Asserts all three health check fields (`status`, `chat`, `db`) instead of just `status`
- Wires the new variable through the CI workflow matrix via `vars.LANGFLOW_AGENT_URL` (already set in repo settings)
- No changes to shared test infrastructure or other agents

### Root cause

The nightly QG4 `langflow-simple-tool-calling-agent` job fails because:
1. The fixture looks for route `langflow-simple-tool-calling-agent` in `ci-testing`
2. The actual Langflow instance is route `langflow` in namespace `langflow-agent`
3. The CI SA (`system:serviceaccount:ci-testing:github-actions`) lacks RBAC to read routes in `langflow-agent`

Since the Langflow endpoint is publicly accessible, we pass the URL directly via a GitHub Actions variable, skipping the route lookup entirely.

### Files changed

| File | Change |
|---|---|
| `agents/langflow/.../conftest.py` | Check `LANGFLOW_AGENT_URL` env var (with https:// validation) before falling back to `oc get route` |
| `agents/langflow/.../test_deployment.py` | Assert `chat` and `db` fields alongside `status` |
| `.github/workflows/agent-deployment-test.yaml` | Add `LANGFLOW_AGENT_URL` to langflow `include:` block and test step env |

### Relation to RHAIENG-6228

This is a bridge fix. [RHAIENG-6228](https://redhat.atlassian.net/browse/RHAIENG-6228) will add full OpenShift deployment support for Langflow (deploying into `ci-testing`), at which point the `LANGFLOW_AGENT_URL` override can be removed and the standard `oc get route` flow will work.

## Test plan

- [x] `make test-integration` passes locally with `LANGFLOW_AGENT_URL` set to the live Langflow endpoint
- [x] Health check returns `{"status":"ok","chat":"ok","db":"ok"}` — all three fields asserted
- [x] `LANGFLOW_AGENT_URL` GitHub Actions variable set in repo settings
- [x] Integration test passes against live cluster
- [ ] Nightly CI run passes on demo cluster (post-merge)

Fixes: [RHAIENG-6284](https://redhat.atlassian.net/browse/RHAIENG-6284)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHAIENG-6228]: https://redhat.atlassian.net/browse/RHAIENG-6228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ