### PR TITLE
fix(guardrails): add logo and fix labels in agent.yaml (RHAIENG-6680)

### DIFF
--- a/agents/langgraph/examples/guardrailed_agent/agent.yaml
+++ b/agents/langgraph/examples/guardrailed_agent/agent.yaml
@@ -1,17 +1,9 @@
 name: langgraph-guardrailed-agent
 displayName: "LangGraph Guardrailed Agent"
 framework: langgraph
-description: >
-  Banking customer service agent with NeMo Guardrails safety layer.
-  Demonstrates content safety rails (input + output), topical guardrails
-  (banking domain boundary), and regex-based input filtering using the
-  NeMo Guardrails proxy pattern. Built on the LangGraph ReAct agent template.
-labels:
-  - guardrails
-  - nemo-guardrails
-  - safety
-  - customer-service
-  - react
+description: "Banking customer service agent with NeMo Guardrails safety layer. Demonstrates content safety, topical guardrails, and regex filtering using the proxy pattern."
+labels: ["guardrails", "nemo-guardrails", "safety", "tool-calling", "react"]
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiMxQzNDM0MiLz4KICA8cGF0aCBkPSJNMzIgMTJjLTMgMC01LjUgMS41LTcgNGwtMiAzLjVjLTEgMS44LS41IDQgMSA1LjJsMS41IDEuMmMtLjUgMS41LS4yIDMuMi44IDQuNWwtNCA3Yy0xLjUgMi42LS41IDYgMiA3LjVsNSAzYzIuNSAxLjUgNS41LjggNy4yLTEuNWw2LTguNWMxLjUtMiAxLjUtNC44IDAtNi44bC0yLTIuOGMuOC0xLjUuOC0zLjUtLjItNUwzOCAxOWMtMS0xLjUtMS0zLjUgMC01LS41LTEuMi0yLjUtMi00LTJoLTJ6IiBmaWxsPSIjNEFERTgwIi8+CiAgPGNpcmNsZSBjeD0iMzAiIGN5PSIyMCIgcj0iMS41IiBmaWxsPSIjMUMzQzNDIi8+CiAgPHBhdGggZD0iTTIyIDQwbDMgNmMuNSAxIDEuOCAxLjUgMi44IDFsMi0xIiBzdHJva2U9IiM0QURFODAiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+Cjwvc3ZnPg=="
 env:
   required:
     - API_KEY


### PR DESCRIPTION
## Summary

- Add base64 SVG logo (LangGraph framework logo, same as other langgraph agents)
- Update labels to inline array format with `tool-calling` tag for consistency
- Required by the RHOAI dashboard catalog backend and pre-release manifest generation workflow (RHAIENG-5072)

## Test plan

- [ ] `agent.yaml` passes YAML validation
- [ ] All required fields present: `name`, `displayName`, `framework`, `description`, `labels`, `logo`, `env`
- [ ] Pre-release workflow discovers this agent via `agents/**/agent.yaml` scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)