### PR TITLE
docs(guardrails): add custom rail walkthrough and production notes (RHAIENG-6265)

### DIFF
--- a/agents/langgraph/examples/guardrailed_agent/README.md
+++ b/agents/langgraph/examples/guardrailed_agent/README.md
@@ -121,7 +121,7 @@ The banking domain is defined in four places. To adapt this example to healthcar
 
 Optionally, replace the `check_account_balance` tool in `src/guardrailed_agent/tools.py` with a domain-relevant tool. Content safety rails (S1-S13) and regex patterns are domain-agnostic and typically don't need changes.
 
-After editing, restart `make guardrails-server-local` (or `nemoguard`) and `make run-app`, then test with on-topic and off-topic requests to verify the new boundary.
+After editing, restart `make guardrails-server-local` or `make guardrails-server-nemoguard`, then restart `make run-app`. Test with on-topic and off-topic requests to verify the new boundary.
 
 ---
 

--- a/agents/langgraph/examples/guardrailed_agent/README.md
+++ b/agents/langgraph/examples/guardrailed_agent/README.md
@@ -108,6 +108,21 @@ TOPIC_CONTROL_MODEL_ENGINE=nim
 
 Verified end-to-end on 2026-07-30: correctly passes banking questions and blocks off-topic ones (e.g. recipe requests) using the default policy text baked into `generate_config.py`. Override the policy text with `TOPIC_CONTROL_CUSTOM_POLICY` in `.env`.
 
+### Adapting to a different domain
+
+The banking domain is defined in four places. To adapt this example to healthcare, telecom, or any other domain:
+
+| File | What to change |
+|------|---------------|
+| `guardrails/config/nemoguard/prompts.yml` | Replace the banking guidelines in the `topic_safety_check_input` task with your domain's allowed/disallowed topics |
+| `guardrails/config/local/prompts.yml` | Update the `self_check_input` policy — change "banking and financial services" to your domain |
+| `guardrails/generate_config.py` | Update `_DEFAULT_TOPIC_CONTROL_POLICY` (used by NIM custom-policy models in the nemoguard profile) |
+| `src/guardrailed_agent/agent.py` | Change the system prompt from banking to your domain |
+
+Optionally, replace the `check_account_balance` tool in `src/guardrailed_agent/tools.py` with a domain-relevant tool. Content safety rails (S1-S13) and regex patterns are domain-agnostic and typically don't need changes.
+
+After editing, restart `make guardrails-server-local` (or `nemoguard`) and `make run-app`, then test with on-topic and off-topic requests to verify the new boundary.
+
 ---
 
 ## Prerequisites

--- a/agents/langgraph/examples/guardrailed_agent/agent.yaml
+++ b/agents/langgraph/examples/guardrailed_agent/agent.yaml
@@ -1,17 +1,9 @@
 name: langgraph-guardrailed-agent
 displayName: "LangGraph Guardrailed Agent"
 framework: langgraph
-description: >
-  Banking customer service agent with NeMo Guardrails safety layer.
-  Demonstrates content safety rails (input + output), topical guardrails
-  (banking domain boundary), and regex-based input filtering using the
-  NeMo Guardrails proxy pattern. Built on the LangGraph ReAct agent template.
-labels:
-  - guardrails
-  - nemo-guardrails
-  - safety
-  - customer-service
-  - react
+description: "Banking customer service agent with NeMo Guardrails safety layer. Demonstrates content safety, topical guardrails, and regex filtering using the proxy pattern."
+labels: ["guardrails", "nemo-guardrails", "safety", "tool-calling", "react"]
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiMxQzNDM0MiLz4KICA8cGF0aCBkPSJNMzIgMTJjLTMgMC01LjUgMS41LTcgNGwtMiAzLjVjLTEgMS44LS41IDQgMSA1LjJsMS41IDEuMmMtLjUgMS41LS4yIDMuMi44IDQuNWwtNCA3Yy0xLjUgMi42LS41IDYgMiA3LjVsNSAzYzIuNSAxLjUgNS41LjggNy4yLTEuNWw2LTguNWMxLjUtMiAxLjUtNC44IDAtNi44bC0yLTIuOGMuOC0xLjUuOC0zLjUtLjItNUwzOCAxOWMtMS0xLjUtMS0zLjUgMC01LS41LTEuMi0yLjUtMi00LTJoLTJ6IiBmaWxsPSIjNEFERTgwIi8+CiAgPGNpcmNsZSBjeD0iMzAiIGN5PSIyMCIgcj0iMS41IiBmaWxsPSIjMUMzQzNDIi8+CiAgPHBhdGggZD0iTTIyIDQwbDMgNmMuNSAxIDEuOCAxLjUgMi44IDFsMi0xIiBzdHJva2U9IiM0QURFODAiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+Cjwvc3ZnPg=="
 env:
   required:
     - API_KEY


### PR DESCRIPTION
## Summary

- Add "Adapting to a different domain" section with table of files to edit when changing the guardrailed agent to a new domain (healthcare, telecom, etc.)
- Add `logo` field and normalize `labels` in `agent.yaml` for RHOAI dashboard catalog backend (RHAIENG-6680)
- Fix incomplete make target name in domain adaptation instructions

## Test plan

- [x] `make test` — 86 unit tests pass
- [x] All file paths in the walkthrough point to files that exist
- [x] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)