### PR TITLE
fix(ci): increase lychee timeout and retries for slow redirects (RHAIENG-6706)

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -10,11 +10,11 @@ accept = ["200", "206", "301", "302", "308"]
 # Maximum number of concurrent network requests
 max_concurrency = 32
 
-# Timeout for each request (in seconds)
-timeout = 15
+# Timeout for each request (in seconds) — lychee default is 20
+timeout = 20
 
-# Number of retries for failed requests
-max_retries = 2
+# Number of retries for failed requests — lychee default is 3
+max_retries = 3
 
 # Retry wait time (in seconds)
 retry_wait_time = 2


### PR DESCRIPTION
## Summary

Fix intermittent `link-check` CI failures caused by `docs.openshift.com` URLs timing out during redirect to `docs.redhat.com`.

## Changes

Revert to lychee defaults — we were running below them:

- `timeout`: 15s → 20s (lychee default)
- `max_retries`: 2 → 3 (lychee default)

The `docs.openshift.com` → `docs.redhat.com` redirect chain (2-3 hops) can be slow under load. Per-host timeout isn't supported in lychee, but reverting to defaults provides enough headroom without inflating timeouts globally. Dead links still fail fast (connection refused is instant).

## Context

- [Failed run](https://github.com/red-hat-data-services/agentic-starter-kits/actions/runs/30644733027) — `docs.openshift.com` timeouts

## Test plan

- [x] `link-check` job passes on this PR
- [ ] Monitor next few push-to-main runs for stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)