### PR TITLE
fix(btest): detect per-agent MLflow experiment names in test runner (RHAIENG-6743)

### DIFF
--- a/tests/behavioral/deterministic/run-btests-pytest.sh
+++ b/tests/behavioral/deterministic/run-btests-pytest.sh
@@ -346,12 +346,18 @@ run_tests() {
 
     log "Launching: ${BOLD}${path}${RESET} -> ${logfile}"
 
+    # Detect per-agent experiment name from its deployment
+    local agent_experiment
+    agent_experiment=$(timeout 30 oc get deployment "${deploy}" -n "${NAMESPACE}" \
+      -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="MLFLOW_EXPERIMENT_NAME")].value}' 2>/dev/null || true)
+    agent_experiment="${agent_experiment:-${MLFLOW_EXPERIMENT_NAME:-}}"
+
     (
       set -euo pipefail
       cd "${REPO_ROOT}"
       export "${env_var}=${agent_url}"
       export MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI:-}"
-      export MLFLOW_EXPERIMENT_NAME="${MLFLOW_EXPERIMENT_NAME:-}"
+      export MLFLOW_EXPERIMENT_NAME="${agent_experiment}"
       export MLFLOW_TRACKING_TOKEN="${MLFLOW_TRACKING_TOKEN:-}"
       export MLFLOW_WORKSPACE="${MLFLOW_WORKSPACE:-}"
       export MLFLOW_TRACKING_INSECURE_TLS="true"


### PR DESCRIPTION
## Summary

- Fix `run-btests-pytest.sh` to detect per-agent `MLFLOW_EXPERIMENT_NAME` from each deployment instead of using a single global value

## Root Cause

All agents deployed to the same namespace shared `MLFLOW_EXPERIMENT_NAME=adonheis-testing`. The `MLflowTraceClient.get_latest_trace()` queries by `experiment_id` only — when multiple agents share an experiment, it returns the most recent trace from ANY agent, not the one being tested. This caused `tool_selection_accuracy` cross-contamination.

The test runner script (`run-btests-pytest.sh`) compounded the issue by detecting the experiment name from the first deployment and exporting it for all agents.

## Test plan

- [x] Deployed all 11 agents with per-agent experiment names (`adonheis-testing/<agent-name>`)
- [x] Verified `[Tracing Enabled]` with unique experiment names in all agent startup logs
- [x] Ran full btest suite: 188 passed, 16 failed — zero cross-contamination (all failures are agent behavior, not trace attribution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)