### PR TITLE
fix(ci): prune openshift build artifacts in ci-testing (RHAIENG-6183)

### DIFF
--- a/agents/a2a/templates/langgraph_crewai_agent/Makefile
+++ b/agents/a2a/templates/langgraph_crewai_agent/Makefile
@@ -199,8 +199,11 @@ deploy: _check-env ## Two-phase Helm deploy (Routes first, then Deployments with
 	echo "=== Done ===" && oc get route a2a-crew-agent a2a-langgraph-agent
 
 undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME) --ignore-not-found
-	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
+	@helm_status=0; cleanup_status=0; \
+	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
+	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
+	exit $$cleanup_status
 
 test-integration: ## Run integration deployment test
 	PYTHONPATH=$$(git rev-parse --show-toplevel)/tests \

--- a/agents/a2a/templates/langgraph_crewai_agent/Makefile
+++ b/agents/a2a/templates/langgraph_crewai_agent/Makefile
@@ -198,7 +198,7 @@ deploy: _check-env ## Two-phase Helm deploy (Routes first, then Deployments with
 	oc rollout status deployment/a2a-langgraph-agent --timeout=300s && \
 	echo "=== Done ===" && oc get route a2a-crew-agent a2a-langgraph-agent
 
-undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+undeploy: ## Remove deployment from cluster
 	helm uninstall $(AGENT_NAME) --ignore-not-found
 	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 

--- a/agents/a2a/templates/langgraph_crewai_agent/Makefile
+++ b/agents/a2a/templates/langgraph_crewai_agent/Makefile
@@ -1,5 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
+REPO_ROOT      := $(shell git rev-parse --show-toplevel)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -127,6 +128,7 @@ push: _check-env ## Push both image tags to the registry
 
 build-openshift: ## Build image in-cluster via OpenShift BuildConfig (no podman/docker needed)
 	@oc new-build --strategy=docker --binary --name=$(AGENT_NAME) --to=$(AGENT_NAME):latest 2>/dev/null || true && \
+	  $(REPO_ROOT)/scripts/openshift-build-config.sh patch-history $(AGENT_NAME) && \
 	  oc start-build $(AGENT_NAME) --from-dir=. --follow && \
 	  oc tag $(AGENT_NAME):latest $(AGENT_NAME):crew && \
 	  oc tag $(AGENT_NAME):latest $(AGENT_NAME):langgraph && \
@@ -196,8 +198,9 @@ deploy: _check-env ## Two-phase Helm deploy (Routes first, then Deployments with
 	oc rollout status deployment/a2a-langgraph-agent --timeout=300s && \
 	echo "=== Done ===" && oc get route a2a-crew-agent a2a-langgraph-agent
 
-undeploy: ## Remove Helm release (all resources)
+undeploy: ## Remove deployment and OpenShift build artifacts from cluster
 	helm uninstall $(AGENT_NAME) --ignore-not-found
+	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 
 test-integration: ## Run integration deployment test
 	PYTHONPATH=$$(git rev-parse --show-toplevel)/tests \

--- a/agents/a2a/templates/langgraph_crewai_agent/Makefile
+++ b/agents/a2a/templates/langgraph_crewai_agent/Makefile
@@ -1,6 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
-REPO_ROOT      := $(shell git rev-parse --show-toplevel)
+REPO_ROOT      := $(shell git rev-parse --show-toplevel 2>/dev/null || echo ../../../..)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -199,9 +199,19 @@ deploy: _check-env ## Two-phase Helm deploy (Routes first, then Deployments with
 	echo "=== Done ===" && oc get route a2a-crew-agent a2a-langgraph-agent
 
 undeploy: ## Remove deployment from cluster
-	@helm_status=0; cleanup_status=0; \
-	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
-	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	@helm_status=0; cleanup_status=0; cleanup_script="$(REPO_ROOT)/scripts/openshift-build-config.sh"; \
+	helm_output=$$(helm uninstall $(AGENT_NAME) 2>&1); helm_status=$$?; \
+	if [ -n "$$helm_output" ]; then \
+	  if [ $$helm_status -eq 0 ]; then printf '%s\n' "$$helm_output"; else printf '%s\n' "$$helm_output" >&2; fi; \
+	fi; \
+	if [ $$helm_status -ne 0 ]; then \
+	  case "$$helm_output" in *"Release not loaded"*|*"release: not found"*) helm_status=0 ;; esac; \
+	fi; \
+	if [ -f "$$cleanup_script" ]; then \
+	  bash "$$cleanup_script" cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	else \
+	  echo "WARNING: cleanup script not found: $$cleanup_script" >&2; \
+	fi; \
 	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
 	exit $$cleanup_status
 

--- a/agents/a2a/templates/langgraph_crewai_agent/tests/integration/conftest.py
+++ b/agents/a2a/templates/langgraph_crewai_agent/tests/integration/conftest.py
@@ -110,6 +110,11 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
                     "Cleanup failed — manual undeploy may be needed",
                     exc_info=True,
                 )
+            except Exception:
+                logger.warning(
+                    "Cleanup could not be launched — manual undeploy may be needed",
+                    exc_info=True,
+                )
         if orig_env is not None:
             try:
                 env_path.write_text(orig_env, encoding="utf-8")

--- a/agents/a2a/templates/langgraph_crewai_agent/tests/integration/conftest.py
+++ b/agents/a2a/templates/langgraph_crewai_agent/tests/integration/conftest.py
@@ -71,10 +71,12 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
     namespace = cluster_auth["namespace"]
     container_image = f"{INTERNAL_REGISTRY}/{namespace}/{agent_name}:latest"
     env_path, orig_env = _write_env_file(agent_dir, container_image)
+    build_attempted = False
 
     try:
         try:
             logger.info("Building image on cluster via build-openshift...")
+            build_attempted = True
             run_make("build-openshift", cwd=agent_dir, timeout=600)
 
             logger.info("Deploying to cluster (two-phase Helm)...")
@@ -99,14 +101,15 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
         yield primary
 
     finally:
-        logger.info("Tearing down deployment...")
-        try:
-            run_make("undeploy", cwd=agent_dir, timeout=120)
-        except MakeTargetError:
-            logger.warning(
-                "Cleanup failed — manual undeploy may be needed",
-                exc_info=True,
-            )
+        if build_attempted:
+            logger.info("Tearing down deployment...")
+            try:
+                run_make("undeploy", cwd=agent_dir, timeout=120)
+            except MakeTargetError:
+                logger.warning(
+                    "Cleanup failed — manual undeploy may be needed",
+                    exc_info=True,
+                )
         if orig_env is not None:
             try:
                 env_path.write_text(orig_env, encoding="utf-8")

--- a/agents/autogen/templates/mcp_agent/Makefile
+++ b/agents/autogen/templates/mcp_agent/Makefile
@@ -1,6 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
-REPO_ROOT      := $(shell git rev-parse --show-toplevel)
+REPO_ROOT      := $(shell git rev-parse --show-toplevel 2>/dev/null || echo ../../../..)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -221,9 +221,19 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set-string env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove agent deployment from cluster (does NOT remove MCP server)
-	@helm_status=0; cleanup_status=0; \
-	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
-	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	@helm_status=0; cleanup_status=0; cleanup_script="$(REPO_ROOT)/scripts/openshift-build-config.sh"; \
+	helm_output=$$(helm uninstall $(AGENT_NAME) 2>&1); helm_status=$$?; \
+	if [ -n "$$helm_output" ]; then \
+	  if [ $$helm_status -eq 0 ]; then printf '%s\n' "$$helm_output"; else printf '%s\n' "$$helm_output" >&2; fi; \
+	fi; \
+	if [ $$helm_status -ne 0 ]; then \
+	  case "$$helm_output" in *"Release not loaded"*|*"release: not found"*) helm_status=0 ;; esac; \
+	fi; \
+	if [ -f "$$cleanup_script" ]; then \
+	  bash "$$cleanup_script" cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	else \
+	  echo "WARNING: cleanup script not found: $$cleanup_script" >&2; \
+	fi; \
 	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
 	exit $$cleanup_status
 

--- a/agents/autogen/templates/mcp_agent/Makefile
+++ b/agents/autogen/templates/mcp_agent/Makefile
@@ -221,8 +221,11 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set-string env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove agent deployment from cluster (does NOT remove MCP server)
-	helm uninstall $(AGENT_NAME) --ignore-not-found
-	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
+	@helm_status=0; cleanup_status=0; \
+	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
+	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
+	exit $$cleanup_status
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)

--- a/agents/autogen/templates/mcp_agent/Makefile
+++ b/agents/autogen/templates/mcp_agent/Makefile
@@ -1,5 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
+REPO_ROOT      := $(shell git rev-parse --show-toplevel)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -115,6 +116,7 @@ push: ## Push container image to registry
 build-openshift: ## Build image in-cluster via OpenShift BuildConfig (no podman/docker needed)
 	@$(STAGE_BUILD_CONTEXT) && \
 	  oc new-build --strategy=docker --binary --name=$(AGENT_NAME) --to=$(AGENT_NAME):latest 2>/dev/null || true && \
+	  $(REPO_ROOT)/scripts/openshift-build-config.sh patch-history $(AGENT_NAME) && \
 	  oc start-build $(AGENT_NAME) --from-dir="$$BUILD_CONTEXT" --follow && \
 	  NS=$$(oc project -q) && \
 	  echo "" && \
@@ -219,7 +221,8 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set-string env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove agent deployment from cluster (does NOT remove MCP server)
-	helm uninstall $(AGENT_NAME)
+	helm uninstall $(AGENT_NAME) --ignore-not-found
+	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)

--- a/agents/autogen/templates/mcp_agent/tests/integration/conftest.py
+++ b/agents/autogen/templates/mcp_agent/tests/integration/conftest.py
@@ -78,7 +78,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
 
     finally:
         if build_attempted:
-            logger.info("Tearing down deployment and build artifacts...")
+            logger.info("Tearing down deployment...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/autogen/templates/mcp_agent/tests/integration/conftest.py
+++ b/agents/autogen/templates/mcp_agent/tests/integration/conftest.py
@@ -57,14 +57,14 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
     container_image = f"{INTERNAL_REGISTRY}/{namespace}/{agent_name}:latest"
     env_path = _write_env_file(agent_dir, container_image)
 
-    deploy_attempted = False
+    build_attempted = False
     try:
         try:
             logger.info("Building image on cluster via build-openshift...")
             run_make("build-openshift", cwd=agent_dir, timeout=600)
+            build_attempted = True
 
             logger.info("Deploying to cluster...")
-            deploy_attempted = True
             run_make("deploy", cwd=agent_dir, timeout=300)
 
             route_url = get_route(agent_name, namespace=namespace)
@@ -77,8 +77,8 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
         yield route_url
 
     finally:
-        if deploy_attempted:
-            logger.info("Tearing down deployment...")
+        if build_attempted:
+            logger.info("Tearing down deployment and build artifacts...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/autogen/templates/mcp_agent/tests/integration/conftest.py
+++ b/agents/autogen/templates/mcp_agent/tests/integration/conftest.py
@@ -61,8 +61,8 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
     try:
         try:
             logger.info("Building image on cluster via build-openshift...")
-            run_make("build-openshift", cwd=agent_dir, timeout=600)
             build_attempted = True
+            run_make("build-openshift", cwd=agent_dir, timeout=600)
 
             logger.info("Deploying to cluster...")
             run_make("deploy", cwd=agent_dir, timeout=300)

--- a/agents/crewai/templates/websearch_agent/Makefile
+++ b/agents/crewai/templates/websearch_agent/Makefile
@@ -1,6 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
-REPO_ROOT      := $(shell git rev-parse --show-toplevel)
+REPO_ROOT      := $(shell git rev-parse --show-toplevel 2>/dev/null || echo ../../../..)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -184,9 +184,19 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove deployment from cluster
-	@helm_status=0; cleanup_status=0; \
-	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
-	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	@helm_status=0; cleanup_status=0; cleanup_script="$(REPO_ROOT)/scripts/openshift-build-config.sh"; \
+	helm_output=$$(helm uninstall $(AGENT_NAME) 2>&1); helm_status=$$?; \
+	if [ -n "$$helm_output" ]; then \
+	  if [ $$helm_status -eq 0 ]; then printf '%s\n' "$$helm_output"; else printf '%s\n' "$$helm_output" >&2; fi; \
+	fi; \
+	if [ $$helm_status -ne 0 ]; then \
+	  case "$$helm_output" in *"Release not loaded"*|*"release: not found"*) helm_status=0 ;; esac; \
+	fi; \
+	if [ -f "$$cleanup_script" ]; then \
+	  bash "$$cleanup_script" cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	else \
+	  echo "WARNING: cleanup script not found: $$cleanup_script" >&2; \
+	fi; \
 	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
 	exit $$cleanup_status
 

--- a/agents/crewai/templates/websearch_agent/Makefile
+++ b/agents/crewai/templates/websearch_agent/Makefile
@@ -1,5 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
+REPO_ROOT      := $(shell git rev-parse --show-toplevel)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -107,6 +108,7 @@ build-openshift: ## Build image in-cluster via OpenShift BuildConfig (no podman/
 	  mkdir -p ./components && cp -r ../../../../components/auth ./components/auth && \
 	  trap 'rm -rf ./images ./components/auth; rmdir ./components 2>/dev/null || true' EXIT && \
 	  oc new-build --strategy=docker --binary --name=$(AGENT_NAME) --to=$(AGENT_NAME):latest 2>/dev/null || true && \
+	  $(REPO_ROOT)/scripts/openshift-build-config.sh patch-history $(AGENT_NAME) && \
 	  oc start-build $(AGENT_NAME) --from-dir=. --follow && \
 	  NS=$$(oc project -q) && \
 	  echo "" && \
@@ -181,8 +183,9 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_TRACKING_INSECURE_TLS:+--set env.MLFLOW_TRACKING_INSECURE_TLS="$${MLFLOW_TRACKING_INSECURE_TLS}"} \
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
-undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME)
+undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+	helm uninstall $(AGENT_NAME) --ignore-not-found
+	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)

--- a/agents/crewai/templates/websearch_agent/Makefile
+++ b/agents/crewai/templates/websearch_agent/Makefile
@@ -183,7 +183,7 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_TRACKING_INSECURE_TLS:+--set env.MLFLOW_TRACKING_INSECURE_TLS="$${MLFLOW_TRACKING_INSECURE_TLS}"} \
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
-undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+undeploy: ## Remove deployment from cluster
 	helm uninstall $(AGENT_NAME) --ignore-not-found
 	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 

--- a/agents/crewai/templates/websearch_agent/Makefile
+++ b/agents/crewai/templates/websearch_agent/Makefile
@@ -184,8 +184,11 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME) --ignore-not-found
-	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
+	@helm_status=0; cleanup_status=0; \
+	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
+	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
+	exit $$cleanup_status
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)

--- a/agents/crewai/templates/websearch_agent/tests/integration/test_deployment.py
+++ b/agents/crewai/templates/websearch_agent/tests/integration/test_deployment.py
@@ -54,15 +54,13 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
     env_path = _write_env_file(agent_dir, container_image)
 
     build_attempted = False
-    deployed = False
     try:
         logger.info("Building image on cluster via build-openshift...")
-        run_make("build-openshift", cwd=agent_dir, timeout=600)
         build_attempted = True
+        run_make("build-openshift", cwd=agent_dir, timeout=600)
 
         logger.info("Deploying to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)
-        deployed = True
 
         route_url = get_route(agent_name, namespace=namespace)
         logger.info("Agent deployed at %s", route_url)

--- a/agents/crewai/templates/websearch_agent/tests/integration/test_deployment.py
+++ b/agents/crewai/templates/websearch_agent/tests/integration/test_deployment.py
@@ -72,7 +72,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
 
     finally:
         if build_attempted:
-            logger.info("Tearing down deployment and build artifacts...")
+            logger.info("Tearing down deployment...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/crewai/templates/websearch_agent/tests/integration/test_deployment.py
+++ b/agents/crewai/templates/websearch_agent/tests/integration/test_deployment.py
@@ -53,10 +53,12 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
     container_image = f"{INTERNAL_REGISTRY}/{namespace}/{agent_name}:latest"
     env_path = _write_env_file(agent_dir, container_image)
 
+    build_attempted = False
     deployed = False
     try:
         logger.info("Building image on cluster via build-openshift...")
         run_make("build-openshift", cwd=agent_dir, timeout=600)
+        build_attempted = True
 
         logger.info("Deploying to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)
@@ -71,8 +73,8 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
         pytest.fail(f"Deployment failed: {exc}")
 
     finally:
-        if deployed:
-            logger.info("Tearing down deployment...")
+        if build_attempted:
+            logger.info("Tearing down deployment and build artifacts...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/google/templates/adk/Makefile
+++ b/agents/google/templates/adk/Makefile
@@ -166,7 +166,7 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_TRACKING_INSECURE_TLS:+--set env.MLFLOW_TRACKING_INSECURE_TLS="$${MLFLOW_TRACKING_INSECURE_TLS}"} \
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
-undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+undeploy: ## Remove deployment from cluster
 	helm uninstall $(AGENT_NAME) --ignore-not-found
 	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 

--- a/agents/google/templates/adk/Makefile
+++ b/agents/google/templates/adk/Makefile
@@ -167,8 +167,11 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME) --ignore-not-found
-	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
+	@helm_status=0; cleanup_status=0; \
+	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
+	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
+	exit $$cleanup_status
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)

--- a/agents/google/templates/adk/Makefile
+++ b/agents/google/templates/adk/Makefile
@@ -1,6 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
-REPO_ROOT      := $(shell git rev-parse --show-toplevel)
+REPO_ROOT      := $(shell git rev-parse --show-toplevel 2>/dev/null || echo ../../../..)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -167,9 +167,19 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove deployment from cluster
-	@helm_status=0; cleanup_status=0; \
-	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
-	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	@helm_status=0; cleanup_status=0; cleanup_script="$(REPO_ROOT)/scripts/openshift-build-config.sh"; \
+	helm_output=$$(helm uninstall $(AGENT_NAME) 2>&1); helm_status=$$?; \
+	if [ -n "$$helm_output" ]; then \
+	  if [ $$helm_status -eq 0 ]; then printf '%s\n' "$$helm_output"; else printf '%s\n' "$$helm_output" >&2; fi; \
+	fi; \
+	if [ $$helm_status -ne 0 ]; then \
+	  case "$$helm_output" in *"Release not loaded"*|*"release: not found"*) helm_status=0 ;; esac; \
+	fi; \
+	if [ -f "$$cleanup_script" ]; then \
+	  bash "$$cleanup_script" cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	else \
+	  echo "WARNING: cleanup script not found: $$cleanup_script" >&2; \
+	fi; \
 	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
 	exit $$cleanup_status
 

--- a/agents/google/templates/adk/Makefile
+++ b/agents/google/templates/adk/Makefile
@@ -1,5 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
+REPO_ROOT      := $(shell git rev-parse --show-toplevel)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -100,6 +101,7 @@ push: ## Push container image to registry
 build-openshift: ## Build image in-cluster via OpenShift BuildConfig (no podman/docker needed)
 	@cp -r ../../../../images ./images && trap 'rm -rf ./images' EXIT && \
 	  oc new-build --strategy=docker --binary --name=$(AGENT_NAME) --to=$(AGENT_NAME):latest 2>/dev/null || true && \
+	  $(REPO_ROOT)/scripts/openshift-build-config.sh patch-history $(AGENT_NAME) && \
 	  oc start-build $(AGENT_NAME) --from-dir=. --follow && \
 	  NS=$$(oc project -q) && \
 	  echo "" && \
@@ -164,8 +166,9 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_TRACKING_INSECURE_TLS:+--set env.MLFLOW_TRACKING_INSECURE_TLS="$${MLFLOW_TRACKING_INSECURE_TLS}"} \
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
-undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME)
+undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+	helm uninstall $(AGENT_NAME) --ignore-not-found
+	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)

--- a/agents/google/templates/adk/tests/integration/test_deployment.py
+++ b/agents/google/templates/adk/tests/integration/test_deployment.py
@@ -54,15 +54,13 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
     env_path = _write_env_file(agent_dir, container_image)
 
     build_attempted = False
-    deployed = False
     try:
         logger.info("Building image on cluster via build-openshift...")
-        run_make("build-openshift", cwd=agent_dir, timeout=600)
         build_attempted = True
+        run_make("build-openshift", cwd=agent_dir, timeout=600)
 
         logger.info("Deploying to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)
-        deployed = True
 
         route_url = get_route(agent_name, namespace=namespace)
         logger.info("Agent deployed at %s", route_url)

--- a/agents/google/templates/adk/tests/integration/test_deployment.py
+++ b/agents/google/templates/adk/tests/integration/test_deployment.py
@@ -72,7 +72,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
 
     finally:
         if build_attempted:
-            logger.info("Tearing down deployment and build artifacts...")
+            logger.info("Tearing down deployment...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/google/templates/adk/tests/integration/test_deployment.py
+++ b/agents/google/templates/adk/tests/integration/test_deployment.py
@@ -53,10 +53,12 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
     container_image = f"{INTERNAL_REGISTRY}/{namespace}/{agent_name}:latest"
     env_path = _write_env_file(agent_dir, container_image)
 
+    build_attempted = False
     deployed = False
     try:
         logger.info("Building image on cluster via build-openshift...")
         run_make("build-openshift", cwd=agent_dir, timeout=600)
+        build_attempted = True
 
         logger.info("Deploying to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)
@@ -71,8 +73,8 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
         pytest.fail(f"Deployment failed: {exc}")
 
     finally:
-        if deployed:
-            logger.info("Tearing down deployment...")
+        if build_attempted:
+            logger.info("Tearing down deployment and build artifacts...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/langgraph/examples/guardrailed_agent/Makefile
+++ b/agents/langgraph/examples/guardrailed_agent/Makefile
@@ -211,7 +211,7 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_TRACKING_SERVER_CERT_PATH:+--set env.MLFLOW_TRACKING_SERVER_CERT_PATH="$${MLFLOW_TRACKING_SERVER_CERT_PATH}"} \
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
-undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+undeploy: ## Remove deployment from cluster
 	helm uninstall $(AGENT_NAME) --ignore-not-found
 	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 

--- a/agents/langgraph/examples/guardrailed_agent/Makefile
+++ b/agents/langgraph/examples/guardrailed_agent/Makefile
@@ -212,8 +212,11 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME) --ignore-not-found
-	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
+	@helm_status=0; cleanup_status=0; \
+	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
+	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
+	exit $$cleanup_status
 
 render-guardrails-configmap: ## Render NeMo Guardrails ConfigMap manifest for cluster deploy
 	@CLUSTER_ENV_FILE="$(CLUSTER_ENV)"; \

--- a/agents/langgraph/examples/guardrailed_agent/Makefile
+++ b/agents/langgraph/examples/guardrailed_agent/Makefile
@@ -1,6 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
-REPO_ROOT      := $(shell git rev-parse --show-toplevel)
+REPO_ROOT      := $(shell git rev-parse --show-toplevel 2>/dev/null || echo ../../../..)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -212,9 +212,19 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove deployment from cluster
-	@helm_status=0; cleanup_status=0; \
-	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
-	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	@helm_status=0; cleanup_status=0; cleanup_script="$(REPO_ROOT)/scripts/openshift-build-config.sh"; \
+	helm_output=$$(helm uninstall $(AGENT_NAME) 2>&1); helm_status=$$?; \
+	if [ -n "$$helm_output" ]; then \
+	  if [ $$helm_status -eq 0 ]; then printf '%s\n' "$$helm_output"; else printf '%s\n' "$$helm_output" >&2; fi; \
+	fi; \
+	if [ $$helm_status -ne 0 ]; then \
+	  case "$$helm_output" in *"Release not loaded"*|*"release: not found"*) helm_status=0 ;; esac; \
+	fi; \
+	if [ -f "$$cleanup_script" ]; then \
+	  bash "$$cleanup_script" cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	else \
+	  echo "WARNING: cleanup script not found: $$cleanup_script" >&2; \
+	fi; \
 	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
 	exit $$cleanup_status
 

--- a/agents/langgraph/examples/guardrailed_agent/Makefile
+++ b/agents/langgraph/examples/guardrailed_agent/Makefile
@@ -1,5 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
+REPO_ROOT      := $(shell git rev-parse --show-toplevel)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -111,6 +112,7 @@ build-openshift: ## Build image in-cluster via OpenShift BuildConfig (no podman/
 	  mkdir -p ./components && cp -r ../../../../components/auth ./components/auth && \
 	  trap 'rm -rf ./images ./components/auth; rmdir ./components 2>/dev/null || true' EXIT && \
 	  oc new-build --strategy=docker --binary --name=$(AGENT_NAME) --to=$(AGENT_NAME):latest 2>/dev/null || true && \
+	  $(REPO_ROOT)/scripts/openshift-build-config.sh patch-history $(AGENT_NAME) && \
 	  oc start-build $(AGENT_NAME) --from-dir=. --follow && \
 	  NS=$$(oc project -q) && \
 	  echo "" && \
@@ -209,8 +211,9 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_TRACKING_SERVER_CERT_PATH:+--set env.MLFLOW_TRACKING_SERVER_CERT_PATH="$${MLFLOW_TRACKING_SERVER_CERT_PATH}"} \
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
-undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME)
+undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+	helm uninstall $(AGENT_NAME) --ignore-not-found
+	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 
 render-guardrails-configmap: ## Render NeMo Guardrails ConfigMap manifest for cluster deploy
 	@CLUSTER_ENV_FILE="$(CLUSTER_ENV)"; \

--- a/agents/langgraph/examples/guardrailed_agent/tests/integration/test_deployment.py
+++ b/agents/langgraph/examples/guardrailed_agent/tests/integration/test_deployment.py
@@ -66,10 +66,12 @@ def deployed_agent(cluster_auth, deployed_guardrails, agent_dir, agent_name):
         agent_dir, container_image, base_url=base_url, model_id=model_id
     )
 
+    build_attempted = False
     deployed = False
     try:
         logger.info("Building image on cluster via build-openshift...")
         run_make("build-openshift", cwd=agent_dir, timeout=600)
+        build_attempted = True
 
         logger.info("Deploying agent to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)
@@ -84,8 +86,8 @@ def deployed_agent(cluster_auth, deployed_guardrails, agent_dir, agent_name):
         pytest.fail(f"Deployment failed: {exc}")
 
     finally:
-        if deployed:
-            logger.info("Tearing down agent deployment...")
+        if build_attempted:
+            logger.info("Tearing down agent deployment and build artifacts...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/langgraph/examples/guardrailed_agent/tests/integration/test_deployment.py
+++ b/agents/langgraph/examples/guardrailed_agent/tests/integration/test_deployment.py
@@ -85,7 +85,7 @@ def deployed_agent(cluster_auth, deployed_guardrails, agent_dir, agent_name):
 
     finally:
         if build_attempted:
-            logger.info("Tearing down agent deployment and build artifacts...")
+            logger.info("Tearing down agent deployment...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/langgraph/examples/guardrailed_agent/tests/integration/test_deployment.py
+++ b/agents/langgraph/examples/guardrailed_agent/tests/integration/test_deployment.py
@@ -67,15 +67,13 @@ def deployed_agent(cluster_auth, deployed_guardrails, agent_dir, agent_name):
     )
 
     build_attempted = False
-    deployed = False
     try:
         logger.info("Building image on cluster via build-openshift...")
-        run_make("build-openshift", cwd=agent_dir, timeout=600)
         build_attempted = True
+        run_make("build-openshift", cwd=agent_dir, timeout=600)
 
         logger.info("Deploying agent to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)
-        deployed = True
 
         route_url = get_route(agent_name, namespace=namespace)
         logger.info("Agent deployed at %s", route_url)

--- a/agents/langgraph/templates/agentic_rag/Makefile
+++ b/agents/langgraph/templates/agentic_rag/Makefile
@@ -220,8 +220,11 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME) --ignore-not-found
-	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
+	@helm_status=0; cleanup_status=0; \
+	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
+	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
+	exit $$cleanup_status
 
 ## ── openShell sandbox targets ─────────────────────────────────────────────────
 OPENSHELL_SANDBOX ?= $(shell . ./.env 2>/dev/null && echo $${OPENSHELL_SANDBOX_NAME:-rag-sandbox})

--- a/agents/langgraph/templates/agentic_rag/Makefile
+++ b/agents/langgraph/templates/agentic_rag/Makefile
@@ -1,5 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
+REPO_ROOT      := $(shell git rev-parse --show-toplevel)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -113,6 +114,7 @@ build-openshift: ## Build image in-cluster via OpenShift BuildConfig (no podman/
 	  cp -r ../../../../images ./images && \
 	  mkdir -p ./components && cp -r ../../../../components/auth ./components/auth && \
 	  oc new-build --strategy=docker --binary --name=$(AGENT_NAME) --to=$(AGENT_NAME):latest 2>/dev/null || true && \
+	  $(REPO_ROOT)/scripts/openshift-build-config.sh patch-history $(AGENT_NAME) && \
 	  oc start-build $(AGENT_NAME) --from-dir=. --follow && \
 	  NS=$$(oc project -q) && \
 	  echo "" && \
@@ -217,8 +219,9 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_TRACKING_INSECURE_TLS:+--set env.MLFLOW_TRACKING_INSECURE_TLS="$${MLFLOW_TRACKING_INSECURE_TLS}"} \
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
-undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME)
+undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+	helm uninstall $(AGENT_NAME) --ignore-not-found
+	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 
 ## ── openShell sandbox targets ─────────────────────────────────────────────────
 OPENSHELL_SANDBOX ?= $(shell . ./.env 2>/dev/null && echo $${OPENSHELL_SANDBOX_NAME:-rag-sandbox})

--- a/agents/langgraph/templates/agentic_rag/Makefile
+++ b/agents/langgraph/templates/agentic_rag/Makefile
@@ -1,6 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
-REPO_ROOT      := $(shell git rev-parse --show-toplevel)
+REPO_ROOT      := $(shell git rev-parse --show-toplevel 2>/dev/null || echo ../../../..)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -220,9 +220,19 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove deployment from cluster
-	@helm_status=0; cleanup_status=0; \
-	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
-	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	@helm_status=0; cleanup_status=0; cleanup_script="$(REPO_ROOT)/scripts/openshift-build-config.sh"; \
+	helm_output=$$(helm uninstall $(AGENT_NAME) 2>&1); helm_status=$$?; \
+	if [ -n "$$helm_output" ]; then \
+	  if [ $$helm_status -eq 0 ]; then printf '%s\n' "$$helm_output"; else printf '%s\n' "$$helm_output" >&2; fi; \
+	fi; \
+	if [ $$helm_status -ne 0 ]; then \
+	  case "$$helm_output" in *"Release not loaded"*|*"release: not found"*) helm_status=0 ;; esac; \
+	fi; \
+	if [ -f "$$cleanup_script" ]; then \
+	  bash "$$cleanup_script" cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	else \
+	  echo "WARNING: cleanup script not found: $$cleanup_script" >&2; \
+	fi; \
 	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
 	exit $$cleanup_status
 

--- a/agents/langgraph/templates/agentic_rag/Makefile
+++ b/agents/langgraph/templates/agentic_rag/Makefile
@@ -219,7 +219,7 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_TRACKING_INSECURE_TLS:+--set env.MLFLOW_TRACKING_INSECURE_TLS="$${MLFLOW_TRACKING_INSECURE_TLS}"} \
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
-undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+undeploy: ## Remove deployment from cluster
 	helm uninstall $(AGENT_NAME) --ignore-not-found
 	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 

--- a/agents/langgraph/templates/agentic_rag/tests/integration/conftest.py
+++ b/agents/langgraph/templates/agentic_rag/tests/integration/conftest.py
@@ -88,7 +88,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
 
     finally:
         if build_attempted:
-            logger.info("Tearing down deployment and build artifacts...")
+            logger.info("Tearing down deployment...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/langgraph/templates/agentic_rag/tests/integration/conftest.py
+++ b/agents/langgraph/templates/agentic_rag/tests/integration/conftest.py
@@ -67,11 +67,13 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
     container_image = f"{INTERNAL_REGISTRY}/{namespace}/{agent_name}:latest"
     env_path = _write_env_file(agent_dir, container_image)
 
+    build_attempted = False
     deployed = False
     try:
         try:
             logger.info("Building image on cluster via build-openshift...")
             run_make("build-openshift", cwd=agent_dir, timeout=600)
+            build_attempted = True
 
             logger.info("Deploying to cluster...")
             run_make("deploy", cwd=agent_dir, timeout=300)
@@ -87,8 +89,8 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
         yield route_url
 
     finally:
-        if deployed:
-            logger.info("Tearing down deployment...")
+        if build_attempted:
+            logger.info("Tearing down deployment and build artifacts...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/langgraph/templates/agentic_rag/tests/integration/conftest.py
+++ b/agents/langgraph/templates/agentic_rag/tests/integration/conftest.py
@@ -68,16 +68,14 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
     env_path = _write_env_file(agent_dir, container_image)
 
     build_attempted = False
-    deployed = False
     try:
         try:
             logger.info("Building image on cluster via build-openshift...")
-            run_make("build-openshift", cwd=agent_dir, timeout=600)
             build_attempted = True
+            run_make("build-openshift", cwd=agent_dir, timeout=600)
 
             logger.info("Deploying to cluster...")
             run_make("deploy", cwd=agent_dir, timeout=300)
-            deployed = True
 
             route_url = get_route(agent_name, namespace=namespace)
             logger.info("Agent deployed at %s", route_url)

--- a/agents/langgraph/templates/ci_failure_summarizer/Makefile
+++ b/agents/langgraph/templates/ci_failure_summarizer/Makefile
@@ -169,8 +169,11 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${SLACK_WEBHOOK_URL:+--set extraSecrets.SLACK_WEBHOOK_URL="REDACTED"} \
 
 undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME) --ignore-not-found
-	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
+	@helm_status=0; cleanup_status=0; \
+	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
+	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
+	exit $$cleanup_status
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration $(PYTEST_ARGS)

--- a/agents/langgraph/templates/ci_failure_summarizer/Makefile
+++ b/agents/langgraph/templates/ci_failure_summarizer/Makefile
@@ -168,7 +168,7 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${GITHUB_TOKEN:+--set extraSecrets.GITHUB_TOKEN="REDACTED"} \
 	    $${SLACK_WEBHOOK_URL:+--set extraSecrets.SLACK_WEBHOOK_URL="REDACTED"} \
 
-undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+undeploy: ## Remove deployment from cluster
 	helm uninstall $(AGENT_NAME) --ignore-not-found
 	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 

--- a/agents/langgraph/templates/ci_failure_summarizer/Makefile
+++ b/agents/langgraph/templates/ci_failure_summarizer/Makefile
@@ -1,5 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
+REPO_ROOT      := $(shell git rev-parse --show-toplevel)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -113,6 +114,7 @@ push: ## Push container image to registry
 
 build-openshift: ## Build image in-cluster via OpenShift BuildConfig (no podman/docker needed)
 	@oc new-build --strategy=docker --binary --name=$(AGENT_NAME) --to=$(AGENT_NAME):latest 2>/dev/null || true && \
+	  $(REPO_ROOT)/scripts/openshift-build-config.sh patch-history $(AGENT_NAME) && \
 	  oc start-build $(AGENT_NAME) --from-dir=. --follow && \
 	  NS=$$(oc project -q) && \
 	  echo "" && \
@@ -166,8 +168,9 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${GITHUB_TOKEN:+--set extraSecrets.GITHUB_TOKEN="REDACTED"} \
 	    $${SLACK_WEBHOOK_URL:+--set extraSecrets.SLACK_WEBHOOK_URL="REDACTED"} \
 
-undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME)
+undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+	helm uninstall $(AGENT_NAME) --ignore-not-found
+	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration $(PYTEST_ARGS)

--- a/agents/langgraph/templates/ci_failure_summarizer/Makefile
+++ b/agents/langgraph/templates/ci_failure_summarizer/Makefile
@@ -1,6 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
-REPO_ROOT      := $(shell git rev-parse --show-toplevel)
+REPO_ROOT      := $(shell git rev-parse --show-toplevel 2>/dev/null || echo ../../../..)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -169,9 +169,19 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${SLACK_WEBHOOK_URL:+--set extraSecrets.SLACK_WEBHOOK_URL="REDACTED"} \
 
 undeploy: ## Remove deployment from cluster
-	@helm_status=0; cleanup_status=0; \
-	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
-	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	@helm_status=0; cleanup_status=0; cleanup_script="$(REPO_ROOT)/scripts/openshift-build-config.sh"; \
+	helm_output=$$(helm uninstall $(AGENT_NAME) 2>&1); helm_status=$$?; \
+	if [ -n "$$helm_output" ]; then \
+	  if [ $$helm_status -eq 0 ]; then printf '%s\n' "$$helm_output"; else printf '%s\n' "$$helm_output" >&2; fi; \
+	fi; \
+	if [ $$helm_status -ne 0 ]; then \
+	  case "$$helm_output" in *"Release not loaded"*|*"release: not found"*) helm_status=0 ;; esac; \
+	fi; \
+	if [ -f "$$cleanup_script" ]; then \
+	  bash "$$cleanup_script" cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	else \
+	  echo "WARNING: cleanup script not found: $$cleanup_script" >&2; \
+	fi; \
 	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
 	exit $$cleanup_status
 

--- a/agents/langgraph/templates/ci_failure_summarizer/tests/integration/conftest.py
+++ b/agents/langgraph/templates/ci_failure_summarizer/tests/integration/conftest.py
@@ -96,16 +96,14 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
     env_path = _write_env_file(agent_dir, container_image)
 
     build_attempted = False
-    deployed = False
     try:
         try:
             logger.info("Building image on cluster via build-openshift...")
-            run_make("build-openshift", cwd=agent_dir, timeout=600)
             build_attempted = True
+            run_make("build-openshift", cwd=agent_dir, timeout=600)
 
             logger.info("Deploying to cluster...")
             run_make("deploy", cwd=agent_dir, timeout=300)
-            deployed = True
 
             route_url = get_route(agent_name, namespace=namespace)
             logger.info("Agent deployed at %s", route_url)

--- a/agents/langgraph/templates/ci_failure_summarizer/tests/integration/conftest.py
+++ b/agents/langgraph/templates/ci_failure_summarizer/tests/integration/conftest.py
@@ -116,7 +116,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
 
     finally:
         if build_attempted:
-            logger.info("Tearing down deployment and build artifacts...")
+            logger.info("Tearing down deployment...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/langgraph/templates/ci_failure_summarizer/tests/integration/conftest.py
+++ b/agents/langgraph/templates/ci_failure_summarizer/tests/integration/conftest.py
@@ -95,11 +95,13 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
     container_image = f"{INTERNAL_REGISTRY}/{namespace}/{agent_name}:latest"
     env_path = _write_env_file(agent_dir, container_image)
 
+    build_attempted = False
     deployed = False
     try:
         try:
             logger.info("Building image on cluster via build-openshift...")
             run_make("build-openshift", cwd=agent_dir, timeout=600)
+            build_attempted = True
 
             logger.info("Deploying to cluster...")
             run_make("deploy", cwd=agent_dir, timeout=300)
@@ -115,8 +117,8 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
         yield route_url
 
     finally:
-        if deployed:
-            logger.info("Tearing down deployment...")
+        if build_attempted:
+            logger.info("Tearing down deployment and build artifacts...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/langgraph/templates/human_in_the_loop/Makefile
+++ b/agents/langgraph/templates/human_in_the_loop/Makefile
@@ -166,7 +166,7 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_TRACKING_INSECURE_TLS:+--set env.MLFLOW_TRACKING_INSECURE_TLS="$${MLFLOW_TRACKING_INSECURE_TLS}"} \
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
-undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+undeploy: ## Remove deployment from cluster
 	helm uninstall $(AGENT_NAME) --ignore-not-found
 	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 

--- a/agents/langgraph/templates/human_in_the_loop/Makefile
+++ b/agents/langgraph/templates/human_in_the_loop/Makefile
@@ -167,8 +167,11 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME) --ignore-not-found
-	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
+	@helm_status=0; cleanup_status=0; \
+	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
+	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
+	exit $$cleanup_status
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)

--- a/agents/langgraph/templates/human_in_the_loop/Makefile
+++ b/agents/langgraph/templates/human_in_the_loop/Makefile
@@ -1,6 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
-REPO_ROOT      := $(shell git rev-parse --show-toplevel)
+REPO_ROOT      := $(shell git rev-parse --show-toplevel 2>/dev/null || echo ../../../..)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -167,9 +167,19 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove deployment from cluster
-	@helm_status=0; cleanup_status=0; \
-	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
-	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	@helm_status=0; cleanup_status=0; cleanup_script="$(REPO_ROOT)/scripts/openshift-build-config.sh"; \
+	helm_output=$$(helm uninstall $(AGENT_NAME) 2>&1); helm_status=$$?; \
+	if [ -n "$$helm_output" ]; then \
+	  if [ $$helm_status -eq 0 ]; then printf '%s\n' "$$helm_output"; else printf '%s\n' "$$helm_output" >&2; fi; \
+	fi; \
+	if [ $$helm_status -ne 0 ]; then \
+	  case "$$helm_output" in *"Release not loaded"*|*"release: not found"*) helm_status=0 ;; esac; \
+	fi; \
+	if [ -f "$$cleanup_script" ]; then \
+	  bash "$$cleanup_script" cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	else \
+	  echo "WARNING: cleanup script not found: $$cleanup_script" >&2; \
+	fi; \
 	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
 	exit $$cleanup_status
 

--- a/agents/langgraph/templates/human_in_the_loop/Makefile
+++ b/agents/langgraph/templates/human_in_the_loop/Makefile
@@ -1,5 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
+REPO_ROOT      := $(shell git rev-parse --show-toplevel)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -100,6 +101,7 @@ push: ## Push container image to registry
 build-openshift: ## Build image in-cluster via OpenShift BuildConfig (no podman/docker needed)
 	@cp -r ../../../../images ./images && trap 'rm -rf ./images' EXIT && \
 	  oc new-build --strategy=docker --binary --name=$(AGENT_NAME) --to=$(AGENT_NAME):latest 2>/dev/null || true && \
+	  $(REPO_ROOT)/scripts/openshift-build-config.sh patch-history $(AGENT_NAME) && \
 	  oc start-build $(AGENT_NAME) --from-dir=. --follow && \
 	  NS=$$(oc project -q) && \
 	  echo "" && \
@@ -164,8 +166,9 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_TRACKING_INSECURE_TLS:+--set env.MLFLOW_TRACKING_INSECURE_TLS="$${MLFLOW_TRACKING_INSECURE_TLS}"} \
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
-undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME)
+undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+	helm uninstall $(AGENT_NAME) --ignore-not-found
+	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)

--- a/agents/langgraph/templates/human_in_the_loop/tests/integration/test_deployment.py
+++ b/agents/langgraph/templates/human_in_the_loop/tests/integration/test_deployment.py
@@ -54,15 +54,13 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
     env_path = _write_env_file(agent_dir, container_image)
 
     build_attempted = False
-    deployed = False
     try:
         logger.info("Building image on cluster via build-openshift...")
-        run_make("build-openshift", cwd=agent_dir, timeout=600)
         build_attempted = True
+        run_make("build-openshift", cwd=agent_dir, timeout=600)
 
         logger.info("Deploying to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)
-        deployed = True
 
         route_url = get_route(agent_name, namespace=namespace)
         logger.info("Agent deployed at %s", route_url)

--- a/agents/langgraph/templates/human_in_the_loop/tests/integration/test_deployment.py
+++ b/agents/langgraph/templates/human_in_the_loop/tests/integration/test_deployment.py
@@ -72,7 +72,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
 
     finally:
         if build_attempted:
-            logger.info("Tearing down deployment and build artifacts...")
+            logger.info("Tearing down deployment...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/langgraph/templates/human_in_the_loop/tests/integration/test_deployment.py
+++ b/agents/langgraph/templates/human_in_the_loop/tests/integration/test_deployment.py
@@ -53,10 +53,12 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
     container_image = f"{INTERNAL_REGISTRY}/{namespace}/{agent_name}:latest"
     env_path = _write_env_file(agent_dir, container_image)
 
+    build_attempted = False
     deployed = False
     try:
         logger.info("Building image on cluster via build-openshift...")
         run_make("build-openshift", cwd=agent_dir, timeout=600)
+        build_attempted = True
 
         logger.info("Deploying to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)
@@ -71,8 +73,8 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
         pytest.fail(f"Deployment failed: {exc}")
 
     finally:
-        if deployed:
-            logger.info("Tearing down deployment...")
+        if build_attempted:
+            logger.info("Tearing down deployment and build artifacts...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/langgraph/templates/react_agent/Makefile
+++ b/agents/langgraph/templates/react_agent/Makefile
@@ -204,7 +204,7 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_TRACKING_SERVER_CERT_PATH:+--set env.MLFLOW_TRACKING_SERVER_CERT_PATH="$${MLFLOW_TRACKING_SERVER_CERT_PATH}"} \
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
-undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+undeploy: ## Remove deployment from cluster
 	helm uninstall $(AGENT_NAME) --ignore-not-found
 	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 

--- a/agents/langgraph/templates/react_agent/Makefile
+++ b/agents/langgraph/templates/react_agent/Makefile
@@ -1,5 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
+REPO_ROOT      := $(shell git rev-parse --show-toplevel)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -104,6 +105,7 @@ build-openshift: ## Build image in-cluster via OpenShift BuildConfig (no podman/
 	  mkdir -p ./components && cp -r ../../../../components/auth ./components/auth && \
 	  trap 'rm -rf ./images ./components/auth; rmdir ./components 2>/dev/null || true' EXIT && \
 	  oc new-build --strategy=docker --binary --name=$(AGENT_NAME) --to=$(AGENT_NAME):latest 2>/dev/null || true && \
+	  $(REPO_ROOT)/scripts/openshift-build-config.sh patch-history $(AGENT_NAME) && \
 	  oc start-build $(AGENT_NAME) --from-dir=. --follow && \
 	  NS=$$(oc project -q) && \
 	  echo "" && \
@@ -202,8 +204,9 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_TRACKING_SERVER_CERT_PATH:+--set env.MLFLOW_TRACKING_SERVER_CERT_PATH="$${MLFLOW_TRACKING_SERVER_CERT_PATH}"} \
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
-undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME)
+undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+	helm uninstall $(AGENT_NAME) --ignore-not-found
+	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)

--- a/agents/langgraph/templates/react_agent/Makefile
+++ b/agents/langgraph/templates/react_agent/Makefile
@@ -205,8 +205,11 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME) --ignore-not-found
-	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
+	@helm_status=0; cleanup_status=0; \
+	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
+	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
+	exit $$cleanup_status
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)

--- a/agents/langgraph/templates/react_agent/Makefile
+++ b/agents/langgraph/templates/react_agent/Makefile
@@ -1,6 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
-REPO_ROOT      := $(shell git rev-parse --show-toplevel)
+REPO_ROOT      := $(shell git rev-parse --show-toplevel 2>/dev/null || echo ../../../..)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -205,9 +205,19 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove deployment from cluster
-	@helm_status=0; cleanup_status=0; \
-	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
-	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	@helm_status=0; cleanup_status=0; cleanup_script="$(REPO_ROOT)/scripts/openshift-build-config.sh"; \
+	helm_output=$$(helm uninstall $(AGENT_NAME) 2>&1); helm_status=$$?; \
+	if [ -n "$$helm_output" ]; then \
+	  if [ $$helm_status -eq 0 ]; then printf '%s\n' "$$helm_output"; else printf '%s\n' "$$helm_output" >&2; fi; \
+	fi; \
+	if [ $$helm_status -ne 0 ]; then \
+	  case "$$helm_output" in *"Release not loaded"*|*"release: not found"*) helm_status=0 ;; esac; \
+	fi; \
+	if [ -f "$$cleanup_script" ]; then \
+	  bash "$$cleanup_script" cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	else \
+	  echo "WARNING: cleanup script not found: $$cleanup_script" >&2; \
+	fi; \
 	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
 	exit $$cleanup_status
 

--- a/agents/langgraph/templates/react_agent/tests/integration/test_auth.py
+++ b/agents/langgraph/templates/react_agent/tests/integration/test_auth.py
@@ -84,10 +84,12 @@ def deployed_auth_agent(cluster_auth, agent_dir, agent_name, auth_callers):
         allowed_caller_sa=auth_callers["allowed"],
     )
 
+    build_attempted = False
     deployed = False
     try:
         logger.info("Building image on cluster via build-openshift...")
         run_make("build-openshift", cwd=agent_dir, timeout=1200)
+        build_attempted = True
 
         logger.info("Deploying auth-enabled agent to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)
@@ -99,8 +101,8 @@ def deployed_auth_agent(cluster_auth, agent_dir, agent_name, auth_callers):
     except (MakeTargetError, RouteNotFoundError) as exc:
         pytest.fail(f"Auth deployment failed: {exc}")
     finally:
-        if deployed:
-            logger.info("Tearing down auth deployment...")
+        if build_attempted:
+            logger.info("Tearing down auth deployment and build artifacts...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/langgraph/templates/react_agent/tests/integration/test_auth.py
+++ b/agents/langgraph/templates/react_agent/tests/integration/test_auth.py
@@ -85,15 +85,13 @@ def deployed_auth_agent(cluster_auth, agent_dir, agent_name, auth_callers):
     )
 
     build_attempted = False
-    deployed = False
     try:
         logger.info("Building image on cluster via build-openshift...")
-        run_make("build-openshift", cwd=agent_dir, timeout=1200)
         build_attempted = True
+        run_make("build-openshift", cwd=agent_dir, timeout=1200)
 
         logger.info("Deploying auth-enabled agent to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)
-        deployed = True
 
         route_url = get_route(agent_name, namespace=namespace)
         logger.info("Auth-enabled agent deployed at %s", route_url)

--- a/agents/langgraph/templates/react_agent/tests/integration/test_auth.py
+++ b/agents/langgraph/templates/react_agent/tests/integration/test_auth.py
@@ -100,7 +100,7 @@ def deployed_auth_agent(cluster_auth, agent_dir, agent_name, auth_callers):
         pytest.fail(f"Auth deployment failed: {exc}")
     finally:
         if build_attempted:
-            logger.info("Tearing down auth deployment and build artifacts...")
+            logger.info("Tearing down auth deployment...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/langgraph/templates/react_agent/tests/integration/test_deployment.py
+++ b/agents/langgraph/templates/react_agent/tests/integration/test_deployment.py
@@ -58,15 +58,13 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
     env_path, orig_env = _write_env_file(agent_dir, container_image)
 
     build_attempted = False
-    deployed = False
     try:
         logger.info("Building image on cluster via build-openshift...")
-        run_make("build-openshift", cwd=agent_dir, timeout=600)
         build_attempted = True
+        run_make("build-openshift", cwd=agent_dir, timeout=600)
 
         logger.info("Deploying to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)
-        deployed = True
 
         route_url = get_route(agent_name, namespace=namespace)
         logger.info("Agent deployed at %s", route_url)

--- a/agents/langgraph/templates/react_agent/tests/integration/test_deployment.py
+++ b/agents/langgraph/templates/react_agent/tests/integration/test_deployment.py
@@ -57,10 +57,12 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
     container_image = f"{INTERNAL_REGISTRY}/{namespace}/{agent_name}:latest"
     env_path, orig_env = _write_env_file(agent_dir, container_image)
 
+    build_attempted = False
     deployed = False
     try:
         logger.info("Building image on cluster via build-openshift...")
         run_make("build-openshift", cwd=agent_dir, timeout=600)
+        build_attempted = True
 
         logger.info("Deploying to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)
@@ -75,8 +77,8 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
         pytest.fail(f"Deployment failed: {exc}")
 
     finally:
-        if deployed:
-            logger.info("Tearing down deployment...")
+        if build_attempted:
+            logger.info("Tearing down deployment and build artifacts...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/langgraph/templates/react_agent/tests/integration/test_deployment.py
+++ b/agents/langgraph/templates/react_agent/tests/integration/test_deployment.py
@@ -76,7 +76,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
 
     finally:
         if build_attempted:
-            logger.info("Tearing down deployment and build artifacts...")
+            logger.info("Tearing down deployment...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/langgraph/templates/react_with_database_memory/Makefile
+++ b/agents/langgraph/templates/react_with_database_memory/Makefile
@@ -176,8 +176,11 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME) --ignore-not-found
-	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
+	@helm_status=0; cleanup_status=0; \
+	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
+	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
+	exit $$cleanup_status
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)

--- a/agents/langgraph/templates/react_with_database_memory/Makefile
+++ b/agents/langgraph/templates/react_with_database_memory/Makefile
@@ -175,7 +175,7 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_TRACKING_INSECURE_TLS:+--set env.MLFLOW_TRACKING_INSECURE_TLS="$${MLFLOW_TRACKING_INSECURE_TLS}"} \
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
-undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+undeploy: ## Remove deployment from cluster
 	helm uninstall $(AGENT_NAME) --ignore-not-found
 	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 

--- a/agents/langgraph/templates/react_with_database_memory/Makefile
+++ b/agents/langgraph/templates/react_with_database_memory/Makefile
@@ -1,5 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
+REPO_ROOT      := $(shell git rev-parse --show-toplevel)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -100,6 +101,7 @@ push: ## Push container image to registry
 build-openshift: ## Build image in-cluster via OpenShift BuildConfig (no podman/docker needed)
 	@cp -r ../../../../images ./images && trap 'rm -rf ./images' EXIT && \
 	  oc new-build --strategy=docker --binary --name=$(AGENT_NAME) --to=$(AGENT_NAME):latest 2>/dev/null || true && \
+	  $(REPO_ROOT)/scripts/openshift-build-config.sh patch-history $(AGENT_NAME) && \
 	  oc start-build $(AGENT_NAME) --from-dir=. --follow && \
 	  NS=$$(oc project -q) && \
 	  echo "" && \
@@ -173,8 +175,9 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_TRACKING_INSECURE_TLS:+--set env.MLFLOW_TRACKING_INSECURE_TLS="$${MLFLOW_TRACKING_INSECURE_TLS}"} \
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
-undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME)
+undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+	helm uninstall $(AGENT_NAME) --ignore-not-found
+	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)

--- a/agents/langgraph/templates/react_with_database_memory/Makefile
+++ b/agents/langgraph/templates/react_with_database_memory/Makefile
@@ -1,6 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
-REPO_ROOT      := $(shell git rev-parse --show-toplevel)
+REPO_ROOT      := $(shell git rev-parse --show-toplevel 2>/dev/null || echo ../../../..)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -176,9 +176,19 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove deployment from cluster
-	@helm_status=0; cleanup_status=0; \
-	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
-	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	@helm_status=0; cleanup_status=0; cleanup_script="$(REPO_ROOT)/scripts/openshift-build-config.sh"; \
+	helm_output=$$(helm uninstall $(AGENT_NAME) 2>&1); helm_status=$$?; \
+	if [ -n "$$helm_output" ]; then \
+	  if [ $$helm_status -eq 0 ]; then printf '%s\n' "$$helm_output"; else printf '%s\n' "$$helm_output" >&2; fi; \
+	fi; \
+	if [ $$helm_status -ne 0 ]; then \
+	  case "$$helm_output" in *"Release not loaded"*|*"release: not found"*) helm_status=0 ;; esac; \
+	fi; \
+	if [ -f "$$cleanup_script" ]; then \
+	  bash "$$cleanup_script" cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	else \
+	  echo "WARNING: cleanup script not found: $$cleanup_script" >&2; \
+	fi; \
 	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
 	exit $$cleanup_status
 

--- a/agents/langgraph/templates/react_with_database_memory/tests/integration/conftest.py
+++ b/agents/langgraph/templates/react_with_database_memory/tests/integration/conftest.py
@@ -68,11 +68,13 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
     container_image = f"{INTERNAL_REGISTRY}/{namespace}/{agent_name}:latest"
     env_path = _write_env_file(agent_dir, container_image)
 
+    build_attempted = False
     deployed = False
     try:
         try:
             logger.info("Building image on cluster via build-openshift...")
             run_make("build-openshift", cwd=agent_dir, timeout=600)
+            build_attempted = True
 
             logger.info("Deploying to cluster...")
             run_make("deploy", cwd=agent_dir, timeout=300)
@@ -88,8 +90,8 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
         yield route_url
 
     finally:
-        if deployed:
-            logger.info("Tearing down deployment...")
+        if build_attempted:
+            logger.info("Tearing down deployment and build artifacts...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/langgraph/templates/react_with_database_memory/tests/integration/conftest.py
+++ b/agents/langgraph/templates/react_with_database_memory/tests/integration/conftest.py
@@ -89,7 +89,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
 
     finally:
         if build_attempted:
-            logger.info("Tearing down deployment and build artifacts...")
+            logger.info("Tearing down deployment...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/langgraph/templates/react_with_database_memory/tests/integration/conftest.py
+++ b/agents/langgraph/templates/react_with_database_memory/tests/integration/conftest.py
@@ -69,16 +69,14 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
     env_path = _write_env_file(agent_dir, container_image)
 
     build_attempted = False
-    deployed = False
     try:
         try:
             logger.info("Building image on cluster via build-openshift...")
-            run_make("build-openshift", cwd=agent_dir, timeout=600)
             build_attempted = True
+            run_make("build-openshift", cwd=agent_dir, timeout=600)
 
             logger.info("Deploying to cluster...")
             run_make("deploy", cwd=agent_dir, timeout=300)
-            deployed = True
 
             route_url = get_route(agent_name, namespace=namespace)
             logger.info("Agent deployed at %s", route_url)

--- a/agents/llamaindex/templates/websearch_agent/Makefile
+++ b/agents/llamaindex/templates/websearch_agent/Makefile
@@ -166,7 +166,7 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_TRACKING_INSECURE_TLS:+--set env.MLFLOW_TRACKING_INSECURE_TLS="$${MLFLOW_TRACKING_INSECURE_TLS}"} \
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
-undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+undeploy: ## Remove deployment from cluster
 	helm uninstall $(AGENT_NAME) --ignore-not-found
 	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 

--- a/agents/llamaindex/templates/websearch_agent/Makefile
+++ b/agents/llamaindex/templates/websearch_agent/Makefile
@@ -167,8 +167,11 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME) --ignore-not-found
-	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
+	@helm_status=0; cleanup_status=0; \
+	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
+	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
+	exit $$cleanup_status
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)

--- a/agents/llamaindex/templates/websearch_agent/Makefile
+++ b/agents/llamaindex/templates/websearch_agent/Makefile
@@ -1,6 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
-REPO_ROOT      := $(shell git rev-parse --show-toplevel)
+REPO_ROOT      := $(shell git rev-parse --show-toplevel 2>/dev/null || echo ../../../..)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -167,9 +167,19 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove deployment from cluster
-	@helm_status=0; cleanup_status=0; \
-	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
-	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	@helm_status=0; cleanup_status=0; cleanup_script="$(REPO_ROOT)/scripts/openshift-build-config.sh"; \
+	helm_output=$$(helm uninstall $(AGENT_NAME) 2>&1); helm_status=$$?; \
+	if [ -n "$$helm_output" ]; then \
+	  if [ $$helm_status -eq 0 ]; then printf '%s\n' "$$helm_output"; else printf '%s\n' "$$helm_output" >&2; fi; \
+	fi; \
+	if [ $$helm_status -ne 0 ]; then \
+	  case "$$helm_output" in *"Release not loaded"*|*"release: not found"*) helm_status=0 ;; esac; \
+	fi; \
+	if [ -f "$$cleanup_script" ]; then \
+	  bash "$$cleanup_script" cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	else \
+	  echo "WARNING: cleanup script not found: $$cleanup_script" >&2; \
+	fi; \
 	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
 	exit $$cleanup_status
 

--- a/agents/llamaindex/templates/websearch_agent/Makefile
+++ b/agents/llamaindex/templates/websearch_agent/Makefile
@@ -1,5 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
+REPO_ROOT      := $(shell git rev-parse --show-toplevel)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -100,6 +101,7 @@ push: ## Push container image to registry
 build-openshift: ## Build image in-cluster via OpenShift BuildConfig (no podman/docker needed)
 	@cp -r ../../../../images ./images && trap 'rm -rf ./images' EXIT && \
 	  oc new-build --strategy=docker --binary --name=$(AGENT_NAME) --to=$(AGENT_NAME):latest 2>/dev/null || true && \
+	  $(REPO_ROOT)/scripts/openshift-build-config.sh patch-history $(AGENT_NAME) && \
 	  oc start-build $(AGENT_NAME) --from-dir=. --follow && \
 	  NS=$$(oc project -q) && \
 	  echo "" && \
@@ -164,8 +166,9 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_TRACKING_INSECURE_TLS:+--set env.MLFLOW_TRACKING_INSECURE_TLS="$${MLFLOW_TRACKING_INSECURE_TLS}"} \
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
-undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME)
+undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+	helm uninstall $(AGENT_NAME) --ignore-not-found
+	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)

--- a/agents/llamaindex/templates/websearch_agent/tests/integration/test_deployment.py
+++ b/agents/llamaindex/templates/websearch_agent/tests/integration/test_deployment.py
@@ -58,15 +58,13 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
     env_path, orig_env = _write_env_file(agent_dir, container_image)
 
     build_attempted = False
-    deployed = False
     try:
         logger.info("Building image on cluster via build-openshift...")
-        run_make("build-openshift", cwd=agent_dir, timeout=600)
         build_attempted = True
+        run_make("build-openshift", cwd=agent_dir, timeout=600)
 
         logger.info("Deploying to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)
-        deployed = True
 
         route_url = get_route(agent_name, namespace=namespace)
         logger.info("Agent deployed at %s", route_url)

--- a/agents/llamaindex/templates/websearch_agent/tests/integration/test_deployment.py
+++ b/agents/llamaindex/templates/websearch_agent/tests/integration/test_deployment.py
@@ -57,10 +57,12 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
     container_image = f"{INTERNAL_REGISTRY}/{namespace}/{agent_name}:latest"
     env_path, orig_env = _write_env_file(agent_dir, container_image)
 
+    build_attempted = False
     deployed = False
     try:
         logger.info("Building image on cluster via build-openshift...")
         run_make("build-openshift", cwd=agent_dir, timeout=600)
+        build_attempted = True
 
         logger.info("Deploying to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)
@@ -75,8 +77,8 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
         pytest.fail(f"Deployment failed: {exc}")
 
     finally:
-        if deployed:
-            logger.info("Tearing down deployment...")
+        if build_attempted:
+            logger.info("Tearing down deployment and build artifacts...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/llamaindex/templates/websearch_agent/tests/integration/test_deployment.py
+++ b/agents/llamaindex/templates/websearch_agent/tests/integration/test_deployment.py
@@ -76,7 +76,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
 
     finally:
         if build_attempted:
-            logger.info("Tearing down deployment and build artifacts...")
+            logger.info("Tearing down deployment...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/vanilla_python/templates/openai_responses_agent/Makefile
+++ b/agents/vanilla_python/templates/openai_responses_agent/Makefile
@@ -127,7 +127,7 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_TRACKING_INSECURE_TLS:+--set env.MLFLOW_TRACKING_INSECURE_TLS="$${MLFLOW_TRACKING_INSECURE_TLS}"} \
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
-undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+undeploy: ## Remove deployment from cluster
 	helm uninstall $(AGENT_NAME) --ignore-not-found
 	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 

--- a/agents/vanilla_python/templates/openai_responses_agent/Makefile
+++ b/agents/vanilla_python/templates/openai_responses_agent/Makefile
@@ -1,6 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
-REPO_ROOT      := $(shell git rev-parse --show-toplevel)
+REPO_ROOT      := $(shell git rev-parse --show-toplevel 2>/dev/null || echo ../../../..)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -128,9 +128,19 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove deployment from cluster
-	@helm_status=0; cleanup_status=0; \
-	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
-	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	@helm_status=0; cleanup_status=0; cleanup_script="$(REPO_ROOT)/scripts/openshift-build-config.sh"; \
+	helm_output=$$(helm uninstall $(AGENT_NAME) 2>&1); helm_status=$$?; \
+	if [ -n "$$helm_output" ]; then \
+	  if [ $$helm_status -eq 0 ]; then printf '%s\n' "$$helm_output"; else printf '%s\n' "$$helm_output" >&2; fi; \
+	fi; \
+	if [ $$helm_status -ne 0 ]; then \
+	  case "$$helm_output" in *"Release not loaded"*|*"release: not found"*) helm_status=0 ;; esac; \
+	fi; \
+	if [ -f "$$cleanup_script" ]; then \
+	  bash "$$cleanup_script" cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	else \
+	  echo "WARNING: cleanup script not found: $$cleanup_script" >&2; \
+	fi; \
 	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
 	exit $$cleanup_status
 

--- a/agents/vanilla_python/templates/openai_responses_agent/Makefile
+++ b/agents/vanilla_python/templates/openai_responses_agent/Makefile
@@ -1,5 +1,6 @@
 SHELL          := bash
 AGENT_NAME     := $(shell python3 -c "import re; print(re.search(r'^name:\s*(.+)', open('agent.yaml').read(), re.M).group(1).strip())")
+REPO_ROOT      := $(shell git rev-parse --show-toplevel)
 CHART_DIR      := ../../deployment
 VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
@@ -61,6 +62,7 @@ push: ## Push container image to registry
 build-openshift: ## Build image in-cluster via OpenShift BuildConfig (no podman/docker needed)
 	@cp -r ../../../../images ./images && trap 'rm -rf ./images' EXIT && \
 	  oc new-build --strategy=docker --binary --name=$(AGENT_NAME) --to=$(AGENT_NAME):latest 2>/dev/null || true && \
+	  $(REPO_ROOT)/scripts/openshift-build-config.sh patch-history $(AGENT_NAME) && \
 	  oc start-build $(AGENT_NAME) --from-dir=. --follow && \
 	  NS=$$(oc project -q) && \
 	  echo "" && \
@@ -125,8 +127,9 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_TRACKING_INSECURE_TLS:+--set env.MLFLOW_TRACKING_INSECURE_TLS="$${MLFLOW_TRACKING_INSECURE_TLS}"} \
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
-undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME)
+undeploy: ## Remove deployment and OpenShift build artifacts from cluster
+	helm uninstall $(AGENT_NAME) --ignore-not-found
+	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)

--- a/agents/vanilla_python/templates/openai_responses_agent/Makefile
+++ b/agents/vanilla_python/templates/openai_responses_agent/Makefile
@@ -128,8 +128,11 @@ dry-run: _check-env ## Render Helm templates without deploying
 	    $${MLFLOW_WORKSPACE:+--set env.MLFLOW_WORKSPACE="$${MLFLOW_WORKSPACE}"}
 
 undeploy: ## Remove deployment from cluster
-	helm uninstall $(AGENT_NAME) --ignore-not-found
-	@$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME)
+	@helm_status=0; cleanup_status=0; \
+	helm uninstall $(AGENT_NAME) --ignore-not-found || helm_status=$$?; \
+	$(REPO_ROOT)/scripts/openshift-build-config.sh cleanup $(AGENT_NAME) || cleanup_status=$$?; \
+	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
+	exit $$cleanup_status
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)

--- a/agents/vanilla_python/templates/openai_responses_agent/tests/integration/test_deployment.py
+++ b/agents/vanilla_python/templates/openai_responses_agent/tests/integration/test_deployment.py
@@ -59,15 +59,13 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
     env_path, orig_env = _write_env_file(agent_dir, container_image)
 
     build_attempted = False
-    deployed = False
     try:
         logger.info("Building image on cluster via build-openshift...")
-        run_make("build-openshift", cwd=agent_dir, timeout=600)
         build_attempted = True
+        run_make("build-openshift", cwd=agent_dir, timeout=600)
 
         logger.info("Deploying to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)
-        deployed = True
 
         route_url = get_route(agent_name, namespace=namespace)
         logger.info("Agent deployed at %s", route_url)

--- a/agents/vanilla_python/templates/openai_responses_agent/tests/integration/test_deployment.py
+++ b/agents/vanilla_python/templates/openai_responses_agent/tests/integration/test_deployment.py
@@ -77,7 +77,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
 
     finally:
         if build_attempted:
-            logger.info("Tearing down deployment and build artifacts...")
+            logger.info("Tearing down deployment...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/agents/vanilla_python/templates/openai_responses_agent/tests/integration/test_deployment.py
+++ b/agents/vanilla_python/templates/openai_responses_agent/tests/integration/test_deployment.py
@@ -58,10 +58,12 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
     container_image = f"{INTERNAL_REGISTRY}/{namespace}/{agent_name}:latest"
     env_path, orig_env = _write_env_file(agent_dir, container_image)
 
+    build_attempted = False
     deployed = False
     try:
         logger.info("Building image on cluster via build-openshift...")
         run_make("build-openshift", cwd=agent_dir, timeout=600)
+        build_attempted = True
 
         logger.info("Deploying to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)
@@ -76,8 +78,8 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
         pytest.fail(f"Deployment failed: {exc}")
 
     finally:
-        if deployed:
-            logger.info("Tearing down deployment...")
+        if build_attempted:
+            logger.info("Tearing down deployment and build artifacts...")
             try:
                 run_make("undeploy", cwd=agent_dir, timeout=120)
             except MakeTargetError:

--- a/docs/openshift-deployment.md
+++ b/docs/openshift-deployment.md
@@ -118,6 +118,16 @@ The route URL is your agent's public endpoint.
 make undeploy
 ```
 
+`make undeploy` removes the Helm release **and** deletes the agent's OpenShift
+`BuildConfig` and `ImageStream`. Build history is capped at **2 successful /
+1 failed** build per agent whenever `make build-openshift` runs.
+
+Shared namespace resources (e.g. `postgres` in `ci-testing`) are not touched.
+
+For one-time cleanup of accumulated build artifacts in the shared `ci-testing`
+namespace, see
+[ci-testing build cleanup runbook](../superpowers/runbooks/ci-testing-build-cleanup.md).
+
 ## Customizing Deployment
 
 Each agent has a `values.yaml` that overrides the framework chart defaults at `agents/<framework>/deployment/values.yaml`. You can:

--- a/docs/openshift-deployment.md
+++ b/docs/openshift-deployment.md
@@ -126,7 +126,7 @@ Shared namespace resources (e.g. `postgres` in `ci-testing`) are not touched.
 
 For one-time cleanup of accumulated build artifacts in the shared `ci-testing`
 namespace, see
-[ci-testing build cleanup runbook](../superpowers/runbooks/ci-testing-build-cleanup.md).
+[ci-testing build cleanup runbook](superpowers/runbooks/ci-testing-build-cleanup.md).
 
 ## Customizing Deployment
 

--- a/docs/superpowers/runbooks/ci-testing-build-cleanup.md
+++ b/docs/superpowers/runbooks/ci-testing-build-cleanup.md
@@ -1,0 +1,88 @@
+# One-time ci-testing build artifact cleanup (RHAIENG-6183)
+
+Use this runbook to reduce accumulated OpenShift build artifacts in the shared
+`ci-testing` namespace after RHAIENG-6183 lands. Ongoing cleanup is handled by
+agent `make undeploy` (Helm release + BC/IS deletion) and `make build-openshift`
+(2/1 history limits via `scripts/openshift-build-config.sh`).
+
+## Patch existing BuildConfigs to 2/1 (triggers controller prune)
+
+```bash
+oc project ci-testing
+for bc in $(oc get bc -o name); do
+  oc patch "$bc" --type=merge \
+    -p '{"spec":{"successfulBuildsHistoryLimit":2,"failedBuildsHistoryLimit":1}}'
+done
+```
+
+Alternatively, patch a single agent BC the same way `make build-openshift` does:
+
+```bash
+scripts/openshift-build-config.sh patch-history <agent-name> -n ci-testing
+```
+
+## Verify counts drop (wait ~5–15 min)
+
+After patching, the build controller prunes excess Build and ConfigMap objects
+over several minutes. Re-check until counts stabilize:
+
+```bash
+oc get builds --no-headers | wc -l
+oc get cm --no-headers | wc -l
+```
+
+Optional spot-check that limits applied:
+
+```bash
+oc get bc -o custom-columns=NAME:.metadata.name,SUCCESS:.spec.successfulBuildsHistoryLimit,FAILED:.spec.failedBuildsHistoryLimit
+```
+
+## Remove stale Helm releases (example)
+
+Orphaned Helm releases may remain after failed integration tests. List and
+remove only releases you recognize as stale test agents:
+
+```bash
+helm list -n ci-testing
+helm uninstall langgraph-ci-failure-summarizer-agent -n ci-testing  # if orphaned
+```
+
+Then remove matching BC/IS if still present (agent name must **not** be on the
+denylist — see below):
+
+```bash
+scripts/openshift-build-config.sh cleanup langgraph-ci-failure-summarizer-agent -n ci-testing
+```
+
+## Do not delete
+
+Never run `oc delete all` or blanket ConfigMap delete in `ci-testing`. The
+following shared resources must be preserved.
+
+### BuildConfig / ImageStream denylist
+
+`scripts/openshift-build-config.sh` refuses `cleanup` for names in
+`CLEANUP_DENYLIST` (see `scripts/openshift-build-config.sh`):
+
+| Resource | Reason |
+|----------|--------|
+| `postgres` | Shared database for integration tests |
+| `minio` | Shared object storage |
+| `mcp-automl` | Shared MCP server (autogen agent); use `undeploy-mcp`, not agent `undeploy` |
+| `langflow-simple-tool-calling-agent` | Langflow pre-deploy / shared infra |
+
+### Platform and CA bundle ConfigMaps
+
+Do **not** delete namespace service accounts, pull secrets, or platform CA
+bundle ConfigMaps, including:
+
+- `config-*-cabundle` (OpenShift injected CA bundles)
+- `kube-root-ca.crt`
+- `odh-*` (Open Data Hub operator bundles)
+- `openshift-service-ca.crt`
+- `tempo-sample-*` (observability sample resources)
+
+### Other shared infra
+
+- Langflow routes and deployments tied to `langflow-simple-tool-calling-agent`
+- Namespace service accounts and image pull secrets

--- a/docs/superpowers/runbooks/ci-testing-build-cleanup.md
+++ b/docs/superpowers/runbooks/ci-testing-build-cleanup.md
@@ -8,10 +8,14 @@ agent `make undeploy` (Helm release + BC/IS deletion) and `make build-openshift`
 ## Patch existing BuildConfigs to 2/1 (triggers controller prune)
 
 ```bash
-oc project ci-testing
-for bc in $(oc get bc -o name); do
-  oc patch "$bc" --type=merge \
-    -p '{"spec":{"successfulBuildsHistoryLimit":2,"failedBuildsHistoryLimit":1}}'
+set -euo pipefail
+oc project ci-testing >/dev/null
+for bc in $(oc get bc -n ci-testing -o name); do
+  name="${bc#buildconfig.build.openshift.io/}"
+  case "$name" in
+    postgres|minio|mcp-automl|langflow-simple-tool-calling-agent) continue ;;
+  esac
+  scripts/openshift-build-config.sh patch-history "$name" -n ci-testing
 done
 ```
 
@@ -27,14 +31,14 @@ After patching, the build controller prunes excess Build and ConfigMap objects
 over several minutes. Re-check until counts stabilize:
 
 ```bash
-oc get builds --no-headers | wc -l
-oc get cm --no-headers | wc -l
+oc get builds -n ci-testing --no-headers | wc -l
+oc get cm -n ci-testing --no-headers | wc -l
 ```
 
 Optional spot-check that limits applied:
 
 ```bash
-oc get bc -o custom-columns=NAME:.metadata.name,SUCCESS:.spec.successfulBuildsHistoryLimit,FAILED:.spec.failedBuildsHistoryLimit
+oc get bc -n ci-testing -o custom-columns=NAME:.metadata.name,SUCCESS:.spec.successfulBuildsHistoryLimit,FAILED:.spec.failedBuildsHistoryLimit
 ```
 
 ## Remove stale Helm releases (example)

--- a/scripts/openshift-build-config.sh
+++ b/scripts/openshift-build-config.sh
@@ -52,8 +52,7 @@ patch_history() {
   local agent="$1"
   local ns_flag=("${NAMESPACE_ARGS[@]}")
   oc patch "bc/${agent}" "${ns_flag[@]}" --type=merge \
-    -p "{\"spec\":{\"successfulBuildsHistoryLimit\":${SUCCESSFUL_LIMIT},\"failedBuildsHistoryLimit\":${FAILED_LIMIT}}}" \
-    2>/dev/null || true
+    -p "{\"spec\":{\"successfulBuildsHistoryLimit\":${SUCCESSFUL_LIMIT},\"failedBuildsHistoryLimit\":${FAILED_LIMIT}}}"
 }
 
 cleanup() {

--- a/scripts/openshift-build-config.sh
+++ b/scripts/openshift-build-config.sh
@@ -32,6 +32,13 @@ require_oc() {
   }
 }
 
+skip_cleanup_without_oc() {
+  if ! command -v oc >/dev/null 2>&1; then
+    echo "WARNING: oc not found in PATH; skipping BC/IS cleanup" >&2
+    exit 0
+  fi
+}
+
 is_cleanup_denylisted() {
   local agent="$1"
   local denied
@@ -78,7 +85,7 @@ main() {
         echo "ERROR: refusing to delete denylisted shared resource: ${agent}" >&2
         exit 1
       fi
-      require_oc
+      skip_cleanup_without_oc
       cleanup "$agent"
       ;;
     *)

--- a/scripts/openshift-build-config.sh
+++ b/scripts/openshift-build-config.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# OpenShift BuildConfig helpers for agent integration tests and local undeploy.
+set -euo pipefail
+
+readonly SUCCESSFUL_LIMIT=2
+readonly FAILED_LIMIT=1
+
+# Shared cluster resources that must never be deleted by cleanup.
+readonly CLEANUP_DENYLIST=(
+  postgres
+  minio
+  mcp-automl
+  langflow-simple-tool-calling-agent
+)
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <command> <agent-name> [-n namespace]
+
+Commands:
+  patch-history   Set BC history limits to ${SUCCESSFUL_LIMIT}/${FAILED_LIMIT}
+  cleanup         Delete BuildConfig and ImageStream for agent-name
+
+Requires: oc logged in; namespace from -n or current oc project.
+EOF
+}
+
+require_oc() {
+  command -v oc >/dev/null 2>&1 || {
+    echo "ERROR: oc not found in PATH" >&2
+    exit 1
+  }
+}
+
+is_cleanup_denylisted() {
+  local agent="$1"
+  local denied
+  for denied in "${CLEANUP_DENYLIST[@]}"; do
+    if [[ "$agent" == "$denied" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+patch_history() {
+  local agent="$1"
+  local ns_flag=("${NAMESPACE_ARGS[@]}")
+  oc patch "bc/${agent}" "${ns_flag[@]}" --type=merge \
+    -p "{\"spec\":{\"successfulBuildsHistoryLimit\":${SUCCESSFUL_LIMIT},\"failedBuildsHistoryLimit\":${FAILED_LIMIT}}}" \
+    2>/dev/null || true
+}
+
+cleanup() {
+  local agent="$1"
+  local ns_flag=("${NAMESPACE_ARGS[@]}")
+  oc delete "buildconfig/${agent}" "imagestream/${agent}" \
+    "${ns_flag[@]}" --ignore-not-found=true
+}
+
+main() {
+  local cmd="${1:-}"
+  local agent="${2:-}"
+  NAMESPACE_ARGS=()
+  if [[ "${3:-}" == "-n" && -n "${4:-}" ]]; then
+    NAMESPACE_ARGS=(-n "$4")
+  fi
+
+  case "$cmd" in
+    patch-history)
+      [[ -n "$agent" ]] || { echo "ERROR: agent name required" >&2; usage; exit 1; }
+      require_oc
+      patch_history "$agent"
+      ;;
+    cleanup)
+      [[ -n "$agent" ]] || { echo "ERROR: agent name required" >&2; usage; exit 1; }
+      if is_cleanup_denylisted "$agent"; then
+        echo "ERROR: refusing to delete denylisted shared resource: ${agent}" >&2
+        exit 1
+      fi
+      require_oc
+      cleanup "$agent"
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/openshift-build-config.sh
+++ b/scripts/openshift-build-config.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
-# OpenShift BuildConfig helpers for agent integration tests and local undeploy.
 set -euo pipefail
 
 readonly SUCCESSFUL_LIMIT=2
 readonly FAILED_LIMIT=1
 
-# Shared cluster resources that must never be deleted by cleanup.
 readonly CLEANUP_DENYLIST=(
   postgres
   minio

--- a/scripts/openshift-build-config.sh
+++ b/scripts/openshift-build-config.sh
@@ -39,9 +39,15 @@ skip_cleanup_without_oc() {
 
 is_cleanup_denylisted() {
   local agent="$1"
+  local normalized_agent
   local denied
+  normalized_agent="$(printf '%s' "$agent" | tr '[:upper:]' '[:lower:]')"
+  normalized_agent="${normalized_agent#"${normalized_agent%%[![:space:]]*}"}"
+  normalized_agent="${normalized_agent%"${normalized_agent##*[![:space:]]}"}"
+  normalized_agent="${normalized_agent#./}"
+  normalized_agent="${normalized_agent##*/}"
   for denied in "${CLEANUP_DENYLIST[@]}"; do
-    if [[ "$agent" == "$denied" ]]; then
+    if [[ "$normalized_agent" == "$denied" ]]; then
       return 0
     fi
   done
@@ -50,14 +56,14 @@ is_cleanup_denylisted() {
 
 patch_history() {
   local agent="$1"
-  local ns_flag=("${NAMESPACE_ARGS[@]}")
+  local ns_flag=("${NAMESPACE_ARGS[@]+"${NAMESPACE_ARGS[@]}"}")
   oc patch "bc/${agent}" "${ns_flag[@]}" --type=merge \
     -p "{\"spec\":{\"successfulBuildsHistoryLimit\":${SUCCESSFUL_LIMIT},\"failedBuildsHistoryLimit\":${FAILED_LIMIT}}}"
 }
 
 cleanup() {
   local agent="$1"
-  local ns_flag=("${NAMESPACE_ARGS[@]}")
+  local ns_flag=("${NAMESPACE_ARGS[@]+"${NAMESPACE_ARGS[@]}"}")
   oc delete "buildconfig/${agent}" "imagestream/${agent}" \
     "${ns_flag[@]}" --ignore-not-found=true
 }

--- a/tests/scripts/test_openshift_build_config.py
+++ b/tests/scripts/test_openshift_build_config.py
@@ -27,8 +27,19 @@ def run_script(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def script_denylist() -> tuple[str, ...]:
+    lines = SCRIPT.read_text(encoding="utf-8").splitlines()
+    start = lines.index("readonly CLEANUP_DENYLIST=(") + 1
+    end = lines.index(")", start)
+    return tuple(line.strip() for line in lines[start:end] if line.strip())
+
+
 def test_script_exists():
     assert SCRIPT.is_file()
+
+
+def test_cleanup_denylist_stays_in_sync_with_script():
+    assert CLEANUP_DENYLIST == script_denylist()
 
 
 def test_patch_history_requires_agent_name():
@@ -42,12 +53,25 @@ def test_cleanup_requires_agent_name():
     assert result.returncode != 0
 
 
+def test_unknown_command_prints_usage():
+    result = run_script("wat")
+    assert result.returncode != 0
+    assert "usage:" in result.stderr.lower() or "usage:" in result.stdout.lower()
+
+
 @pytest.mark.parametrize("denylisted", CLEANUP_DENYLIST)
 def test_cleanup_rejects_denylisted_names(denylisted: str):
     result = run_script("cleanup", denylisted)
     assert result.returncode == 1
     assert "denylisted" in result.stderr.lower() or "refusing" in result.stderr.lower()
     assert denylisted in result.stderr
+
+
+@pytest.mark.parametrize("denylisted", (" POSTGRES ", "./postgres", "foo/POSTGRES"))
+def test_cleanup_rejects_normalized_denylisted_names(denylisted: str):
+    result = run_script("cleanup", denylisted)
+    assert result.returncode == 1
+    assert "denylisted" in result.stderr.lower() or "refusing" in result.stderr.lower()
 
 
 def test_cleanup_skips_when_oc_missing(tmp_path: Path):
@@ -66,6 +90,24 @@ def test_cleanup_skips_when_oc_missing(tmp_path: Path):
     )
     assert result.returncode == 0
     assert "skipping" in result.stderr.lower()
+
+
+def test_patch_history_requires_oc(tmp_path: Path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    bash_path = shutil.which("bash")
+    assert bash_path is not None
+    fake_bin.joinpath("bash").symlink_to(Path(bash_path).resolve())
+    result = subprocess.run(
+        [str(SCRIPT), "patch-history", "langgraph-react-agent"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={"PATH": str(fake_bin)},
+    )
+    assert result.returncode != 0
+    assert "oc not found" in result.stderr.lower()
 
 
 def test_patch_history_fails_when_oc_patch_fails(tmp_path: Path):
@@ -90,3 +132,28 @@ def test_patch_history_fails_when_oc_patch_fails(tmp_path: Path):
     )
     assert result.returncode != 0
     assert "patch failed" in result.stderr
+
+
+def test_cleanup_deletes_buildconfig_and_imagestream(tmp_path: Path):
+    fake_oc = tmp_path / "oc"
+    log_path = tmp_path / "oc.log"
+    fake_oc.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf \'%s\\n\' \"$*\" >> "{log_path}"\n'
+        "exit 0\n"
+    )
+    fake_oc.chmod(0o755)
+
+    result = subprocess.run(
+        [str(SCRIPT), "cleanup", "langgraph-react-agent"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={"PATH": f"{tmp_path}:/usr/bin:/bin"},
+    )
+
+    assert result.returncode == 0
+    assert log_path.read_text(encoding="utf-8").splitlines() == [
+        "delete buildconfig/langgraph-react-agent imagestream/langgraph-react-agent --ignore-not-found=true"
+    ]

--- a/tests/scripts/test_openshift_build_config.py
+++ b/tests/scripts/test_openshift_build_config.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "openshift-build-config.sh"
+
+CLEANUP_DENYLIST = (
+    "postgres",
+    "minio",
+    "mcp-automl",
+    "langflow-simple-tool-calling-agent",
+)
+
+
+def run_script(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(SCRIPT), *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_script_exists_and_is_executable():
+    assert SCRIPT.is_file()
+    assert SCRIPT.stat().st_mode & 0o111
+
+
+def test_patch_history_requires_agent_name():
+    result = run_script("patch-history")
+    assert result.returncode != 0
+    assert "agent name" in result.stderr.lower() or "usage" in result.stderr.lower()
+
+
+def test_cleanup_requires_agent_name():
+    result = run_script("cleanup")
+    assert result.returncode != 0
+
+
+@pytest.mark.parametrize("denylisted", CLEANUP_DENYLIST)
+def test_cleanup_rejects_denylisted_names(denylisted: str):
+    result = run_script("cleanup", denylisted)
+    assert result.returncode == 1
+    assert "denylisted" in result.stderr.lower() or "refusing" in result.stderr.lower()
+    assert denylisted in result.stderr
+
+
+def test_patch_history_payload_is_valid_json():
+    """Dry-run: script should emit merge patch with 2/1 limits (no oc required)."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "successfulBuildsHistoryLimit" in text
+    assert "failedBuildsHistoryLimit" in text
+    assert "SUCCESSFUL_LIMIT=2" in text
+    assert "FAILED_LIMIT=1" in text
+
+
+def test_cleanup_denylist_contains_expected_names():
+    text = SCRIPT.read_text(encoding="utf-8")
+    for name in CLEANUP_DENYLIST:
+        assert name in text

--- a/tests/scripts/test_openshift_build_config.py
+++ b/tests/scripts/test_openshift_build_config.py
@@ -138,9 +138,7 @@ def test_cleanup_deletes_buildconfig_and_imagestream(tmp_path: Path):
     fake_oc = tmp_path / "oc"
     log_path = tmp_path / "oc.log"
     fake_oc.write_text(
-        "#!/usr/bin/env bash\n"
-        f'printf \'%s\\n\' \"$*\" >> "{log_path}"\n'
-        "exit 0\n"
+        f'#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" >> "{log_path}"\nexit 0\n'
     )
     fake_oc.chmod(0o755)
 

--- a/tests/scripts/test_openshift_build_config.py
+++ b/tests/scripts/test_openshift_build_config.py
@@ -60,3 +60,27 @@ def test_cleanup_skips_when_oc_missing():
     )
     assert result.returncode == 0
     assert "skipping" in result.stderr.lower()
+
+
+def test_patch_history_fails_when_oc_patch_fails(tmp_path: Path):
+    fake_oc = tmp_path / "oc"
+    fake_oc.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [[ "$1" == patch ]]; then\n'
+        '  echo "patch failed" >&2\n'
+        "  exit 1\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    fake_oc.chmod(0o755)
+
+    result = subprocess.run(
+        [str(SCRIPT), "patch-history", "langgraph-react-agent", "-n", "ci-testing"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={"PATH": f"{tmp_path}:/usr/bin:/bin"},
+    )
+    assert result.returncode != 0
+    assert "patch failed" in result.stderr

--- a/tests/scripts/test_openshift_build_config.py
+++ b/tests/scripts/test_openshift_build_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -49,14 +50,19 @@ def test_cleanup_rejects_denylisted_names(denylisted: str):
     assert denylisted in result.stderr
 
 
-def test_cleanup_skips_when_oc_missing():
+def test_cleanup_skips_when_oc_missing(tmp_path: Path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    bash_path = shutil.which("bash")
+    assert bash_path is not None
+    fake_bin.joinpath("bash").symlink_to(Path(bash_path).resolve())
     result = subprocess.run(
         [str(SCRIPT), "cleanup", "langgraph-react-agent"],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
         check=False,
-        env={"PATH": "/usr/bin:/bin"},
+        env={"PATH": str(fake_bin)},
     )
     assert result.returncode == 0
     assert "skipping" in result.stderr.lower()

--- a/tests/scripts/test_openshift_build_config.py
+++ b/tests/scripts/test_openshift_build_config.py
@@ -50,6 +50,19 @@ def test_cleanup_rejects_denylisted_names(denylisted: str):
     assert denylisted in result.stderr
 
 
+def test_cleanup_skips_when_oc_missing():
+    result = subprocess.run(
+        [str(SCRIPT), "cleanup", "langgraph-react-agent"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={"PATH": "/usr/bin:/bin"},
+    )
+    assert result.returncode == 0
+    assert "skipping" in result.stderr.lower()
+
+
 def test_patch_history_payload_is_valid_json():
     """Dry-run: script should emit merge patch with 2/1 limits (no oc required)."""
     text = SCRIPT.read_text(encoding="utf-8")

--- a/tests/scripts/test_openshift_build_config.py
+++ b/tests/scripts/test_openshift_build_config.py
@@ -26,9 +26,8 @@ def run_script(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def test_script_exists_and_is_executable():
+def test_script_exists():
     assert SCRIPT.is_file()
-    assert SCRIPT.stat().st_mode & 0o111
 
 
 def test_patch_history_requires_agent_name():
@@ -61,18 +60,3 @@ def test_cleanup_skips_when_oc_missing():
     )
     assert result.returncode == 0
     assert "skipping" in result.stderr.lower()
-
-
-def test_patch_history_payload_is_valid_json():
-    """Dry-run: script should emit merge patch with 2/1 limits (no oc required)."""
-    text = SCRIPT.read_text(encoding="utf-8")
-    assert "successfulBuildsHistoryLimit" in text
-    assert "failedBuildsHistoryLimit" in text
-    assert "SUCCESSFUL_LIMIT=2" in text
-    assert "FAILED_LIMIT=1" in text
-
-
-def test_cleanup_denylist_contains_expected_names():
-    text = SCRIPT.read_text(encoding="utf-8")
-    for name in CLEANUP_DENYLIST:
-        assert name in text


### PR DESCRIPTION
## Description

Integration tests and QG4 nightly runs use `make build-openshift`, which creates OpenShift BuildConfigs, ImageStreams, and build history in the shared `ci-testing` namespace. Teardown only ran `helm uninstall`, so BC/IS and build objects accumulated across runs.

This PR:

- Adds `scripts/openshift-build-config.sh` with `patch-history` (sets `successfulBuildsHistoryLimit: 2`, `failedBuildsHistoryLimit: 1`) and `cleanup` (deletes BC + IS for one agent)
- Wires both into all 12 agent `build-openshift` / `undeploy` Makefile targets
- Updates integration fixtures to call `undeploy` whenever `build-openshift` was attempted (including failed container builds)
- Documents behavior in `docs/openshift-deployment.md` and a one-time ops runbook

`cleanup` refuses denylisted shared resources: `postgres`, `minio`, `mcp-automl`, `langflow-simple-tool-calling-agent`.

## Jira Ticket

[RHAIENG-6183](https://redhat.atlassian.net/browse/RHAIENG-6183)

## Testing

- [x] `make test` passes (run from the affected agent directory)
- [x] Manual testing performed (describe steps below)
- [ ] No testing required (documentation/config change only)

- `python3 -m pytest tests/scripts/test_openshift_build_config.py` — 8 passed (denylist rejection, missing `oc` skip)
- `make test` in `agents/langgraph/templates/react_agent` — 24 passed, 1 skipped
- Cluster (`ci-testing`): one-time patch of all BCs to 2/1 — builds 62→24, ConfigMaps 180→78

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)

## Review Guidance

- Start with `scripts/openshift-build-config.sh` (denylist + `skip_cleanup_without_oc`)
- Makefile changes are repetitive across 12 agents — one representative diff (`react_agent`) is enough
- Integration fixture change is the same pattern: `build_attempted` set before `run_make("build-openshift")`
- `autogen` `undeploy-mcp` unchanged; agent `undeploy` only cleans `$(AGENT_NAME)`, not `mcp-automl`

## Related PRs

None

[RHAIENG-6183]: https://redhat.atlassian.net/browse/RHAIENG-6183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

AI-Attribution: AIA PAI Ce Hin R composer-2.5 v1.0
AI-Interpretation: https://aiattribution.github.io/statements/AIA-PAI-Ce-Hin-R-?model=composer-2.5