### PR TITLE
fix(langgraph): graceful error handling to all LangGraph agent templates

### DIFF
--- a/agents/langgraph/templates/agentic_rag/main.py
+++ b/agents/langgraph/templates/agentic_rag/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import time
@@ -8,6 +9,7 @@ from os import getenv
 from pathlib import Path
 from typing import Any
 
+import openai
 from agentic_rag.agent import get_graph_closure
 from agentic_rag.tracing import enable_tracing
 from fastapi import FastAPI, HTTPException
@@ -17,10 +19,25 @@ from fastapi.responses import (
     JSONResponse,
     StreamingResponse,
 )
+from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
-from pydantic import BaseModel, Field
+from langgraph.errors import GraphRecursionError
+from pydantic import BaseModel, Field, ValidationError
 
 logger = logging.getLogger(__name__)
+
+_MAX_INVOKE_ATTEMPTS = 3
+_GRACEFUL_ERROR_MESSAGE = (
+    "I was unable to process this request due to repeated internal errors."
+)
+_RETRYABLE_EXCEPTIONS = (
+    GraphRecursionError,
+    ValidationError,
+    OutputParserException,
+    openai.InternalServerError,
+    openai.APITimeoutError,
+    openai.APIConnectionError,
+)
 
 
 # OpenAI-compatible request/response models
@@ -212,6 +229,36 @@ def _make_completion_id() -> str:
     return f"chatcmpl-{uuid.uuid4().hex[:12]}"
 
 
+async def _invoke_with_retry(
+    input_data: dict,
+    config: dict,
+) -> dict:
+    global agent_graph
+    last_exception: Exception = RuntimeError("no invocation attempts were made")
+
+    for attempt in range(1, _MAX_INVOKE_ATTEMPTS + 1):
+        try:
+            return await agent_graph.ainvoke(input_data, config=config)
+        except _RETRYABLE_EXCEPTIONS as exc:
+            last_exception = exc
+            if attempt < _MAX_INVOKE_ATTEMPTS:
+                logger.warning(
+                    "LLM/graph invocation failed (attempt %d/%d): %s. Retrying.",
+                    attempt,
+                    _MAX_INVOKE_ATTEMPTS,
+                    type(exc).__name__,
+                )
+                await asyncio.sleep(0.5 * attempt)
+            else:
+                logger.error(
+                    "LLM/graph invocation failed after %d attempts: %s",
+                    _MAX_INVOKE_ATTEMPTS,
+                    type(exc).__name__,
+                )
+
+    raise last_exception
+
+
 @app.post(
     "/chat/completions",
     response_model=ChatCompletionResponse,
@@ -239,9 +286,28 @@ async def _handle_chat(messages: list[HumanMessage], model_id: str) -> dict[str,
     global agent_graph
 
     try:
-        result = await agent_graph.ainvoke(
-            {"messages": messages}, config={"recursion_limit": 15}
-        )
+        try:
+            result = await _invoke_with_retry(
+                {"messages": messages}, config={"recursion_limit": 15}
+            )
+        except _RETRYABLE_EXCEPTIONS:
+            return {
+                "id": _make_completion_id(),
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": model_id,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": _GRACEFUL_ERROR_MESSAGE,
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": None,
+            }
 
         # Extract the final assistant message content
         assistant_content = ""

--- a/agents/langgraph/templates/agentic_rag/main.py
+++ b/agents/langgraph/templates/agentic_rag/main.py
@@ -31,13 +31,14 @@ _GRACEFUL_ERROR_MESSAGE = (
     "I was unable to process this request due to repeated internal errors."
 )
 _RETRYABLE_EXCEPTIONS = (
-    GraphRecursionError,
     ValidationError,
     OutputParserException,
     openai.InternalServerError,
     openai.APITimeoutError,
     openai.APIConnectionError,
+    openai.RateLimitError,
 )
+_GRACEFUL_EXCEPTIONS = _RETRYABLE_EXCEPTIONS + (GraphRecursionError,)
 
 
 # OpenAI-compatible request/response models
@@ -290,7 +291,7 @@ async def _handle_chat(messages: list[HumanMessage], model_id: str) -> dict[str,
             result = await _invoke_with_retry(
                 {"messages": messages}, config={"recursion_limit": 15}
             )
-        except _RETRYABLE_EXCEPTIONS:
+        except _GRACEFUL_EXCEPTIONS:
             return {
                 "id": _make_completion_id(),
                 "object": "chat.completion",
@@ -306,6 +307,7 @@ async def _handle_chat(messages: list[HumanMessage], model_id: str) -> dict[str,
                         "finish_reason": "stop",
                     }
                 ],
+                "context": [],
                 "usage": None,
             }
 

--- a/agents/langgraph/templates/agentic_rag/tests/test_api_contract.py
+++ b/agents/langgraph/templates/agentic_rag/tests/test_api_contract.py
@@ -125,9 +125,18 @@ class TestInvokeWithRetry:
 
     def test_succeeds_after_transient_failure(self):
         expected = {"messages": [AIMessage(content="recovered")]}
-        mock_graph = AsyncMock(
-            ainvoke=AsyncMock(side_effect=[GraphRecursionError("loop"), expected])
+        exc = ValidationError.from_exception_data(
+            title="test",
+            line_errors=[
+                {
+                    "type": "dict_type",
+                    "loc": ("x",),
+                    "msg": "bad",
+                    "input": "y",
+                }
+            ],
         )
+        mock_graph = AsyncMock(ainvoke=AsyncMock(side_effect=[exc, expected]))
         with (
             patch("main.agent_graph", mock_graph),
             patch("main.asyncio.sleep", new_callable=AsyncMock),
@@ -137,14 +146,23 @@ class TestInvokeWithRetry:
         assert mock_graph.ainvoke.call_count == 2
 
     def test_exhausts_retries_and_raises(self):
-        mock_graph = AsyncMock(
-            ainvoke=AsyncMock(side_effect=GraphRecursionError("loop"))
+        exc = ValidationError.from_exception_data(
+            title="test",
+            line_errors=[
+                {
+                    "type": "dict_type",
+                    "loc": ("x",),
+                    "msg": "bad",
+                    "input": "y",
+                }
+            ],
         )
+        mock_graph = AsyncMock(ainvoke=AsyncMock(side_effect=exc))
         with (
             patch("main.agent_graph", mock_graph),
             patch("main.asyncio.sleep", new_callable=AsyncMock),
         ):
-            with pytest.raises(GraphRecursionError):
+            with pytest.raises(ValidationError):
                 asyncio.run(_invoke_with_retry({"messages": []}, config={}))
         assert mock_graph.ainvoke.call_count == _MAX_INVOKE_ATTEMPTS
 
@@ -178,6 +196,7 @@ class TestInvokeWithRetry:
         ):
             with pytest.raises(ValidationError):
                 asyncio.run(_invoke_with_retry({"messages": []}, config={}))
+        assert caplog.records
         for record in caplog.records:
             assert malformed_args not in record.getMessage()
 

--- a/agents/langgraph/templates/agentic_rag/tests/test_api_contract.py
+++ b/agents/langgraph/templates/agentic_rag/tests/test_api_contract.py
@@ -6,16 +6,26 @@ Covers:
 - _extract_usage returns None when no metadata is available
 """
 
+import asyncio
+import logging
 import os
 import sys
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langgraph.errors import GraphRecursionError
 from pydantic import ValidationError
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from main import ChatCompletionRequest, _extract_usage
+from main import (
+    _GRACEFUL_ERROR_MESSAGE,
+    _MAX_INVOKE_ATTEMPTS,
+    ChatCompletionRequest,
+    _extract_usage,
+    _invoke_with_retry,
+)
 
 
 class TestEmptyMessagesValidation:
@@ -102,3 +112,105 @@ class TestExtractUsage:
 
     def test_returns_none_for_empty_list(self):
         assert _extract_usage([]) is None
+
+
+class TestInvokeWithRetry:
+    def test_succeeds_on_first_attempt(self):
+        expected = {"messages": [AIMessage(content="hello")]}
+        mock_graph = AsyncMock(ainvoke=AsyncMock(return_value=expected))
+        with patch("main.agent_graph", mock_graph):
+            result = asyncio.run(_invoke_with_retry({"messages": []}, config={}))
+        assert result == expected
+        assert mock_graph.ainvoke.call_count == 1
+
+    def test_succeeds_after_transient_failure(self):
+        expected = {"messages": [AIMessage(content="recovered")]}
+        mock_graph = AsyncMock(
+            ainvoke=AsyncMock(side_effect=[GraphRecursionError("loop"), expected])
+        )
+        with (
+            patch("main.agent_graph", mock_graph),
+            patch("main.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = asyncio.run(_invoke_with_retry({"messages": []}, config={}))
+        assert result == expected
+        assert mock_graph.ainvoke.call_count == 2
+
+    def test_exhausts_retries_and_raises(self):
+        mock_graph = AsyncMock(
+            ainvoke=AsyncMock(side_effect=GraphRecursionError("loop"))
+        )
+        with (
+            patch("main.agent_graph", mock_graph),
+            patch("main.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            with pytest.raises(GraphRecursionError):
+                asyncio.run(_invoke_with_retry({"messages": []}, config={}))
+        assert mock_graph.ainvoke.call_count == _MAX_INVOKE_ATTEMPTS
+
+    def test_non_retryable_error_propagates_immediately(self):
+        mock_graph = AsyncMock(
+            ainvoke=AsyncMock(side_effect=RuntimeError("unexpected"))
+        )
+        with patch("main.agent_graph", mock_graph):
+            with pytest.raises(RuntimeError, match="unexpected"):
+                asyncio.run(_invoke_with_retry({"messages": []}, config={}))
+        assert mock_graph.ainvoke.call_count == 1
+
+    def test_malformed_tool_args_not_leaked_in_logs(self, caplog):
+        malformed_args = "%4W!O;VL"
+        exc = ValidationError.from_exception_data(
+            title="AIMessage",
+            line_errors=[
+                {
+                    "type": "dict_type",
+                    "loc": ("tool_calls", 0, "args"),
+                    "msg": "Input should be a valid dictionary",
+                    "input": malformed_args,
+                }
+            ],
+        )
+        mock_graph = AsyncMock(ainvoke=AsyncMock(side_effect=exc))
+        with (
+            patch("main.agent_graph", mock_graph),
+            patch("main.asyncio.sleep", new_callable=AsyncMock),
+            caplog.at_level(logging.WARNING, logger="main"),
+        ):
+            with pytest.raises(ValidationError):
+                asyncio.run(_invoke_with_retry({"messages": []}, config={}))
+        for record in caplog.records:
+            assert malformed_args not in record.getMessage()
+
+
+class TestHandleChatGracefulError:
+    def test_returns_200_with_error_message_after_retries_exhausted(self):
+        from main import _handle_chat
+
+        mock_graph = AsyncMock(
+            ainvoke=AsyncMock(
+                side_effect=GraphRecursionError("recursion limit reached")
+            )
+        )
+        with (
+            patch("main.agent_graph", mock_graph),
+            patch("main.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = asyncio.run(
+                _handle_chat([HumanMessage(content="test")], "test-model")
+            )
+        assert result["choices"][0]["message"]["content"] == _GRACEFUL_ERROR_MESSAGE
+        assert result["choices"][0]["finish_reason"] == "stop"
+        assert result["object"] == "chat.completion"
+        assert result["usage"] is None
+
+    def test_still_returns_500_for_non_retryable_errors(self):
+        from fastapi import HTTPException
+        from main import _handle_chat
+
+        mock_graph = AsyncMock(
+            ainvoke=AsyncMock(side_effect=RuntimeError("server broke"))
+        )
+        with patch("main.agent_graph", mock_graph):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(_handle_chat([HumanMessage(content="test")], "test-model"))
+        assert exc_info.value.status_code == 500

--- a/agents/langgraph/templates/human_in_the_loop/main.py
+++ b/agents/langgraph/templates/human_in_the_loop/main.py
@@ -341,7 +341,10 @@ async def _handle_chat(
                 else:
                     resume_value = {
                         "decisions": [
-                            {"type": "reject", "message": "User rejected the tool call."}
+                            {
+                                "type": "reject",
+                                "message": "User rejected the tool call.",
+                            }
                         ]
                     }
                 result = await _invoke_with_retry(

--- a/agents/langgraph/templates/human_in_the_loop/main.py
+++ b/agents/langgraph/templates/human_in_the_loop/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import time
@@ -27,6 +28,7 @@ from pydantic import BaseModel, Field, ValidationError
 
 logger = logging.getLogger(__name__)
 
+_MAX_INVOKE_ATTEMPTS = 3
 _GRACEFUL_ERROR_MESSAGE = (
     "I was unable to process this request due to repeated internal errors."
 )
@@ -220,6 +222,36 @@ def _make_completion_id() -> str:
     return f"chatcmpl-{uuid.uuid4().hex[:12]}"
 
 
+async def _invoke_with_retry(
+    agent,
+    input_data,
+    **kwargs,
+) -> dict:
+    last_exception: Exception = RuntimeError("no invocation attempts were made")
+
+    for attempt in range(1, _MAX_INVOKE_ATTEMPTS + 1):
+        try:
+            return await agent.ainvoke(input_data, **kwargs)
+        except _RETRYABLE_EXCEPTIONS as exc:
+            last_exception = exc
+            if attempt < _MAX_INVOKE_ATTEMPTS:
+                logger.warning(
+                    "LLM/graph invocation failed (attempt %d/%d): %s. Retrying.",
+                    attempt,
+                    _MAX_INVOKE_ATTEMPTS,
+                    type(exc).__name__,
+                )
+                await asyncio.sleep(0.5 * attempt)
+            else:
+                logger.error(
+                    "LLM/graph invocation failed after %d attempts: %s",
+                    _MAX_INVOKE_ATTEMPTS,
+                    type(exc).__name__,
+                )
+
+    raise last_exception
+
+
 def _format_context_messages(messages) -> list[dict]:
     """Convert LangChain messages to OpenAI-compatible context dicts."""
     context = []
@@ -304,7 +336,8 @@ async def _handle_chat(
 
         try:
             if request.approval:
-                # Resume from interrupt with human decision
+                # Resume from interrupt with human decision — no retry
+                # (consumed interrupts cannot be resumed again)
                 if request.approval.lower() in ("yes", "y", "approve"):
                     resume_value = {"decisions": [{"type": "approve"}]}
                 else:
@@ -322,14 +355,19 @@ async def _handle_chat(
                     version="v2",
                 )
             else:
-                # New conversation turn
+                # New conversation turn — retry transient failures
                 langchain_messages = _build_langchain_messages(request.messages)
-                result = await agent.ainvoke(
+                result = await _invoke_with_retry(
+                    agent,
                     {"messages": langchain_messages},
                     config=config,
                     version="v2",
                 )
         except _GRACEFUL_EXCEPTIONS:
+            logger.warning(
+                "Returning graceful error after invocation failure: %s",
+                "retries_exhausted",
+            )
             return {
                 "id": _make_completion_id(),
                 "object": "chat.completion",
@@ -406,7 +444,7 @@ async def _handle_chat(
         }
 
     except Exception:
-        logger.exception("Error processing chat completion request")
+        logger.error("Unhandled error in chat completion request")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 

--- a/agents/langgraph/templates/human_in_the_loop/main.py
+++ b/agents/langgraph/templates/human_in_the_loop/main.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import logging
 import time
@@ -28,18 +27,18 @@ from pydantic import BaseModel, Field, ValidationError
 
 logger = logging.getLogger(__name__)
 
-_MAX_INVOKE_ATTEMPTS = 3
 _GRACEFUL_ERROR_MESSAGE = (
     "I was unable to process this request due to repeated internal errors."
 )
 _RETRYABLE_EXCEPTIONS = (
-    GraphRecursionError,
     ValidationError,
     OutputParserException,
     openai.InternalServerError,
     openai.APITimeoutError,
     openai.APIConnectionError,
+    openai.RateLimitError,
 )
+_GRACEFUL_EXCEPTIONS = _RETRYABLE_EXCEPTIONS + (GraphRecursionError,)
 
 
 # OpenAI-compatible request/response models
@@ -221,36 +220,6 @@ def _make_completion_id() -> str:
     return f"chatcmpl-{uuid.uuid4().hex[:12]}"
 
 
-async def _invoke_with_retry(
-    agent,
-    input_data,
-    **kwargs,
-) -> dict:
-    last_exception: Exception = RuntimeError("no invocation attempts were made")
-
-    for attempt in range(1, _MAX_INVOKE_ATTEMPTS + 1):
-        try:
-            return await agent.ainvoke(input_data, **kwargs)
-        except _RETRYABLE_EXCEPTIONS as exc:
-            last_exception = exc
-            if attempt < _MAX_INVOKE_ATTEMPTS:
-                logger.warning(
-                    "LLM/graph invocation failed (attempt %d/%d): %s. Retrying.",
-                    attempt,
-                    _MAX_INVOKE_ATTEMPTS,
-                    type(exc).__name__,
-                )
-                await asyncio.sleep(0.5 * attempt)
-            else:
-                logger.error(
-                    "LLM/graph invocation failed after %d attempts: %s",
-                    _MAX_INVOKE_ATTEMPTS,
-                    type(exc).__name__,
-                )
-
-    raise last_exception
-
-
 def _format_context_messages(messages) -> list[dict]:
     """Convert LangChain messages to OpenAI-compatible context dicts."""
     context = []
@@ -347,8 +316,7 @@ async def _handle_chat(
                             }
                         ]
                     }
-                result = await _invoke_with_retry(
-                    agent,
+                result = await agent.ainvoke(
                     Command(resume=resume_value),
                     config=config,
                     version="v2",
@@ -356,13 +324,12 @@ async def _handle_chat(
             else:
                 # New conversation turn
                 langchain_messages = _build_langchain_messages(request.messages)
-                result = await _invoke_with_retry(
-                    agent,
+                result = await agent.ainvoke(
                     {"messages": langchain_messages},
                     config=config,
                     version="v2",
                 )
-        except _RETRYABLE_EXCEPTIONS:
+        except _GRACEFUL_EXCEPTIONS:
             return {
                 "id": _make_completion_id(),
                 "object": "chat.completion",
@@ -378,6 +345,7 @@ async def _handle_chat(
                         "finish_reason": "stop",
                     }
                 ],
+                "context": [],
                 "thread_id": thread_id,
                 "usage": None,
             }

--- a/agents/langgraph/templates/human_in_the_loop/main.py
+++ b/agents/langgraph/templates/human_in_the_loop/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import time
@@ -8,6 +9,7 @@ from os import getenv
 from pathlib import Path
 from typing import Any
 
+import openai
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import (
     FileResponse,
@@ -17,12 +19,27 @@ from fastapi.responses import (
 )
 from human_in_the_loop.agent import get_graph_closure
 from human_in_the_loop.tracing import enable_tracing
+from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.checkpoint.memory import MemorySaver
+from langgraph.errors import GraphRecursionError
 from langgraph.types import Command
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 logger = logging.getLogger(__name__)
+
+_MAX_INVOKE_ATTEMPTS = 3
+_GRACEFUL_ERROR_MESSAGE = (
+    "I was unable to process this request due to repeated internal errors."
+)
+_RETRYABLE_EXCEPTIONS = (
+    GraphRecursionError,
+    ValidationError,
+    OutputParserException,
+    openai.InternalServerError,
+    openai.APITimeoutError,
+    openai.APIConnectionError,
+)
 
 
 # OpenAI-compatible request/response models
@@ -204,6 +221,36 @@ def _make_completion_id() -> str:
     return f"chatcmpl-{uuid.uuid4().hex[:12]}"
 
 
+async def _invoke_with_retry(
+    agent,
+    input_data,
+    **kwargs,
+) -> dict:
+    last_exception: Exception = RuntimeError("no invocation attempts were made")
+
+    for attempt in range(1, _MAX_INVOKE_ATTEMPTS + 1):
+        try:
+            return await agent.ainvoke(input_data, **kwargs)
+        except _RETRYABLE_EXCEPTIONS as exc:
+            last_exception = exc
+            if attempt < _MAX_INVOKE_ATTEMPTS:
+                logger.warning(
+                    "LLM/graph invocation failed (attempt %d/%d): %s. Retrying.",
+                    attempt,
+                    _MAX_INVOKE_ATTEMPTS,
+                    type(exc).__name__,
+                )
+                await asyncio.sleep(0.5 * attempt)
+            else:
+                logger.error(
+                    "LLM/graph invocation failed after %d attempts: %s",
+                    _MAX_INVOKE_ATTEMPTS,
+                    type(exc).__name__,
+                )
+
+    raise last_exception
+
+
 def _format_context_messages(messages) -> list[dict]:
     """Convert LangChain messages to OpenAI-compatible context dicts."""
     context = []
@@ -286,29 +333,51 @@ async def _handle_chat(
                 prior.checkpoint.get("channel_values", {}).get("messages", [])
             )
 
-        if request.approval:
-            # Resume from interrupt with human decision
-            if request.approval.lower() in ("yes", "y", "approve"):
-                resume_value = {"decisions": [{"type": "approve"}]}
+        try:
+            if request.approval:
+                # Resume from interrupt with human decision
+                if request.approval.lower() in ("yes", "y", "approve"):
+                    resume_value = {"decisions": [{"type": "approve"}]}
+                else:
+                    resume_value = {
+                        "decisions": [
+                            {"type": "reject", "message": "User rejected the tool call."}
+                        ]
+                    }
+                result = await _invoke_with_retry(
+                    agent,
+                    Command(resume=resume_value),
+                    config=config,
+                    version="v2",
+                )
             else:
-                resume_value = {
-                    "decisions": [
-                        {"type": "reject", "message": "User rejected the tool call."}
-                    ]
-                }
-            result = await agent.ainvoke(
-                Command(resume=resume_value),
-                config=config,
-                version="v2",
-            )
-        else:
-            # New conversation turn
-            langchain_messages = _build_langchain_messages(request.messages)
-            result = await agent.ainvoke(
-                {"messages": langchain_messages},
-                config=config,
-                version="v2",
-            )
+                # New conversation turn
+                langchain_messages = _build_langchain_messages(request.messages)
+                result = await _invoke_with_retry(
+                    agent,
+                    {"messages": langchain_messages},
+                    config=config,
+                    version="v2",
+                )
+        except _RETRYABLE_EXCEPTIONS:
+            return {
+                "id": _make_completion_id(),
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": model_id,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": _GRACEFUL_ERROR_MESSAGE,
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "thread_id": thread_id,
+                "usage": None,
+            }
 
         # Check if the graph was interrupted (pending human approval)
         if result.interrupts:

--- a/agents/langgraph/templates/human_in_the_loop/tests/test_api_contract.py
+++ b/agents/langgraph/templates/human_in_the_loop/tests/test_api_contract.py
@@ -7,25 +7,19 @@ Covers:
 - HITL turn scoping: resumed-thread responses include only current-turn messages
 """
 
-import asyncio
-import logging
 import os
 import sys
-from unittest.mock import AsyncMock, patch
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
-from langgraph.errors import GraphRecursionError
 from pydantic import ValidationError
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from main import (
-    _MAX_INVOKE_ATTEMPTS,
     ChatCompletionRequest,
     _extract_usage,
     _format_context_messages,
-    _invoke_with_retry,
 )
 
 
@@ -184,62 +178,3 @@ class TestHitlTurnScoping:
             "completion_tokens": 60,
             "total_tokens": 180,
         }
-
-
-class TestInvokeWithRetry:
-    def test_succeeds_on_first_attempt(self):
-        expected = {"messages": [AIMessage(content="hello")]}
-        mock_agent = AsyncMock(ainvoke=AsyncMock(return_value=expected))
-        result = asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}))
-        assert result == expected
-        assert mock_agent.ainvoke.call_count == 1
-
-    def test_succeeds_after_transient_failure(self):
-        expected = {"messages": [AIMessage(content="recovered")]}
-        mock_agent = AsyncMock(
-            ainvoke=AsyncMock(side_effect=[GraphRecursionError("loop"), expected])
-        )
-        with patch("main.asyncio.sleep", new_callable=AsyncMock):
-            result = asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}))
-        assert result == expected
-        assert mock_agent.ainvoke.call_count == 2
-
-    def test_exhausts_retries_and_raises(self):
-        mock_agent = AsyncMock(
-            ainvoke=AsyncMock(side_effect=GraphRecursionError("loop"))
-        )
-        with patch("main.asyncio.sleep", new_callable=AsyncMock):
-            with pytest.raises(GraphRecursionError):
-                asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}))
-        assert mock_agent.ainvoke.call_count == _MAX_INVOKE_ATTEMPTS
-
-    def test_non_retryable_error_propagates_immediately(self):
-        mock_agent = AsyncMock(
-            ainvoke=AsyncMock(side_effect=RuntimeError("unexpected"))
-        )
-        with pytest.raises(RuntimeError, match="unexpected"):
-            asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}))
-        assert mock_agent.ainvoke.call_count == 1
-
-    def test_malformed_tool_args_not_leaked_in_logs(self, caplog):
-        malformed_args = "%4W!O;VL"
-        exc = ValidationError.from_exception_data(
-            title="AIMessage",
-            line_errors=[
-                {
-                    "type": "dict_type",
-                    "loc": ("tool_calls", 0, "args"),
-                    "msg": "Input should be a valid dictionary",
-                    "input": malformed_args,
-                }
-            ],
-        )
-        mock_agent = AsyncMock(ainvoke=AsyncMock(side_effect=exc))
-        with (
-            patch("main.asyncio.sleep", new_callable=AsyncMock),
-            caplog.at_level(logging.WARNING, logger="main"),
-        ):
-            with pytest.raises(ValidationError):
-                asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}))
-        for record in caplog.records:
-            assert malformed_args not in record.getMessage()

--- a/agents/langgraph/templates/human_in_the_loop/tests/test_api_contract.py
+++ b/agents/langgraph/templates/human_in_the_loop/tests/test_api_contract.py
@@ -7,19 +7,26 @@ Covers:
 - HITL turn scoping: resumed-thread responses include only current-turn messages
 """
 
+import asyncio
+import logging
 import os
 import sys
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langgraph.errors import GraphRecursionError
 from pydantic import ValidationError
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from main import (
+    _GRACEFUL_ERROR_MESSAGE,
+    _MAX_INVOKE_ATTEMPTS,
     ChatCompletionRequest,
     _extract_usage,
     _format_context_messages,
+    _invoke_with_retry,
 )
 
 
@@ -178,3 +185,167 @@ class TestHitlTurnScoping:
             "completion_tokens": 60,
             "total_tokens": 180,
         }
+
+
+class TestInvokeWithRetry:
+    def test_succeeds_on_first_attempt(self):
+        expected = {"messages": [AIMessage(content="hello")]}
+        mock_agent = AsyncMock(ainvoke=AsyncMock(return_value=expected))
+        result = asyncio.run(
+            _invoke_with_retry(mock_agent, {"messages": []}, config={})
+        )
+        assert result == expected
+        assert mock_agent.ainvoke.call_count == 1
+
+    def test_succeeds_after_transient_failure(self):
+        expected = {"messages": [AIMessage(content="recovered")]}
+        exc = ValidationError.from_exception_data(
+            title="test",
+            line_errors=[
+                {
+                    "type": "dict_type",
+                    "loc": ("x",),
+                    "msg": "bad",
+                    "input": "y",
+                }
+            ],
+        )
+        mock_agent = AsyncMock(ainvoke=AsyncMock(side_effect=[exc, expected]))
+        with patch("main.asyncio.sleep", new_callable=AsyncMock):
+            result = asyncio.run(
+                _invoke_with_retry(mock_agent, {"messages": []}, config={})
+            )
+        assert result == expected
+        assert mock_agent.ainvoke.call_count == 2
+
+    def test_exhausts_retries_and_raises(self):
+        exc = ValidationError.from_exception_data(
+            title="test",
+            line_errors=[
+                {
+                    "type": "dict_type",
+                    "loc": ("x",),
+                    "msg": "bad",
+                    "input": "y",
+                }
+            ],
+        )
+        mock_agent = AsyncMock(ainvoke=AsyncMock(side_effect=exc))
+        with patch("main.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(ValidationError):
+                asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}, config={}))
+        assert mock_agent.ainvoke.call_count == _MAX_INVOKE_ATTEMPTS
+
+    def test_non_retryable_error_propagates_immediately(self):
+        mock_agent = AsyncMock(
+            ainvoke=AsyncMock(side_effect=RuntimeError("unexpected"))
+        )
+        with pytest.raises(RuntimeError, match="unexpected"):
+            asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}, config={}))
+        assert mock_agent.ainvoke.call_count == 1
+
+    def test_malformed_tool_args_not_leaked_in_logs(self, caplog):
+        malformed_args = "%4W!O;VL"
+        exc = ValidationError.from_exception_data(
+            title="AIMessage",
+            line_errors=[
+                {
+                    "type": "dict_type",
+                    "loc": ("tool_calls", 0, "args"),
+                    "msg": "Input should be a valid dictionary",
+                    "input": malformed_args,
+                }
+            ],
+        )
+        mock_agent = AsyncMock(ainvoke=AsyncMock(side_effect=exc))
+        with (
+            patch("main.asyncio.sleep", new_callable=AsyncMock),
+            caplog.at_level(logging.WARNING, logger="main"),
+        ):
+            with pytest.raises(ValidationError):
+                asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}, config={}))
+        assert caplog.records
+        for record in caplog.records:
+            assert malformed_args not in record.getMessage()
+
+
+class TestHandleChatGracefulError:
+    def test_returns_200_with_error_message_on_graceful_exception(self):
+        from main import _handle_chat
+
+        mock_agent = AsyncMock(
+            ainvoke=AsyncMock(
+                side_effect=GraphRecursionError("recursion limit reached")
+            )
+        )
+
+        def mock_closure(cp):
+            return mock_agent
+
+        mock_checkpointer = type(
+            "FakeCheckpointer",
+            (),
+            {"get_tuple": lambda self, cfg: None},
+        )()
+        with (
+            patch("main.agent_graph_closure", mock_closure),
+            patch("main.checkpointer", mock_checkpointer),
+            patch("main.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            from main import ChatCompletionRequest
+
+            request = ChatCompletionRequest(
+                messages=[{"role": "user", "content": "test"}],
+                thread_id="test-thread",
+            )
+            result = asyncio.run(
+                _handle_chat(
+                    request,
+                    "test-model",
+                    "test-thread",
+                    {"configurable": {"thread_id": "test-thread"}},
+                )
+            )
+        assert result["choices"][0]["message"]["content"] == _GRACEFUL_ERROR_MESSAGE
+        assert result["choices"][0]["finish_reason"] == "stop"
+        assert result["object"] == "chat.completion"
+        assert result["thread_id"] == "test-thread"
+        assert result["context"] == []
+        assert result["usage"] is None
+
+    def test_still_returns_500_for_non_retryable_errors(self):
+        from fastapi import HTTPException
+        from main import _handle_chat
+
+        mock_agent = AsyncMock(
+            ainvoke=AsyncMock(side_effect=RuntimeError("server broke"))
+        )
+
+        def mock_closure(cp):
+            return mock_agent
+
+        mock_checkpointer = type(
+            "FakeCheckpointer",
+            (),
+            {"get_tuple": lambda self, cfg: None},
+        )()
+        with (
+            patch("main.agent_graph_closure", mock_closure),
+            patch("main.checkpointer", mock_checkpointer),
+        ):
+            from main import ChatCompletionRequest
+
+            request = ChatCompletionRequest(
+                messages=[{"role": "user", "content": "test"}],
+                thread_id="test-thread",
+            )
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    _handle_chat(
+                        request,
+                        "test-model",
+                        "test-thread",
+                        {"configurable": {"thread_id": "test-thread"}},
+                    )
+                )
+        assert exc_info.value.status_code == 500

--- a/agents/langgraph/templates/human_in_the_loop/tests/test_api_contract.py
+++ b/agents/langgraph/templates/human_in_the_loop/tests/test_api_contract.py
@@ -7,16 +7,27 @@ Covers:
 - HITL turn scoping: resumed-thread responses include only current-turn messages
 """
 
+import asyncio
+import logging
 import os
 import sys
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langgraph.errors import GraphRecursionError
 from pydantic import ValidationError
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from main import ChatCompletionRequest, _extract_usage, _format_context_messages
+from main import (
+    _GRACEFUL_ERROR_MESSAGE,
+    _MAX_INVOKE_ATTEMPTS,
+    ChatCompletionRequest,
+    _extract_usage,
+    _format_context_messages,
+    _invoke_with_retry,
+)
 
 
 class TestEmptyMessagesValidation:
@@ -174,3 +185,62 @@ class TestHitlTurnScoping:
             "completion_tokens": 60,
             "total_tokens": 180,
         }
+
+
+class TestInvokeWithRetry:
+    def test_succeeds_on_first_attempt(self):
+        expected = {"messages": [AIMessage(content="hello")]}
+        mock_agent = AsyncMock(ainvoke=AsyncMock(return_value=expected))
+        result = asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}))
+        assert result == expected
+        assert mock_agent.ainvoke.call_count == 1
+
+    def test_succeeds_after_transient_failure(self):
+        expected = {"messages": [AIMessage(content="recovered")]}
+        mock_agent = AsyncMock(
+            ainvoke=AsyncMock(side_effect=[GraphRecursionError("loop"), expected])
+        )
+        with patch("main.asyncio.sleep", new_callable=AsyncMock):
+            result = asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}))
+        assert result == expected
+        assert mock_agent.ainvoke.call_count == 2
+
+    def test_exhausts_retries_and_raises(self):
+        mock_agent = AsyncMock(
+            ainvoke=AsyncMock(side_effect=GraphRecursionError("loop"))
+        )
+        with patch("main.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(GraphRecursionError):
+                asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}))
+        assert mock_agent.ainvoke.call_count == _MAX_INVOKE_ATTEMPTS
+
+    def test_non_retryable_error_propagates_immediately(self):
+        mock_agent = AsyncMock(
+            ainvoke=AsyncMock(side_effect=RuntimeError("unexpected"))
+        )
+        with pytest.raises(RuntimeError, match="unexpected"):
+            asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}))
+        assert mock_agent.ainvoke.call_count == 1
+
+    def test_malformed_tool_args_not_leaked_in_logs(self, caplog):
+        malformed_args = "%4W!O;VL"
+        exc = ValidationError.from_exception_data(
+            title="AIMessage",
+            line_errors=[
+                {
+                    "type": "dict_type",
+                    "loc": ("tool_calls", 0, "args"),
+                    "msg": "Input should be a valid dictionary",
+                    "input": malformed_args,
+                }
+            ],
+        )
+        mock_agent = AsyncMock(ainvoke=AsyncMock(side_effect=exc))
+        with (
+            patch("main.asyncio.sleep", new_callable=AsyncMock),
+            caplog.at_level(logging.WARNING, logger="main"),
+        ):
+            with pytest.raises(ValidationError):
+                asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}))
+        for record in caplog.records:
+            assert malformed_args not in record.getMessage()

--- a/agents/langgraph/templates/human_in_the_loop/tests/test_api_contract.py
+++ b/agents/langgraph/templates/human_in_the_loop/tests/test_api_contract.py
@@ -21,7 +21,6 @@ from pydantic import ValidationError
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from main import (
-    _GRACEFUL_ERROR_MESSAGE,
     _MAX_INVOKE_ATTEMPTS,
     ChatCompletionRequest,
     _extract_usage,

--- a/agents/langgraph/templates/react_agent/main.py
+++ b/agents/langgraph/templates/react_agent/main.py
@@ -31,13 +31,14 @@ _GRACEFUL_ERROR_MESSAGE = (
     "I was unable to process this request due to repeated internal errors."
 )
 _RETRYABLE_EXCEPTIONS = (
-    GraphRecursionError,
     ValidationError,
     OutputParserException,
     openai.InternalServerError,
     openai.APITimeoutError,
     openai.APIConnectionError,
+    openai.RateLimitError,
 )
+_GRACEFUL_EXCEPTIONS = _RETRYABLE_EXCEPTIONS + (GraphRecursionError,)
 
 
 # OpenAI-compatible request/response models
@@ -288,7 +289,7 @@ async def _handle_chat(messages: list[HumanMessage], model_id: str) -> dict[str,
             result = await _invoke_with_retry(
                 {"messages": messages}, config={"recursion_limit": 10}
             )
-        except _RETRYABLE_EXCEPTIONS:
+        except _GRACEFUL_EXCEPTIONS:
             return {
                 "id": _make_completion_id(),
                 "object": "chat.completion",
@@ -304,6 +305,7 @@ async def _handle_chat(messages: list[HumanMessage], model_id: str) -> dict[str,
                         "finish_reason": "stop",
                     }
                 ],
+                "context": [],
                 "usage": None,
             }
 

--- a/agents/langgraph/templates/react_agent/tests/test_api_contract.py
+++ b/agents/langgraph/templates/react_agent/tests/test_api_contract.py
@@ -125,9 +125,18 @@ class TestInvokeWithRetry:
 
     def test_succeeds_after_transient_failure(self):
         expected = {"messages": [AIMessage(content="recovered")]}
-        mock_graph = AsyncMock(
-            ainvoke=AsyncMock(side_effect=[GraphRecursionError("loop"), expected])
+        transient_exc = ValidationError.from_exception_data(
+            title="test",
+            line_errors=[
+                {
+                    "type": "dict_type",
+                    "loc": ("x",),
+                    "msg": "bad",
+                    "input": "y",
+                }
+            ],
         )
+        mock_graph = AsyncMock(ainvoke=AsyncMock(side_effect=[transient_exc, expected]))
         with (
             patch("main.agent_graph", mock_graph),
             patch("main.asyncio.sleep", new_callable=AsyncMock),
@@ -137,14 +146,23 @@ class TestInvokeWithRetry:
         assert mock_graph.ainvoke.call_count == 2
 
     def test_exhausts_retries_and_raises(self):
-        mock_graph = AsyncMock(
-            ainvoke=AsyncMock(side_effect=GraphRecursionError("loop"))
+        exhaust_exc = ValidationError.from_exception_data(
+            title="test",
+            line_errors=[
+                {
+                    "type": "dict_type",
+                    "loc": ("x",),
+                    "msg": "bad",
+                    "input": "y",
+                }
+            ],
         )
+        mock_graph = AsyncMock(ainvoke=AsyncMock(side_effect=exhaust_exc))
         with (
             patch("main.agent_graph", mock_graph),
             patch("main.asyncio.sleep", new_callable=AsyncMock),
         ):
-            with pytest.raises(GraphRecursionError):
+            with pytest.raises(ValidationError):
                 asyncio.run(_invoke_with_retry({"messages": []}, config={}))
         assert mock_graph.ainvoke.call_count == _MAX_INVOKE_ATTEMPTS
 
@@ -178,6 +196,7 @@ class TestInvokeWithRetry:
         ):
             with pytest.raises(ValidationError):
                 asyncio.run(_invoke_with_retry({"messages": []}, config={}))
+        assert caplog.records
         for record in caplog.records:
             assert malformed_args not in record.getMessage()
 

--- a/agents/langgraph/templates/react_with_database_memory/main.py
+++ b/agents/langgraph/templates/react_with_database_memory/main.py
@@ -366,9 +366,7 @@ async def _handle_chat(
                         agent, {"messages": messages}, config=config
                     )
                 else:
-                    result = await _invoke_with_retry(
-                        agent, {"messages": messages}
-                    )
+                    result = await _invoke_with_retry(agent, {"messages": messages})
             except _RETRYABLE_EXCEPTIONS:
                 return {
                     "id": _make_completion_id(),

--- a/agents/langgraph/templates/react_with_database_memory/main.py
+++ b/agents/langgraph/templates/react_with_database_memory/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import time
@@ -35,6 +36,8 @@ from react_with_database_memory.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+_MAX_INVOKE_ATTEMPTS = 3
 
 _GRACEFUL_ERROR_MESSAGE = (
     "I was unable to process this request due to repeated internal errors."
@@ -233,6 +236,36 @@ def _make_completion_id() -> str:
     return f"chatcmpl-{uuid.uuid4().hex[:12]}"
 
 
+async def _invoke_with_retry(
+    agent,
+    input_data,
+    **kwargs,
+) -> dict:
+    last_exception: Exception = RuntimeError("no invocation attempts were made")
+
+    for attempt in range(1, _MAX_INVOKE_ATTEMPTS + 1):
+        try:
+            return await agent.ainvoke(input_data, **kwargs)
+        except _RETRYABLE_EXCEPTIONS as exc:
+            last_exception = exc
+            if attempt < _MAX_INVOKE_ATTEMPTS:
+                logger.warning(
+                    "LLM/graph invocation failed (attempt %d/%d): %s. Retrying.",
+                    attempt,
+                    _MAX_INVOKE_ATTEMPTS,
+                    type(exc).__name__,
+                )
+                await asyncio.sleep(0.5 * attempt)
+            else:
+                logger.error(
+                    "LLM/graph invocation failed after %d attempts: %s",
+                    _MAX_INVOKE_ATTEMPTS,
+                    type(exc).__name__,
+                )
+
+    raise last_exception
+
+
 def _format_context_messages(messages: list[BaseMessage]) -> list[dict]:
     """Convert LangChain messages to OpenAI-compatible context dicts."""
     context = []
@@ -331,9 +364,11 @@ async def _handle_chat(
                                 "messages", []
                             )
                         )
-                    result = await agent.ainvoke({"messages": messages}, config=config)
+                    result = await _invoke_with_retry(
+                        agent, {"messages": messages}, config=config
+                    )
                 else:
-                    result = await agent.ainvoke({"messages": messages})
+                    result = await _invoke_with_retry(agent, {"messages": messages})
             except _GRACEFUL_EXCEPTIONS:
                 return {
                     "id": _make_completion_id(),
@@ -386,10 +421,9 @@ async def _handle_chat(
             "usage": _extract_usage(new_messages),
         }
 
-    except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Error processing request: {str(e)}"
-        )
+    except Exception:
+        logger.error("Unhandled error in chat completion request")
+        raise HTTPException(status_code=500, detail="Error processing request")
 
 
 async def _handle_stream(

--- a/agents/langgraph/templates/react_with_database_memory/main.py
+++ b/agents/langgraph/templates/react_with_database_memory/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import time
@@ -8,6 +9,7 @@ from os import getenv
 from pathlib import Path
 from typing import Any
 
+import openai
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import (
     FileResponse,
@@ -15,6 +17,7 @@ from fastapi.responses import (
     JSONResponse,
     StreamingResponse,
 )
+from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import (
     AIMessage,
     BaseMessage,
@@ -24,7 +27,8 @@ from langchain_core.messages import (
 )
 from langgraph.checkpoint.postgres import PostgresSaver
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
-from pydantic import BaseModel, Field
+from langgraph.errors import GraphRecursionError
+from pydantic import BaseModel, Field, ValidationError
 from react_with_database_memory.agent import get_graph_closure
 from react_with_database_memory.tracing import enable_tracing
 from react_with_database_memory.utils import (
@@ -32,6 +36,19 @@ from react_with_database_memory.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+_MAX_INVOKE_ATTEMPTS = 3
+_GRACEFUL_ERROR_MESSAGE = (
+    "I was unable to process this request due to repeated internal errors."
+)
+_RETRYABLE_EXCEPTIONS = (
+    GraphRecursionError,
+    ValidationError,
+    OutputParserException,
+    openai.InternalServerError,
+    openai.APITimeoutError,
+    openai.APIConnectionError,
+)
 
 
 # OpenAI-compatible request/response models
@@ -217,6 +234,36 @@ def _make_completion_id() -> str:
     return f"chatcmpl-{uuid.uuid4().hex[:12]}"
 
 
+async def _invoke_with_retry(
+    agent,
+    input_data,
+    **kwargs,
+) -> dict:
+    last_exception: Exception = RuntimeError("no invocation attempts were made")
+
+    for attempt in range(1, _MAX_INVOKE_ATTEMPTS + 1):
+        try:
+            return await agent.ainvoke(input_data, **kwargs)
+        except _RETRYABLE_EXCEPTIONS as exc:
+            last_exception = exc
+            if attempt < _MAX_INVOKE_ATTEMPTS:
+                logger.warning(
+                    "LLM/graph invocation failed (attempt %d/%d): %s. Retrying.",
+                    attempt,
+                    _MAX_INVOKE_ATTEMPTS,
+                    type(exc).__name__,
+                )
+                await asyncio.sleep(0.5 * attempt)
+            else:
+                logger.error(
+                    "LLM/graph invocation failed after %d attempts: %s",
+                    _MAX_INVOKE_ATTEMPTS,
+                    type(exc).__name__,
+                )
+
+    raise last_exception
+
+
 def _format_context_messages(messages: list[BaseMessage]) -> list[dict]:
     """Convert LangChain messages to OpenAI-compatible context dicts."""
     context = []
@@ -305,16 +352,41 @@ async def _handle_chat(
 
             # Count existing messages before invoke so we can return only new ones
             prior_count = 0
-            if thread_id:
-                config = {"configurable": {"thread_id": thread_id}}
-                prior = await saver.aget_tuple(config)
-                if prior and prior.checkpoint:
-                    prior_count = len(
-                        prior.checkpoint.get("channel_values", {}).get("messages", [])
+            try:
+                if thread_id:
+                    config = {"configurable": {"thread_id": thread_id}}
+                    prior = await saver.aget_tuple(config)
+                    if prior and prior.checkpoint:
+                        prior_count = len(
+                            prior.checkpoint.get("channel_values", {}).get(
+                                "messages", []
+                            )
+                        )
+                    result = await _invoke_with_retry(
+                        agent, {"messages": messages}, config=config
                     )
-                result = await agent.ainvoke({"messages": messages}, config=config)
-            else:
-                result = await agent.ainvoke({"messages": messages})
+                else:
+                    result = await _invoke_with_retry(
+                        agent, {"messages": messages}
+                    )
+            except _RETRYABLE_EXCEPTIONS:
+                return {
+                    "id": _make_completion_id(),
+                    "object": "chat.completion",
+                    "created": int(time.time()),
+                    "model": model_id,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": _GRACEFUL_ERROR_MESSAGE,
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": None,
+                }
 
         all_messages = result.get("messages", [])
         new_messages = all_messages[prior_count:]

--- a/agents/langgraph/templates/react_with_database_memory/main.py
+++ b/agents/langgraph/templates/react_with_database_memory/main.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import logging
 import time
@@ -37,18 +36,18 @@ from react_with_database_memory.utils import (
 
 logger = logging.getLogger(__name__)
 
-_MAX_INVOKE_ATTEMPTS = 3
 _GRACEFUL_ERROR_MESSAGE = (
     "I was unable to process this request due to repeated internal errors."
 )
 _RETRYABLE_EXCEPTIONS = (
-    GraphRecursionError,
     ValidationError,
     OutputParserException,
     openai.InternalServerError,
     openai.APITimeoutError,
     openai.APIConnectionError,
+    openai.RateLimitError,
 )
+_GRACEFUL_EXCEPTIONS = _RETRYABLE_EXCEPTIONS + (GraphRecursionError,)
 
 
 # OpenAI-compatible request/response models
@@ -234,36 +233,6 @@ def _make_completion_id() -> str:
     return f"chatcmpl-{uuid.uuid4().hex[:12]}"
 
 
-async def _invoke_with_retry(
-    agent,
-    input_data,
-    **kwargs,
-) -> dict:
-    last_exception: Exception = RuntimeError("no invocation attempts were made")
-
-    for attempt in range(1, _MAX_INVOKE_ATTEMPTS + 1):
-        try:
-            return await agent.ainvoke(input_data, **kwargs)
-        except _RETRYABLE_EXCEPTIONS as exc:
-            last_exception = exc
-            if attempt < _MAX_INVOKE_ATTEMPTS:
-                logger.warning(
-                    "LLM/graph invocation failed (attempt %d/%d): %s. Retrying.",
-                    attempt,
-                    _MAX_INVOKE_ATTEMPTS,
-                    type(exc).__name__,
-                )
-                await asyncio.sleep(0.5 * attempt)
-            else:
-                logger.error(
-                    "LLM/graph invocation failed after %d attempts: %s",
-                    _MAX_INVOKE_ATTEMPTS,
-                    type(exc).__name__,
-                )
-
-    raise last_exception
-
-
 def _format_context_messages(messages: list[BaseMessage]) -> list[dict]:
     """Convert LangChain messages to OpenAI-compatible context dicts."""
     context = []
@@ -362,12 +331,10 @@ async def _handle_chat(
                                 "messages", []
                             )
                         )
-                    result = await _invoke_with_retry(
-                        agent, {"messages": messages}, config=config
-                    )
+                    result = await agent.ainvoke({"messages": messages}, config=config)
                 else:
-                    result = await _invoke_with_retry(agent, {"messages": messages})
-            except _RETRYABLE_EXCEPTIONS:
+                    result = await agent.ainvoke({"messages": messages})
+            except _GRACEFUL_EXCEPTIONS:
                 return {
                     "id": _make_completion_id(),
                     "object": "chat.completion",
@@ -383,6 +350,7 @@ async def _handle_chat(
                             "finish_reason": "stop",
                         }
                     ],
+                    "context": [],
                     "usage": None,
                 }
 

--- a/agents/langgraph/templates/react_with_database_memory/tests/test_api_contract.py
+++ b/agents/langgraph/templates/react_with_database_memory/tests/test_api_contract.py
@@ -6,18 +6,28 @@ Covers:
 - _extract_usage returns None when no metadata is available
 """
 
+import asyncio
+import logging
 import os
 import sys
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
 
 import pytest
+from fastapi import HTTPException
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langgraph.errors import GraphRecursionError
 from pydantic import ValidationError
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+import main
 from main import (
+    _GRACEFUL_ERROR_MESSAGE,
+    _MAX_INVOKE_ATTEMPTS,
     ChatCompletionRequest,
     _extract_usage,
+    _invoke_with_retry,
 )
 
 
@@ -105,3 +115,161 @@ class TestExtractUsage:
 
     def test_returns_none_for_empty_list(self):
         assert _extract_usage([]) is None
+
+
+class TestInvokeWithRetry:
+    def test_succeeds_on_first_attempt(self):
+        expected = {"messages": [AIMessage(content="hello")]}
+        mock_agent = AsyncMock(ainvoke=AsyncMock(return_value=expected))
+        result = asyncio.run(
+            _invoke_with_retry(mock_agent, {"messages": []}, config={})
+        )
+        assert result == expected
+        assert mock_agent.ainvoke.call_count == 1
+
+    def test_succeeds_after_transient_failure(self):
+        expected = {"messages": [AIMessage(content="recovered")]}
+        exc = ValidationError.from_exception_data(
+            title="test",
+            line_errors=[
+                {
+                    "type": "dict_type",
+                    "loc": ("x",),
+                    "msg": "bad",
+                    "input": "y",
+                }
+            ],
+        )
+        mock_agent = AsyncMock(ainvoke=AsyncMock(side_effect=[exc, expected]))
+        with patch("main.asyncio.sleep", new_callable=AsyncMock):
+            result = asyncio.run(
+                _invoke_with_retry(mock_agent, {"messages": []}, config={})
+            )
+        assert result == expected
+        assert mock_agent.ainvoke.call_count == 2
+
+    def test_exhausts_retries_and_raises(self):
+        exc = ValidationError.from_exception_data(
+            title="test",
+            line_errors=[
+                {
+                    "type": "dict_type",
+                    "loc": ("x",),
+                    "msg": "bad",
+                    "input": "y",
+                }
+            ],
+        )
+        mock_agent = AsyncMock(ainvoke=AsyncMock(side_effect=exc))
+        with patch("main.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(ValidationError):
+                asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}, config={}))
+        assert mock_agent.ainvoke.call_count == _MAX_INVOKE_ATTEMPTS
+
+    def test_non_retryable_error_propagates_immediately(self):
+        mock_agent = AsyncMock(
+            ainvoke=AsyncMock(side_effect=RuntimeError("unexpected"))
+        )
+        with pytest.raises(RuntimeError, match="unexpected"):
+            asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}, config={}))
+        assert mock_agent.ainvoke.call_count == 1
+
+    def test_malformed_tool_args_not_leaked_in_logs(self, caplog):
+        malformed_args = "%4W!O;VL"
+        exc = ValidationError.from_exception_data(
+            title="AIMessage",
+            line_errors=[
+                {
+                    "type": "dict_type",
+                    "loc": ("tool_calls", 0, "args"),
+                    "msg": "Input should be a valid dictionary",
+                    "input": malformed_args,
+                }
+            ],
+        )
+        mock_agent = AsyncMock(ainvoke=AsyncMock(side_effect=exc))
+        with (
+            patch("main.asyncio.sleep", new_callable=AsyncMock),
+            caplog.at_level(logging.WARNING, logger="main"),
+        ):
+            with pytest.raises(ValidationError):
+                asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}, config={}))
+        assert caplog.records
+        for record in caplog.records:
+            assert malformed_args not in record.getMessage()
+
+
+class TestHandleChatGracefulError:
+    @pytest.mark.anyio
+    async def test_returns_200_with_error_message_on_graceful_exception(self):
+        class FakeAgent:
+            async def ainvoke(self, *_args, **_kwargs):
+                raise GraphRecursionError("recursion limit reached")
+
+        class FakeSaver:
+            async def setup(self):
+                return None
+
+            async def aget_tuple(self, _config):
+                return None
+
+        @asynccontextmanager
+        async def fake_saver_ctx(*_args, **_kwargs):
+            yield FakeSaver()
+
+        with (
+            patch.object(main, "DB_URI", "postgresql://test"),
+            patch.object(
+                main,
+                "agent_graph_closure",
+                lambda *_args, **_kwargs: FakeAgent(),
+            ),
+            patch(
+                "main.AsyncPostgresSaver.from_conn_string",
+                side_effect=fake_saver_ctx,
+            ),
+            patch("main.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await main._handle_chat(
+                [HumanMessage(content="test")], "test-model", "test-thread", None
+            )
+        assert result["choices"][0]["message"]["content"] == _GRACEFUL_ERROR_MESSAGE
+        assert result["choices"][0]["finish_reason"] == "stop"
+        assert result["object"] == "chat.completion"
+        assert result["context"] == []
+        assert result["usage"] is None
+
+    @pytest.mark.anyio
+    async def test_still_returns_500_for_non_retryable_errors(self):
+        class FakeAgent:
+            async def ainvoke(self, *_args, **_kwargs):
+                raise RuntimeError("server broke")
+
+        class FakeSaver:
+            async def setup(self):
+                return None
+
+            async def aget_tuple(self, _config):
+                return None
+
+        @asynccontextmanager
+        async def fake_saver_ctx(*_args, **_kwargs):
+            yield FakeSaver()
+
+        with (
+            patch.object(main, "DB_URI", "postgresql://test"),
+            patch.object(
+                main,
+                "agent_graph_closure",
+                lambda *_args, **_kwargs: FakeAgent(),
+            ),
+            patch(
+                "main.AsyncPostgresSaver.from_conn_string",
+                side_effect=fake_saver_ctx,
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await main._handle_chat(
+                    [HumanMessage(content="test")], "test-model", None, None
+                )
+        assert exc_info.value.status_code == 500

--- a/agents/langgraph/templates/react_with_database_memory/tests/test_api_contract.py
+++ b/agents/langgraph/templates/react_with_database_memory/tests/test_api_contract.py
@@ -6,24 +6,18 @@ Covers:
 - _extract_usage returns None when no metadata is available
 """
 
-import asyncio
-import logging
 import os
 import sys
-from unittest.mock import AsyncMock, patch
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
-from langgraph.errors import GraphRecursionError
 from pydantic import ValidationError
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from main import (
-    _MAX_INVOKE_ATTEMPTS,
     ChatCompletionRequest,
     _extract_usage,
-    _invoke_with_retry,
 )
 
 
@@ -111,62 +105,3 @@ class TestExtractUsage:
 
     def test_returns_none_for_empty_list(self):
         assert _extract_usage([]) is None
-
-
-class TestInvokeWithRetry:
-    def test_succeeds_on_first_attempt(self):
-        expected = {"messages": [AIMessage(content="hello")]}
-        mock_agent = AsyncMock(ainvoke=AsyncMock(return_value=expected))
-        result = asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}))
-        assert result == expected
-        assert mock_agent.ainvoke.call_count == 1
-
-    def test_succeeds_after_transient_failure(self):
-        expected = {"messages": [AIMessage(content="recovered")]}
-        mock_agent = AsyncMock(
-            ainvoke=AsyncMock(side_effect=[GraphRecursionError("loop"), expected])
-        )
-        with patch("main.asyncio.sleep", new_callable=AsyncMock):
-            result = asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}))
-        assert result == expected
-        assert mock_agent.ainvoke.call_count == 2
-
-    def test_exhausts_retries_and_raises(self):
-        mock_agent = AsyncMock(
-            ainvoke=AsyncMock(side_effect=GraphRecursionError("loop"))
-        )
-        with patch("main.asyncio.sleep", new_callable=AsyncMock):
-            with pytest.raises(GraphRecursionError):
-                asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}))
-        assert mock_agent.ainvoke.call_count == _MAX_INVOKE_ATTEMPTS
-
-    def test_non_retryable_error_propagates_immediately(self):
-        mock_agent = AsyncMock(
-            ainvoke=AsyncMock(side_effect=RuntimeError("unexpected"))
-        )
-        with pytest.raises(RuntimeError, match="unexpected"):
-            asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}))
-        assert mock_agent.ainvoke.call_count == 1
-
-    def test_malformed_tool_args_not_leaked_in_logs(self, caplog):
-        malformed_args = "%4W!O;VL"
-        exc = ValidationError.from_exception_data(
-            title="AIMessage",
-            line_errors=[
-                {
-                    "type": "dict_type",
-                    "loc": ("tool_calls", 0, "args"),
-                    "msg": "Input should be a valid dictionary",
-                    "input": malformed_args,
-                }
-            ],
-        )
-        mock_agent = AsyncMock(ainvoke=AsyncMock(side_effect=exc))
-        with (
-            patch("main.asyncio.sleep", new_callable=AsyncMock),
-            caplog.at_level(logging.WARNING, logger="main"),
-        ):
-            with pytest.raises(ValidationError):
-                asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}))
-        for record in caplog.records:
-            assert malformed_args not in record.getMessage()

--- a/agents/langgraph/templates/react_with_database_memory/tests/test_api_contract.py
+++ b/agents/langgraph/templates/react_with_database_memory/tests/test_api_contract.py
@@ -20,7 +20,6 @@ from pydantic import ValidationError
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from main import (
-    _GRACEFUL_ERROR_MESSAGE,
     _MAX_INVOKE_ATTEMPTS,
     ChatCompletionRequest,
     _extract_usage,

--- a/agents/langgraph/templates/react_with_database_memory/tests/test_api_contract.py
+++ b/agents/langgraph/templates/react_with_database_memory/tests/test_api_contract.py
@@ -6,16 +6,26 @@ Covers:
 - _extract_usage returns None when no metadata is available
 """
 
+import asyncio
+import logging
 import os
 import sys
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langgraph.errors import GraphRecursionError
 from pydantic import ValidationError
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from main import ChatCompletionRequest, _extract_usage
+from main import (
+    _GRACEFUL_ERROR_MESSAGE,
+    _MAX_INVOKE_ATTEMPTS,
+    ChatCompletionRequest,
+    _extract_usage,
+    _invoke_with_retry,
+)
 
 
 class TestEmptyMessagesValidation:
@@ -102,3 +112,62 @@ class TestExtractUsage:
 
     def test_returns_none_for_empty_list(self):
         assert _extract_usage([]) is None
+
+
+class TestInvokeWithRetry:
+    def test_succeeds_on_first_attempt(self):
+        expected = {"messages": [AIMessage(content="hello")]}
+        mock_agent = AsyncMock(ainvoke=AsyncMock(return_value=expected))
+        result = asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}))
+        assert result == expected
+        assert mock_agent.ainvoke.call_count == 1
+
+    def test_succeeds_after_transient_failure(self):
+        expected = {"messages": [AIMessage(content="recovered")]}
+        mock_agent = AsyncMock(
+            ainvoke=AsyncMock(side_effect=[GraphRecursionError("loop"), expected])
+        )
+        with patch("main.asyncio.sleep", new_callable=AsyncMock):
+            result = asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}))
+        assert result == expected
+        assert mock_agent.ainvoke.call_count == 2
+
+    def test_exhausts_retries_and_raises(self):
+        mock_agent = AsyncMock(
+            ainvoke=AsyncMock(side_effect=GraphRecursionError("loop"))
+        )
+        with patch("main.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(GraphRecursionError):
+                asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}))
+        assert mock_agent.ainvoke.call_count == _MAX_INVOKE_ATTEMPTS
+
+    def test_non_retryable_error_propagates_immediately(self):
+        mock_agent = AsyncMock(
+            ainvoke=AsyncMock(side_effect=RuntimeError("unexpected"))
+        )
+        with pytest.raises(RuntimeError, match="unexpected"):
+            asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}))
+        assert mock_agent.ainvoke.call_count == 1
+
+    def test_malformed_tool_args_not_leaked_in_logs(self, caplog):
+        malformed_args = "%4W!O;VL"
+        exc = ValidationError.from_exception_data(
+            title="AIMessage",
+            line_errors=[
+                {
+                    "type": "dict_type",
+                    "loc": ("tool_calls", 0, "args"),
+                    "msg": "Input should be a valid dictionary",
+                    "input": malformed_args,
+                }
+            ],
+        )
+        mock_agent = AsyncMock(ainvoke=AsyncMock(side_effect=exc))
+        with (
+            patch("main.asyncio.sleep", new_callable=AsyncMock),
+            caplog.at_level(logging.WARNING, logger="main"),
+        ):
+            with pytest.raises(ValidationError):
+                asyncio.run(_invoke_with_retry(mock_agent, {"messages": []}))
+        for record in caplog.records:
+            assert malformed_args not in record.getMessage()


### PR DESCRIPTION
## Description

Extends the retry logic and graceful error handling from `react_agent` (#304) to the remaining four LangGraph agent templates: `agentic_rag`, `human_in_the_loop`, `react_with_database_memory`, and `ci_failure_summarizer`.

### Problem

PR #304 fixed `react_agent` so that adversarial/malformed LLM inputs no longer crash the agent with HTTP 500 (causing garak red-teaming scans to hang indefinitely). However, the same bare `except Exception` handler exists in all other LangGraph templates — any of them would exhibit the identical failure mode under adversarial workloads.

### Fix

Each template now includes:

- **`_invoke_with_retry` helper**: Wraps `agent.ainvoke()` with bounded retries (3 attempts). Catches retryable exceptions (`GraphRecursionError`, `ValidationError`, `OutputParserException`, `openai.InternalServerError`, `openai.APITimeoutError`, `openai.APIConnectionError`). Non-retryable errors propagate immediately.
- **Backoff between retries**: `await asyncio.sleep(0.5 * attempt)` — 0.5s after attempt 1, 1.0s after attempt 2. Helps with transient network errors where instant retry would likely hit the same issue.
- **Graceful degradation in `_handle_chat`**: When all retries exhaust, returns HTTP 200 with `"I was unable to process this request due to repeated internal errors."` instead of HTTP 500.
- **Sanitized logging**: Only `type(exc).__name__` is logged — raw exception text (which may contain malformed tool arguments) is never written to logs.

### Adaptation per template

| Template | `_invoke_with_retry` signature | Notes |
|---|---|---|
| `agentic_rag` | `(input_data, config)` — uses global `agent_graph` | Identical to `react_agent` pattern |
| `human_in_the_loop` | `(agent, input_data, **kwargs)` — parameterized | Wraps both approval-resume and new-turn invoke paths |
| `react_with_database_memory` | `(agent, input_data, **kwargs)` — parameterized | Agent created dynamically from closure with `AsyncPostgresSaver` |
| `ci_failure_summarizer` | `(agent, input_data, **kwargs)` — parameterized | Same as `react_with_database_memory` |

Templates that create agents dynamically from closures use a parameterized helper signature instead of referencing the global `agent_graph`.

## Jira Ticket

RHAIENG-6845

## Testing

- [x] `make test` passes (run from the affected agent directory)
- [ ] Manual testing performed (describe steps below)
- [ ] No testing required (documentation/config change only)

### Unit tests added (5 per template, 20 total)

Each template received the same 5 regression tests:

- `TestInvokeWithRetry::test_succeeds_on_first_attempt`
- `TestInvokeWithRetry::test_succeeds_after_transient_failure`
- `TestInvokeWithRetry::test_exhausts_retries_and_raises`
- `TestInvokeWithRetry::test_non_retryable_error_propagates_immediately`
- `TestInvokeWithRetry::test_malformed_tool_args_not_leaked_in_logs`

`agentic_rag` additionally has `TestHandleChatGracefulError` tests (same as `react_agent`) since it shares the same global `agent_graph` pattern.

### Test results

| Template | Tests | Status |
|---|---|---|
| `react_agent` | 31 passed | No changes (reference) |
| `agentic_rag` | 25 passed | +7 new tests |
| `human_in_the_loop` | 16 passed | +5 new tests |
| `react_with_database_memory` | 19 passed | +5 new tests |
| `ci_failure_summarizer` | 97 passed | +5 new tests |

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)

## Review Guidance

- **`main.py` changes in each template**: Focus on `_invoke_with_retry` and the inner try/except in `_handle_chat`. The pattern is consistent across all templates — the only variation is the helper signature (global vs parameterized).
- **Test changes**: All new tests use `asyncio.run()` with `AsyncMock` patches and mock `asyncio.sleep` to avoid real delays. No new test dependencies.
- **`ci_failure_summarizer` graceful response**: Includes `"context": []` in the graceful error response because its `ChatCompletionResponse` model has `context` as a required field (unlike the other templates where it's untyped).

## Related PRs

- #304 — Original fix for `react_agent` (merged)