### PR TITLE
fix(ci): accept HTTP 429 in lychee link check (RHAIENG-6905)

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -4,8 +4,11 @@
 # Root directory for resolving root-relative links (e.g. /images/logo.svg)
 root_dir = "."
 
-# Accept these HTTP status codes as valid (no global 403 — new broken links are still caught)
-accept = ["200", "206", "301", "302", "308"]
+# Accept these HTTP status codes as valid (no global 403 — new broken links are still caught).
+# 429 = rate limited, not broken: sites like docs.vllm.ai (Read the Docs/Cloudflare)
+# throttle shared IPs (GitHub Actions runners, and sometimes local pre-commit runs),
+# returning 429 for links that are actually live. Accepting it can't hide a real 404.
+accept = ["200", "206", "301", "302", "308", "429"]
 
 # Maximum number of concurrent network requests
 max_concurrency = 32


### PR DESCRIPTION
## Summary

The `link-check` job (and local pre-commit runs) intermittently fail on links that are actually live, because rate-limiting docs hosts return **HTTP 429 Too Many Requests** to shared IPs.

Example from [a recent run](https://github.com/red-hat-data-services/agentic-starter-kits/actions/runs/31492863814/job/93783298131) — `agents/codex/README.md`:

```
[429] https://docs.vllm.ai/en/latest/serving/integrations/codex/ (at 547:9) | Rejected status code: 429 Too Many Requests
```

That URL returns `200` on every direct request. The `429` comes from Read the Docs / Cloudflare throttling shared IP ranges (GitHub Actions runners, and occasionally local machines running pre-commit).

## Change

Add `429` to the `accept` list in `lychee.toml`, with an explanatory comment.

## Why this is safe

A `429` means "rate limited, retry later" — **never** "broken link". Unlike a global `403` accept (deliberately avoided, since 403 can mask a genuinely blocked/dead link), accepting 429 cannot hide a real 404. This applies to all hosts, so future readthedocs/Cloudflare-fronted docs won't flake either.

### Alternatives considered
- **Exclude `docs.vllm.ai`** — too narrow; stops checking that host entirely, and other hosts could still flake.
- **Retry/backoff tuning** — ineffective; the throttle is per shared IP across all traffic, so retries seconds apart keep returning 429.

## Testing

- `lychee --config lychee.toml --no-progress agents/codex/README.md` → `33 Total, 33 OK, 0 Errors`
- Genuinely broken links still fail the check (429 is the only newly-accepted code).

Jira: [RHAIENG-6905](https://redhat.atlassian.net/browse/RHAIENG-6905)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHAIENG-6905]: https://redhat.atlassian.net/browse/RHAIENG-6905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ