### PR TITLE
fix(vanilla_python): handle unknown actions and execute all tools per turn (RHAIENG-6911)

### DIFF
--- a/agents/vanilla_python/templates/openai_responses_agent/src/openai_responses_agent/agent.py
+++ b/agents/vanilla_python/templates/openai_responses_agent/src/openai_responses_agent/agent.py
@@ -352,24 +352,43 @@ class AIAgent:
                 ]
 
                 if actions:
-                    action, args_str = actions[0].groups()
-                    action_inputs = self._parse_arguments(args_str)
+                    observations = []
+                    for match in actions:
+                        action, args_str = match.groups()
 
-                    if on_event:
-                        on_event("tool_call", {"name": action, "args": action_inputs})
+                        if action.lower() == "none":
+                            continue
 
-                    tool = self.tools.get(action)
-                    if not tool:
-                        raise ValueError(f"Unknown action: {action}")
+                        action_inputs = self._parse_arguments(args_str)
 
-                    observation = tool(*action_inputs)
+                        if on_event:
+                            on_event(
+                                "tool_call", {"name": action, "args": action_inputs}
+                            )
 
-                    if on_event:
-                        on_event(
-                            "tool_result", {"name": action, "output": str(observation)}
-                        )
+                        tool = self.tools.get(action)
+                        if not tool:
+                            obs = (
+                                f"Unknown tool '{action}'. "
+                                f"Available tools: {list(self.tools.keys())}"
+                            )
+                            observations.append(obs)
+                            continue
 
-                    next_prompt = f"Observation: {observation}"
+                        observation = tool(*action_inputs)
+
+                        if on_event:
+                            on_event(
+                                "tool_result",
+                                {"name": action, "output": str(observation)},
+                            )
+
+                        observations.append(str(observation))
+
+                    if not observations:
+                        return result.strip() if result else None
+
+                    next_prompt = "Observation: " + " | ".join(observations)
                 else:
                     # No Action: line – treat the whole response as the final answer
                     return result.strip() if result else None

--- a/agents/vanilla_python/templates/openai_responses_agent/tests/behavioral/test_tool_usage.py
+++ b/agents/vanilla_python/templates/openai_responses_agent/tests/behavioral/test_tool_usage.py
@@ -90,9 +90,6 @@ async def test_single_tool_selection(
         )
 
 
-@pytest.mark.xfail(
-    reason="model inconsistently calls search_reviews — tool selection scorer fails on partial recall"
-)
 @pytest.mark.parametrize(
     "golden",
     _multi_tool_queries(),

--- a/tests/behavioral/configs/thresholds.yaml
+++ b/tests/behavioral/configs/thresholds.yaml
@@ -8,10 +8,10 @@ langgraph_react:
   pass_at_k: 8
 
 vanilla_python:
-  # tool_selection observed 0.58/0.52/0.52 across 3 runs; p5 ~0.50, threshold = 0.45
-  # multi_tool pass@k = 0/8 all runs (model inconsistently calls search_reviews)
-  tool_selection_accuracy: 0.45
-  multi_tool_accuracy: 0.0
+  # tool_selection observed 0.85 after multi-action loop fix; conservative threshold
+  tool_selection_accuracy: 0.60
+  # multi_tool pass@k now works after agent loop fix (iterates all actions per turn)
+  multi_tool_accuracy: 0.25
   response_coherence_accuracy: 0.75
   max_latency_p95: 15.0
   pass_at_k: 8


### PR DESCRIPTION
## Summary
- Fix agent ReAct loop to iterate over ALL parsed `Action:` lines per turn instead of only `actions[0]`, enabling reliable multi-tool queries
- Gracefully handle unknown/hallucinated action names by feeding back available tools instead of crashing with HTTP 500
- Treat `Action: None()` as a no-op for greetings and no-tool queries
- Remove `@pytest.mark.xfail` from `test_multi_tool_selection` (now reliably passes)
- Bump behavioral test thresholds: `tool_selection_accuracy` 0.45→0.60, `multi_tool_accuracy` 0.0→0.25

## Test plan
- [x] `ruff check` and `ruff format --check` pass on all modified files
- [x] Unit tests pass (`make test` — 16 passed)
- [x] Deployed fixed agent to OpenShift (`agen-e2e-rhoai2` cluster, `adonheis-testing` namespace)
- [x] Behavioral tests: **25 passed, 0 failed, 0 skipped** (was 2 failed before fix)
- [x] MLflow tracing confirmed working (`[Tracing Enabled]` in startup logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)