### PR TITLE
fix(opencode): remove Kagenti references from A2A deployment docs and template

### DIFF
--- a/agents/opencode/README.md
+++ b/agents/opencode/README.md
@@ -23,7 +23,7 @@ Deploy [OpenCode](https://opencode.ai), an open-source terminal-based coding age
   - [View Traces](#view-traces)
   - [Key Notes](#key-notes)
   - [OpenShell + MLflow Tracing](#openshell--mlflow-tracing)
-- [A2A / Kagenti Discovery](#a2a--kagenti-discovery)
+- [A2A Discovery](#a2a-discovery)
 - [Security](#security)
 - [Architecture](#architecture)
 - [Image Reference](#image-reference)
@@ -65,7 +65,7 @@ The quick start uses a **pre-built image** — no Containerfile or image build i
 |---------|----------------------|----------|-----------------|
 | **Base (quick start)** | `quay.io/opendatahub/odh-opencode-rhel9:20260619-194847e` | Standard web or CLI deployment | No — pre-built |
 | **MLflow tracing** | [`Containerfile.mlflow`](deployment/Containerfile.mlflow) | You need agent execution traces exported to MLflow | Yes |
-| **A2A / Kagenti** | [`Containerfile.a2a`](deployment/Containerfile.a2a) | You want Kagenti agent discovery via the A2A protocol (agent card and discovery available; task execution pending RHAIENG-5826) | Yes |
+| **A2A** | [`Containerfile.a2a`](deployment/Containerfile.a2a) | You want A2A agent card discovery (agent card available; task execution pending RHAIENG-5826) | Yes |
 | **OpenShell sandbox** | [`Containerfile.openshell`](deployment/Containerfile.openshell) | Sandboxed experimentation inside an OpenShell gateway | Yes |
 | **OpenShell + MLflow** | [`Containerfile.openshell-mlflow`](deployment/Containerfile.openshell-mlflow) | OpenShell sandbox with MLflow tracing support | Yes |
 
@@ -79,7 +79,7 @@ cd agents/opencode/deployment
 # MLflow tracing
 podman build --platform linux/amd64 -t opencode-mlflow:latest -f Containerfile.mlflow .
 
-# A2A / Kagenti
+# A2A
 podman build --platform linux/amd64 -t opencode-a2a:latest -f Containerfile.a2a .
 
 # OpenShell sandbox
@@ -819,14 +819,14 @@ Open the URL, select your workspace (the namespace name), and navigate to the ex
 
 ---
 
-## A2A / Kagenti Discovery
+## A2A Discovery
 
-OpenCode can be deployed as a Kagenti-discoverable agent using the Agent-to-Agent (A2A) protocol. This enables service discovery via the Kagenti agent catalog.
+OpenCode can be deployed as an A2A agent using the Agent-to-Agent (A2A) protocol, serving an agent card that enables service discovery.
 
 **Current state:**
 
 - Agent card server is implemented and running
-- Agent discovery works in Kagenti UI
+- Agent card is accessible at `/.well-known/agent-card.json`
 - Health checks are proxied
 - A2A task execution is not yet implemented (tracked in RHAIENG-5826)
 
@@ -941,10 +941,10 @@ agents/opencode/
     ├── Containerfile.openshell       # OpenShell sandbox variant
     ├── Containerfile.openshell-mlflow  # OpenShell sandbox + MLflow tracing variant
     ├── Containerfile.mlflow          # MLflow tracing image variant
-    ├── Containerfile.a2a             # A2A / Kagenti agent discovery variant
+    ├── Containerfile.a2a             # A2A agent card discovery variant
     ├── entrypoint-a2a.sh             # Entrypoint for A2A variant
-    ├── kagenti-agent.yaml            # OpenShift Template for Kagenti deployment
-    ├── README-a2a.md                 # A2A / Kagenti deployment guide
+    ├── opencode-a2a-template.yaml    # OpenShift Template for A2A deployment
+    ├── README-a2a.md                 # A2A deployment guide
     └── docs/                         # MLflow tracing schema and benchmarks
 ```
 
@@ -952,7 +952,7 @@ agents/opencode/
 
 ## Related Resources
 
-- [deployment/README-a2a.md](deployment/README-a2a.md) — A2A / Kagenti agent discovery deployment
+- [deployment/README-a2a.md](deployment/README-a2a.md) — A2A agent discovery deployment
 - [deployment/docs/mlflow-tracing.md](deployment/docs/mlflow-tracing.md) — tracing schema, backend comparisons, latency benchmarks
 - [opendatahub-io/opencode](https://github.com/opendatahub-io/opencode) — container image source and CI
 - [OpenCode upstream](https://github.com/anomalyco/opencode) — upstream project

--- a/agents/opencode/deployment/Containerfile.a2a
+++ b/agents/opencode/deployment/Containerfile.a2a
@@ -1,7 +1,7 @@
 # OpenCode with A2A agent card support
 #
 # Extends the pre-built OpenCode image with:
-# - opencode-a2a server for Kagenti discovery (A2A protocol)
+# - opencode-a2a server for A2A agent card discovery
 # - Custom entrypoint running both opencode serve and opencode-a2a
 #
 # Build:

--- a/agents/opencode/deployment/README-a2a.md
+++ b/agents/opencode/deployment/README-a2a.md
@@ -1,13 +1,13 @@
 # OpenCode A2A Agent Deployment
 
-This directory contains a reference implementation for deploying [OpenCode](https://opencode.ai) as a Kagenti-discoverable agent using the Agent-to-Agent (A2A) protocol.
+This directory contains a reference implementation for deploying [OpenCode](https://opencode.ai) as an A2A agent using the Agent-to-Agent (A2A) protocol.
 
 ## Overview
 
 OpenCode is an AI-powered coding assistant. This implementation wraps OpenCode with an A2A agent card server to enable:
 
-- **Service discovery** via Kagenti agent catalog
-- **Standardized configuration** using Kagenti-standard environment variables
+- **Service discovery** via A2A agent card endpoint
+- **Standardized configuration** using LLM_* environment variables
 - **Multi-provider support** (direct vLLM, OGX, OpenAI, etc.)
 
 ## Architecture
@@ -41,21 +41,20 @@ OpenCode is an AI-powered coding assistant. This implementation wraps OpenCode w
 
 2. **opencode-a2a Server** (`Containerfile.a2a`)
    - Installed from `agent-servers` repo (opencode subdirectory)
-   - Serves A2A agent card for Kagenti discovery
+   - Serves A2A agent card for discovery
    - Proxies health checks from OpenCode
 
 3. **Entrypoint Script** (`entrypoint-a2a.sh`)
-   - Translates Kagenti-standard env vars to OpenCode config
+   - Translates LLM_* env vars to OpenCode config
    - Starts both `opencode serve` and `opencode-a2a` processes
 
-4. **Kubernetes Template** (`kagenti-agent.yaml`)
+4. **Kubernetes Template** (`opencode-a2a-template.yaml`)
    - OpenShift Template for deployment
-   - Configures Kagenti discovery labels
-   - Supports multiple deployment variants (direct vLLM, OGX, etc.)
+   - Supports multiple deployment variants (direct vLLM, OGX, OpenAI, etc.)
 
 ## Environment Variables
 
-The deployment follows [Kagenti standard naming conventions](https://github.com/rossoctl/rossoctl):
+The deployment uses the following LLM configuration variables:
 
 | Variable           | Description                                              | Required | Default    |
 |--------------------|----------------------------------------------------------|----------|------------|
@@ -77,7 +76,6 @@ The deployment follows [Kagenti standard naming conventions](https://github.com/
 ### Prerequisites
 
 - OpenShift/Kubernetes cluster
-- Kagenti installed and configured (for agent discovery)
 - LLM endpoint accessible from the cluster
 - Secret containing LLM API key (if required)
 
@@ -147,7 +145,7 @@ oc create secret generic opencode-model-credentials \
   -n your-namespace
 
 # Deploy using template
-oc process -f kagenti-agent.yaml \
+oc process -f opencode-a2a-template.yaml \
   -p NAMESPACE=your-namespace \
   -p IMAGE=image-registry.openshift-image-registry.svc:5000/your-namespace/opencode-a2a:latest \
   -p LLM_PROVIDER=vllm \
@@ -159,7 +157,7 @@ oc process -f kagenti-agent.yaml \
 #### Option 2: Through OGX
 
 ```bash
-oc process -f kagenti-agent.yaml \
+oc process -f opencode-a2a-template.yaml \
   -p NAMESPACE=your-namespace \
   -p IMAGE=image-registry.openshift-image-registry.svc:5000/your-namespace/opencode-a2a:latest \
   -p LLM_PROVIDER=ogx \
@@ -173,7 +171,7 @@ Note: OGX namespaces models by provider, so use `provider/model` format.
 #### Option 3: OpenAI API
 
 ```bash
-oc process -f kagenti-agent.yaml \
+oc process -f opencode-a2a-template.yaml \
   -p NAMESPACE=your-namespace \
   -p IMAGE=image-registry.openshift-image-registry.svc:5000/your-namespace/opencode-a2a:latest \
   -p LLM_PROVIDER=openai \
@@ -183,64 +181,16 @@ oc process -f kagenti-agent.yaml \
   | oc apply -f -
 ```
 
-### Enable Kagenti Discovery
-
-Add your namespace to Kagenti's monitored namespaces:
-
-```bash
-# Add Helm labels and annotations to namespace
-oc label namespace your-namespace \
-  app.kubernetes.io/managed-by=Helm \
-  app.kubernetes.io/instance=kagenti \
-  app.kubernetes.io/name=kagenti \
-  kagenti.io/enabled=true
-
-oc annotate namespace your-namespace \
-  meta.helm.sh/release-name=kagenti \
-  meta.helm.sh/release-namespace=kagenti-system
-
-# Update Kagenti Helm values
-helm get values kagenti -n kagenti-system -o yaml > /tmp/kagenti-values.yaml
-
-# Edit /tmp/kagenti-values.yaml and add your namespace to agentNamespaces list:
-# agentNamespaces:
-#   - team1
-#   - team2
-#   - your-namespace  # <-- Add this
-
-# Upgrade Kagenti
-helm upgrade kagenti /path/to/kagenti/chart \
-  -n kagenti-system \
-  -f /tmp/kagenti-values.yaml
-```
-
 ## Verification
 
-### Check AgentRuntime and AgentCard Creation
+### Check Deployment Status
 
 ```bash
-# Check AgentRuntime was created
-oc get agentruntime -n your-namespace
+# Check deployment is running
+oc get deployment opencode-a2a -n your-namespace
 
-# List AgentCards in your namespace
-oc get agentcard -n your-namespace
-
-# View AgentCard details
-oc get agentcard opencode-a2a-deployment-card -n your-namespace -o yaml
-```
-
-Expected AgentRuntime output shows `Phase=Active`:
-
-```text
-NAME                       TYPE    TARGET          PHASE
-opencode-a2a-runtime       agent   opencode-a2a    Active
-```
-
-Expected AgentCard output shows `Synced=True`:
-
-```text
-NAME                          PROTOCOL   KIND         TARGET        AGENT      VERIFIED   BOUND   SYNCED   LASTSYNC
-opencode-a2a-deployment-card  a2a        Deployment   opencode-a2a  OpenCode              false   True     30s
+# Check pod status
+oc get pods -n your-namespace -l app.kubernetes.io/name=opencode-a2a
 ```
 
 ### Test Agent Card Endpoint
@@ -300,13 +250,6 @@ opencode attach http://localhost:4096
 # Try sending a message to verify LLM connectivity
 ```
 
-### Check Kagenti UI
-
-1. Access Kagenti UI: `https://kagenti-ui-kagenti-system.apps.YOUR_CLUSTER/`
-2. Navigate to agent catalog
-3. Your namespace should appear with OpenCode agents listed
-4. Agent card shows name, description, skills, and provider info
-
 ### Verify LLM Traffic
 
 Monitor logs to confirm requests reach the LLM:
@@ -329,7 +272,7 @@ oc logs -n ogx-namespace deployment/ogx --tail=50
 The `entrypoint-a2a.sh` script performs the following translation:
 
 ```bash
-# Input (Kagenti standard):
+# Input:
 LLM_PROVIDER=vllm
 LLM_API_BASE=http://vllm:8000/v1
 LLM_MODEL=gpt-oss-120b
@@ -360,7 +303,7 @@ LLM_API_KEY=secret-key
 
 This approach allows:
 
-- **Standardization**: Use Kagenti conventions across all agents
+- **Standardization**: Use consistent naming across all agents
 - **Flexibility**: Support any OpenAI-compatible provider
 - **Runtime configuration**: No image rebuilds for different providers
 
@@ -371,24 +314,23 @@ This approach allows:
 **Current state (RHAIENG-5825 ✅):**
 
 - Agent card server is implemented and running
-- Agent discovery works in Kagenti UI
+- Agent card is accessible at `/.well-known/agent-card.json`
 - Health checks are proxied
 - Configuration is correctly generated
 
 **Not yet implemented (RHAIENG-5826 ⏳):**
 
 - A2A task execution endpoint (`POST /v1/agent/tasks`)
-- Request proxying from Kagenti to OpenCode
+- Request proxying from A2A client to OpenCode
 - Streaming response support
 - State management
 
 **Current behavior:**
 
-- Agent appears in Kagenti catalog ✅
-- Clicking "Try it" returns 404 error ⚠️
+- Agent card endpoint is accessible ✅
 - Direct OpenCode TUI access works ✅
 
-The full A2A protocol implementation is tracked in **RHAIENG-5826** and will enable end-to-end agent execution through Kagenti.
+The full A2A protocol implementation is tracked in **RHAIENG-5826** and will enable end-to-end agent execution.
 
 ### OpenCode TUI Access
 
@@ -404,7 +346,7 @@ oc exec -it -n your-namespace deployment/opencode-a2a -- opencode attach http://
 |-----------------------|---------------------------------------------------------------|
 | `Containerfile.a2a`   | Extends base OpenCode image with opencode-a2a server          |
 | `entrypoint-a2a.sh`   | Entrypoint that configures OpenCode and runs both servers     |
-| `kagenti-agent.yaml`  | OpenShift Template for Kagenti-compatible deployment          |
+| `opencode-a2a-template.yaml` | OpenShift Template for A2A deployment                   |
 | `README-a2a.md`       | This file - deployment and usage guide                        |
 
 ## Related Work
@@ -412,35 +354,11 @@ oc exec -it -n your-namespace deployment/opencode-a2a -- opencode attach http://
 - **agent-servers repo**: Source for opencode-a2a Python package
   - Installation: `pip install 'opencode-a2a @ git+https://github.com/red-hat-data-services/agent-servers.git#subdirectory=opencode'`
 
-- **Kagenti**: Agent orchestration platform
-  - Uses A2A protocol for agent discovery and execution
-  - Monitors namespaces with `kagenti.io/enabled=true` label
-
 - **OpenCode**: AI coding assistant
   - Project: <https://opencode.ai>
   - Supports multiple LLM providers via Vercel AI SDK
 
 ## Troubleshooting
-
-### Agent not appearing in Kagenti UI
-
-Check namespace is in Kagenti's `agentNamespaces` list:
-
-```bash
-helm get values kagenti -n kagenti-system | grep -A 5 agentNamespaces
-```
-
-Verify AgentCard is created and synced:
-
-```bash
-oc get agentcard -n your-namespace
-```
-
-Check Kagenti backend logs:
-
-```bash
-oc logs -n kagenti-system deployment/kagenti-backend --tail=50
-```
 
 ### OpenCode can't reach LLM
 

--- a/agents/opencode/deployment/README.md
+++ b/agents/opencode/deployment/README.md
@@ -15,9 +15,9 @@ For the full deployment guide, see the [OpenCode on RHOAI README](../README.md).
 | `Containerfile.openshell` | OpenShell sandbox image variant |
 | `Containerfile.openshell-mlflow` | OpenShell sandbox + MLflow tracing variant |
 | `Containerfile.mlflow` | MLflow tracing image variant (kustomize deployment) |
-| `Containerfile.a2a` | A2A / Kagenti agent discovery variant |
+| `Containerfile.a2a` | A2A agent card discovery variant |
 | `entrypoint-a2a.sh` | Entrypoint for A2A variant (runs opencode serve + opencode-a2a) |
-| `kagenti-agent.yaml` | OpenShift Template for Kagenti-compatible deployment |
+| `opencode-a2a-template.yaml` | OpenShift Template for A2A deployment |
 | `DEPLOYMENT.md` | Legacy deployment guide (content moved to `../README.md`) |
-| `README-a2a.md` | A2A / Kagenti deployment guide |
+| `README-a2a.md` | A2A deployment guide |
 | `docs/` | MLflow tracing schema, benchmarks, and screenshots |

--- a/agents/opencode/deployment/entrypoint-a2a.sh
+++ b/agents/opencode/deployment/entrypoint-a2a.sh
@@ -5,7 +5,7 @@
 # 1. opencode serve (background) - OpenCode HTTP API on port 4096
 # 2. opencode-a2a (foreground) - A2A agent card server on port 8000
 #
-# Environment variables (Kagenti standard names):
+# Environment variables:
 #   LLM_API_BASE  - LLM API endpoint (e.g., https://api.openai.com/v1)
 #   LLM_API_KEY   - API key for the LLM provider (optional)
 #   LLM_MODEL     - Model identifier (e.g., gpt-4o)
@@ -14,11 +14,11 @@ set -e
 
 echo "Starting OpenCode A2A container..."
 
-# Translate Kagenti-standard LLM_* env vars to OpenCode configuration
-# Kagenti standard: LLM_API_BASE, LLM_API_KEY, LLM_MODEL
-# OpenCode needs: Full provider configuration in opencode.json
+# Translate LLM_* env vars to OpenCode configuration
+# Input: LLM_API_BASE, LLM_API_KEY, LLM_MODEL
+# Output: Full provider configuration in opencode.json
 if [[ -n "${LLM_API_BASE}" || -n "${LLM_MODEL}" ]]; then
-    echo "Configuring OpenCode from Kagenti LLM_* environment variables..."
+    echo "Configuring OpenCode from LLM_* environment variables..."
 
     CONFIG_DIR="${HOME}/.config/opencode"
     mkdir -p "${CONFIG_DIR}"

--- a/agents/opencode/deployment/opencode-a2a-template.yaml
+++ b/agents/opencode/deployment/opencode-a2a-template.yaml
@@ -1,21 +1,21 @@
-# OpenCode A2A Agent - Kagenti-compatible OpenShift Template
+# OpenCode A2A Agent - OpenShift Template
 #
 # Deploy with:
-#   oc process -f kagenti-agent.yaml \
+#   oc process -f opencode-a2a-template.yaml \
 #     -p NAMESPACE=my-namespace \
 #     -p LLM_API_BASE=https://api.openai.com/v1 \
 #     -p LLM_MODEL=gpt-4o | oc apply -f -
 #
 # Or create a parameters file and use:
-#   oc process -f kagenti-agent.yaml --param-file=params.env | oc apply -f -
+#   oc process -f opencode-a2a-template.yaml --param-file=params.env | oc apply -f -
 #
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: opencode-a2a-agent
   annotations:
-    description: "OpenCode A2A Agent for Kagenti discovery"
-    tags: "agent,a2a,opencode,kagenti"
+    description: "OpenCode A2A Agent with agent card server"
+    tags: "agent,a2a,opencode"
 parameters:
   - name: NAMESPACE
     description: "Target namespace for deployment"
@@ -28,10 +28,10 @@ parameters:
     description: "Provider name (vllm, ogx, openai, etc.) - defaults to vllm"
     value: "vllm"
   - name: LLM_API_BASE
-    description: "LLM API endpoint (e.g., https://api.openai.com/v1) - Kagenti standard"
+    description: "LLM API endpoint (e.g., https://api.openai.com/v1)"
     value: ""
   - name: LLM_MODEL
-    description: "Model identifier (e.g., gpt-4o) - Kagenti standard"
+    description: "Model identifier (e.g., gpt-4o)"
     value: ""
   - name: LLM_API_KEY_SECRET
     description: "Secret name containing LLM API key (key: api-key)"
@@ -45,20 +45,6 @@ objects:
     metadata:
       name: opencode-a2a
       namespace: ${NAMESPACE}
-  - apiVersion: agent.kagenti.dev/v1alpha1
-    kind: AgentRuntime
-    metadata:
-      name: opencode-a2a-runtime
-      namespace: ${NAMESPACE}
-      labels:
-        app.kubernetes.io/name: opencode-a2a
-    spec:
-      type: agent
-      protocol: a2a
-      targetRef:
-        apiVersion: apps/v1
-        kind: Deployment
-        name: opencode-a2a
   - apiVersion: v1
     kind: Service
     metadata:
@@ -66,7 +52,6 @@ objects:
       namespace: ${NAMESPACE}
       labels:
         app.kubernetes.io/name: opencode-a2a
-        protocol.kagenti.io/a2a: "true"
     spec:
       type: ClusterIP
       selector:
@@ -83,7 +68,6 @@ objects:
       namespace: ${NAMESPACE}
       labels:
         app.kubernetes.io/name: opencode-a2a
-        protocol.kagenti.io/a2a: "true"
     spec:
       replicas: 1
       selector:
@@ -93,7 +77,6 @@ objects:
         metadata:
           labels:
             app.kubernetes.io/name: opencode-a2a
-            protocol.kagenti.io/a2a: "true"
           annotations:
             sidecar.istio.io/inject: "false"
         spec:


### PR DESCRIPTION
## Summary

- Kagenti was used only as a test vehicle for A2A agent discovery and is
  not part of RHOAI — remove all references while keeping the A2A
  integration intact
- Rename `kagenti-agent.yaml` → `opencode-a2a-template.yaml`; remove the
  `AgentRuntime` CRD object (requires Kagenti installed) and
  `protocol.kagenti.io/a2a` labels (Kagenti watch labels) from the
  OpenShift Template — the Service, Deployment, probes, env vars, and
  security context are unchanged
- Drop the "Enable Kagenti Discovery" section (Helm-based namespace
  enrollment), "Check Kagenti UI" verification step, and "Agent not
  appearing in Kagenti UI" troubleshooting from `README-a2a.md`
- Replace Kagenti-specific "Check AgentRuntime and AgentCard Creation"
  verification block with standard `oc get deployment/pods` commands
- Update `entrypoint-a2a.sh` comments: "Kagenti standard names" →
  neutral `LLM_*` variable descriptions (no logic changes)
- Update `Containerfile.a2a` comment (no build changes)
- Update variant table, TOC, section heading, directory tree, and links
  in `agents/opencode/README.md`

## Test plan

- [ ] `oc process -f opencode-a2a-template.yaml -p NAMESPACE=... -p LLM_API_BASE=... -p LLM_MODEL=... | oc apply -f -` applies cleanly (no unknown CRD errors)
- [ ] Pod starts and readiness probe passes (`GET /.well-known/agent-card.json` returns 200)
- [ ] `curl http://opencode-a2a.<namespace>.svc.cluster.local:8000/.well-known/agent-card.json` returns a valid agent card
- [ ] `cat ~/.config/opencode/opencode.json` inside the pod shows correct provider config from `LLM_*` env vars
- [ ] `grep -r kagenti agents/opencode/` returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)