### PR TITLE
ci: add QG1 cluster readiness gate

### DIFF
--- a/.github/actions/run-qg1/action.yml
+++ b/.github/actions/run-qg1/action.yml
@@ -1,0 +1,64 @@
+name: "Run QG1 Cluster Readiness"
+description: "Run cluster-readiness assertions after cluster setup/login."
+
+inputs:
+  cluster-profile:
+    description: "Logical cluster profile name for reporting and future matrixing"
+    required: true
+  require-gpu:
+    description: "Whether GPU nodes are required for this cluster profile"
+    required: false
+    default: "true"
+  required-namespaces:
+    description: "Comma- or newline-separated namespaces that must exist"
+    required: false
+    default: "ci-testing"
+  summary-json-path:
+    description: "Path for machine-readable summary output"
+    required: false
+    default: "qg1-results/summary.json"
+  summary-md-path:
+    description: "Path for markdown summary output"
+    required: false
+    default: "qg1-results/summary.md"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Ensure result directories exist
+      shell: bash
+      env:
+        SUMMARY_JSON_PATH: ${{ inputs.summary-json-path }}
+        SUMMARY_MD_PATH: ${{ inputs.summary-md-path }}
+      run: |
+        set -euo pipefail
+        mkdir -p "$(dirname "${SUMMARY_JSON_PATH}")"
+        mkdir -p "$(dirname "${SUMMARY_MD_PATH}")"
+
+    - name: Execute QG1 checker
+      shell: bash
+      env:
+        CLUSTER_PROFILE: ${{ inputs.cluster-profile }}
+        REQUIRE_GPU: ${{ inputs.require-gpu }}
+        REQUIRED_NAMESPACES: ${{ inputs.required-namespaces }}
+        SUMMARY_JSON_PATH: ${{ inputs.summary-json-path }}
+        SUMMARY_MD_PATH: ${{ inputs.summary-md-path }}
+      run: |
+        set -euo pipefail
+        python .github/scripts/qg1_cluster_readiness.py \
+          --cluster-profile "${CLUSTER_PROFILE}" \
+          --require-gpu "${REQUIRE_GPU}" \
+          --required-namespaces "${REQUIRED_NAMESPACES}" \
+          --summary-json "${SUMMARY_JSON_PATH}" \
+          --summary-md "${SUMMARY_MD_PATH}"
+
+    - name: Publish markdown summary
+      if: always()
+      shell: bash
+      env:
+        SUMMARY_MD_PATH: ${{ inputs.summary-md-path }}
+      run: |
+        set -euo pipefail
+        if [[ -f "${SUMMARY_MD_PATH}" ]]; then
+          cat "${SUMMARY_MD_PATH}" >> "${GITHUB_STEP_SUMMARY}"
+        fi

--- a/.github/scripts/fixtures/ci-runs-sample.json
+++ b/.github/scripts/fixtures/ci-runs-sample.json
@@ -54,6 +54,20 @@
       "run_started_at": "2026-07-04T16:45:08Z"
     }
   ],
+  "qg1-cluster-readiness.yml": [
+    {
+      "id": 10025,
+      "name": "QG1: Cluster Readiness",
+      "event": "schedule",
+      "head_branch": "main",
+      "status": "completed",
+      "conclusion": "success",
+      "html_url": "https://github.com/red-hat-data-services/agentic-starter-kits/actions/runs/10025",
+      "created_at": "2026-07-05T01:05:10Z",
+      "updated_at": "2026-07-05T01:08:55Z",
+      "run_started_at": "2026-07-05T01:05:18Z"
+    }
+  ],
   "agent-deployment-test.yaml": [
     {
       "id": 10031,

--- a/.github/scripts/generate_ci_health_page.py
+++ b/.github/scripts/generate_ci_health_page.py
@@ -43,6 +43,11 @@ WORKFLOWS = (
         "description": "Behavioral pytest and EvalHub gating on selected paths.",
     },
     {
+        "file": "qg1-cluster-readiness.yml",
+        "name": "QG1: Cluster Readiness",
+        "description": "Cluster API, GPU, and namespace readiness checks before downstream gates.",
+    },
+    {
         "file": "agent-deployment-test.yaml",
         "name": "QG4: Agent Deployment Integration Tests",
         "description": "Nightly OpenShift deploy, /health checks, and teardown.",

--- a/.github/scripts/qg1_cluster_readiness.py
+++ b/.github/scripts/qg1_cluster_readiness.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+OC_TIMEOUT_SECONDS = 60
+
+
+def parse_required_namespaces(raw: str) -> list[str]:
+    return [item.strip() for item in raw.replace("\n", ",").split(",") if item.strip()]
+
+
+def run_oc(*args: str, timeout: float = OC_TIMEOUT_SECONDS) -> str:
+    result = subprocess.run(
+        ["oc", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return result.stdout.strip()
+
+
+def evaluate_cluster_state(
+    *,
+    api_health: str,
+    cluster_version: str,
+    gpu_nodes: list[str],
+    namespaces: list[str],
+    required_namespaces: list[str],
+    require_gpu: bool,
+) -> list[dict[str, object]]:
+    checks: list[dict[str, object]] = []
+    checks.append(
+        {
+            "name": "api_health",
+            "passed": api_health == "ok",
+            "details": "API healthy"
+            if api_health == "ok"
+            else f"API returned: {api_health or 'empty'}",
+        }
+    )
+    checks.append(
+        {
+            "name": "cluster_version",
+            "passed": bool(cluster_version),
+            "details": f"Cluster version: {cluster_version}"
+            if cluster_version
+            else "Cluster version unavailable",
+        }
+    )
+    if require_gpu:
+        checks.append(
+            {
+                "name": "gpu_nodes",
+                "passed": len(gpu_nodes) > 0,
+                "details": f"Found {len(gpu_nodes)} GPU node(s)"
+                if gpu_nodes
+                else "No GPU nodes found",
+            }
+        )
+    else:
+        checks.append(
+            {
+                "name": "gpu_nodes",
+                "passed": True,
+                "details": "GPU requirement disabled",
+            }
+        )
+
+    missing_namespaces = [ns for ns in required_namespaces if ns not in namespaces]
+    checks.append(
+        {
+            "name": "required_namespaces",
+            "passed": not missing_namespaces,
+            "details": "All required namespaces present"
+            if not missing_namespaces
+            else f"Missing namespaces: {', '.join(missing_namespaces)}",
+        }
+    )
+    return checks
+
+
+def build_summary(
+    cluster_profile: str, checks: list[dict[str, object]]
+) -> dict[str, object]:
+    return {
+        "cluster_profile": cluster_profile,
+        "passed": all(bool(item["passed"]) for item in checks),
+        "checks": checks,
+    }
+
+
+def build_error_summary(
+    cluster_profile: str, error: subprocess.CalledProcessError
+) -> dict[str, object]:
+    command = " ".join(error.cmd) if isinstance(error.cmd, list) else str(error.cmd)
+    stderr = (error.stderr or "").strip()
+    details = f"Command failed ({command}): {stderr or 'no stderr output'}"
+    return {
+        "cluster_profile": cluster_profile,
+        "passed": False,
+        "checks": [
+            {
+                "name": "oc_command",
+                "passed": False,
+                "details": details,
+            }
+        ],
+    }
+
+
+def build_timeout_summary(
+    cluster_profile: str, error: subprocess.TimeoutExpired
+) -> dict[str, object]:
+    command = " ".join(error.cmd) if isinstance(error.cmd, list) else str(error.cmd)
+    details = f"Command timed out after {error.timeout}s ({command})"
+    return {
+        "cluster_profile": cluster_profile,
+        "passed": False,
+        "checks": [
+            {
+                "name": "oc_command",
+                "passed": False,
+                "details": details,
+            }
+        ],
+    }
+
+
+def write_outputs(summary: dict[str, object], json_path: Path, md_path: Path) -> None:
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+    lines = [
+        "# QG1 Cluster Readiness",
+        "",
+        f"- cluster_profile: {summary['cluster_profile']}",
+        f"- overall: {'PASS' if summary['passed'] else 'FAIL'}",
+        "",
+    ]
+    for check in summary["checks"]:
+        status = "PASS" if check["passed"] else "FAIL"
+        lines.append(f"- {check['name']}: {status} — {check['details']}")
+    md_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cluster-profile", required=True)
+    parser.add_argument("--require-gpu", default="true")
+    parser.add_argument("--required-namespaces", default="ci-testing")
+    parser.add_argument("--summary-json", required=True)
+    parser.add_argument("--summary-md", required=True)
+    args = parser.parse_args(argv)
+
+    require_gpu = args.require_gpu.lower() == "true"
+    required_namespaces = parse_required_namespaces(args.required_namespaces)
+
+    try:
+        api_health = run_oc("get", "--raw", "/healthz")
+        cluster_version = run_oc(
+            "get",
+            "clusterversion",
+            "-o",
+            "jsonpath={.items[0].status.desired.version}",
+        )
+        gpu_raw = run_oc(
+            "get",
+            "nodes",
+            "-l",
+            "nvidia.com/gpu.present=true",
+            "-o",
+            "jsonpath={.items[*].metadata.name}",
+        )
+        ns_raw = run_oc("get", "namespaces", "-o", "jsonpath={.items[*].metadata.name}")
+    except subprocess.TimeoutExpired as error:
+        summary = build_timeout_summary(args.cluster_profile, error)
+        write_outputs(summary, Path(args.summary_json), Path(args.summary_md))
+        return 1
+    except subprocess.CalledProcessError as error:
+        summary = build_error_summary(args.cluster_profile, error)
+        write_outputs(summary, Path(args.summary_json), Path(args.summary_md))
+        return 1
+
+    checks = evaluate_cluster_state(
+        api_health=api_health,
+        cluster_version=cluster_version,
+        gpu_nodes=[item for item in gpu_raw.split() if item],
+        namespaces=[item for item in ns_raw.split() if item],
+        required_namespaces=required_namespaces,
+        require_gpu=require_gpu,
+    )
+    summary = build_summary(args.cluster_profile, checks)
+    write_outputs(summary, Path(args.summary_json), Path(args.summary_md))
+    return 0 if summary["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_generate_ci_health_page.py
+++ b/.github/scripts/tests/test_generate_ci_health_page.py
@@ -24,10 +24,19 @@ FIXTURE = Path(__file__).resolve().parent.parent / "fixtures" / "ci-runs-sample.
 
 def test_fixture_loads_all_workflows():
     summaries = summaries_from_fixture(FIXTURE)
-    assert len(summaries) == 4
+    assert len(summaries) == 5
     assert summaries[0].display_name == "Code Quality"
     assert summaries[0].latest is not None
     assert summaries[0].latest.conclusion == "success"
+
+
+def test_qg1_fixture_entry_is_included():
+    summaries = summaries_from_fixture(FIXTURE)
+    qg1 = next(
+        item for item in summaries if item.workflow_file == "qg1-cluster-readiness.yml"
+    )
+    assert qg1.display_name == "QG1: Cluster Readiness"
+    assert qg1.latest is not None
 
 
 def test_qg4_latest_failure_is_surfaced():
@@ -140,7 +149,7 @@ def test_summaries_from_api_continues_after_workflow_failure(monkeypatch):
     summaries = summaries_from_api(
         "red-hat-data-services/agentic-starter-kits", "token"
     )
-    assert len(summaries) == 4
+    assert len(summaries) == 5
     gating = next(item for item in summaries if item.workflow_file == "eval-gating.yml")
     assert gating.error_message is not None
     assert "404" in gating.error_message
@@ -153,3 +162,4 @@ def test_main_writes_html(tmp_path):
     content = output.read_text(encoding="utf-8")
     assert "agentic-starter-kits CI Health" in content
     assert "QG4: Agent Deployment Integration Tests" in content
+    assert "QG1: Cluster Readiness" in content

--- a/.github/scripts/tests/test_qg1_cluster_readiness.py
+++ b/.github/scripts/tests/test_qg1_cluster_readiness.py
@@ -10,8 +10,8 @@ import qg1_cluster_readiness as mod  # noqa: E402
 
 
 def test_parse_required_namespaces_accepts_csv_and_newlines():
-    parsed = mod.parse_required_namespaces("ci-testing,llama-serving\nkagenti-system")
-    assert parsed == ["ci-testing", "llama-serving", "kagenti-system"]
+    parsed = mod.parse_required_namespaces("ci-testing\nllama-serving")
+    assert parsed == ["ci-testing", "llama-serving"]
 
 
 def test_evaluate_cluster_state_flags_missing_namespace():
@@ -19,15 +19,15 @@ def test_evaluate_cluster_state_flags_missing_namespace():
         api_health="ok",
         cluster_version="4.16.12",
         gpu_nodes=["worker-gpu-0"],
-        namespaces=["ci-testing", "llama-serving"],
-        required_namespaces=["ci-testing", "kagenti-system"],
+        namespaces=["ci-testing"],
+        required_namespaces=["ci-testing", "llama-serving"],
         require_gpu=True,
     )
     namespace_check = next(
         item for item in checks if item["name"] == "required_namespaces"
     )
     assert namespace_check["passed"] is False
-    assert namespace_check["details"] == "Missing namespaces: kagenti-system"
+    assert namespace_check["details"] == "Missing namespaces: llama-serving"
 
 
 def test_evaluate_cluster_state_flags_degraded_api():
@@ -92,7 +92,7 @@ def test_build_summary_reports_overall_failure():
         {
             "name": "required_namespaces",
             "passed": False,
-            "details": "Missing namespaces: kagenti-system",
+            "details": "Missing namespaces: llama-serving",
         },
     ]
     summary = mod.build_summary("rhoai2", checks)

--- a/.github/scripts/tests/test_qg1_cluster_readiness.py
+++ b/.github/scripts/tests/test_qg1_cluster_readiness.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import qg1_cluster_readiness as mod  # noqa: E402
+
+
+def test_parse_required_namespaces_accepts_csv_and_newlines():
+    parsed = mod.parse_required_namespaces("ci-testing,llama-serving\nkagenti-system")
+    assert parsed == ["ci-testing", "llama-serving", "kagenti-system"]
+
+
+def test_evaluate_cluster_state_flags_missing_namespace():
+    checks = mod.evaluate_cluster_state(
+        api_health="ok",
+        cluster_version="4.16.12",
+        gpu_nodes=["worker-gpu-0"],
+        namespaces=["ci-testing", "llama-serving"],
+        required_namespaces=["ci-testing", "kagenti-system"],
+        require_gpu=True,
+    )
+    namespace_check = next(
+        item for item in checks if item["name"] == "required_namespaces"
+    )
+    assert namespace_check["passed"] is False
+    assert namespace_check["details"] == "Missing namespaces: kagenti-system"
+
+
+def test_evaluate_cluster_state_flags_degraded_api():
+    checks = mod.evaluate_cluster_state(
+        api_health="degraded",
+        cluster_version="4.16.12",
+        gpu_nodes=["worker-gpu-0"],
+        namespaces=["ci-testing"],
+        required_namespaces=["ci-testing"],
+        require_gpu=True,
+    )
+    api_check = next(item for item in checks if item["name"] == "api_health")
+    assert api_check["passed"] is False
+    assert api_check["details"] == "API returned: degraded"
+
+
+def test_evaluate_cluster_state_flags_empty_cluster_version():
+    checks = mod.evaluate_cluster_state(
+        api_health="ok",
+        cluster_version="",
+        gpu_nodes=["worker-gpu-0"],
+        namespaces=["ci-testing"],
+        required_namespaces=["ci-testing"],
+        require_gpu=True,
+    )
+    version_check = next(item for item in checks if item["name"] == "cluster_version")
+    assert version_check["passed"] is False
+    assert version_check["details"] == "Cluster version unavailable"
+
+
+def test_evaluate_cluster_state_gpu_required_and_present_passes():
+    checks = mod.evaluate_cluster_state(
+        api_health="ok",
+        cluster_version="4.16.12",
+        gpu_nodes=["worker-gpu-0", "worker-gpu-1"],
+        namespaces=["ci-testing"],
+        required_namespaces=["ci-testing"],
+        require_gpu=True,
+    )
+    gpu_check = next(item for item in checks if item["name"] == "gpu_nodes")
+    assert gpu_check["passed"] is True
+    assert gpu_check["details"] == "Found 2 GPU node(s)"
+
+
+def test_evaluate_cluster_state_allows_gpu_to_be_optional():
+    checks = mod.evaluate_cluster_state(
+        api_health="ok",
+        cluster_version="4.16.12",
+        gpu_nodes=[],
+        namespaces=["ci-testing"],
+        required_namespaces=["ci-testing"],
+        require_gpu=False,
+    )
+    gpu_check = next(item for item in checks if item["name"] == "gpu_nodes")
+    assert gpu_check["passed"] is True
+    assert gpu_check["details"] == "GPU requirement disabled"
+
+
+def test_build_summary_reports_overall_failure():
+    checks = [
+        {"name": "api_health", "passed": True, "details": "API healthy"},
+        {
+            "name": "required_namespaces",
+            "passed": False,
+            "details": "Missing namespaces: kagenti-system",
+        },
+    ]
+    summary = mod.build_summary("rhoai2", checks)
+    assert summary["cluster_profile"] == "rhoai2"
+    assert summary["passed"] is False
+    assert summary["checks"][1]["name"] == "required_namespaces"
+
+
+def test_write_outputs_creates_json_and_markdown(tmp_path):
+    checks = [
+        {"name": "api_health", "passed": True, "details": "API healthy"},
+        {"name": "gpu_nodes", "passed": True, "details": "Found 2 GPU nodes"},
+    ]
+    summary = mod.build_summary("rhoai2", checks)
+    json_path = tmp_path / "summary.json"
+    md_path = tmp_path / "summary.md"
+    mod.write_outputs(summary, json_path, md_path)
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["passed"] is True
+    markdown = md_path.read_text(encoding="utf-8")
+    assert "# QG1 Cluster Readiness" in markdown
+    assert "- api_health: PASS — API healthy" in markdown
+
+
+def test_build_error_summary_formats_command_and_stderr():
+    error = subprocess.CalledProcessError(
+        returncode=1,
+        cmd=["oc", "get", "--raw", "/healthz"],
+        output="",
+        stderr="error: You must be logged in to the server (Unauthorized)",
+    )
+    summary = mod.build_error_summary("rhoai2", error)
+    assert summary["cluster_profile"] == "rhoai2"
+    assert summary["passed"] is False
+    assert len(summary["checks"]) == 1
+    check = summary["checks"][0]
+    assert check["name"] == "oc_command"
+    assert check["passed"] is False
+    assert "oc get --raw /healthz" in check["details"]
+    assert "Unauthorized" in check["details"]
+
+
+def test_build_timeout_summary_formats_command_and_duration():
+    error = subprocess.TimeoutExpired(
+        cmd=["oc", "get", "--raw", "/healthz"], timeout=60
+    )
+    summary = mod.build_timeout_summary("rhoai2", error)
+    assert summary["cluster_profile"] == "rhoai2"
+    assert summary["passed"] is False
+    assert len(summary["checks"]) == 1
+    check = summary["checks"][0]
+    assert check["name"] == "oc_command"
+    assert check["passed"] is False
+    assert "oc get --raw /healthz" in check["details"]
+    assert "60s" in check["details"]
+
+
+def test_build_error_summary_handles_missing_stderr():
+    error = subprocess.CalledProcessError(
+        returncode=1,
+        cmd=["oc", "get", "namespaces"],
+        output="",
+        stderr=None,
+    )
+    summary = mod.build_error_summary("rhoai2", error)
+    assert "no stderr output" in summary["checks"][0]["details"]
+
+
+def test_main_writes_failing_summary_when_oc_raises_called_process_error(
+    tmp_path, monkeypatch
+):
+    def raise_error(*args, **kwargs):
+        raise subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["oc", "get", "--raw", "/healthz"],
+            output="",
+            stderr="error: dial tcp: connection refused",
+        )
+
+    monkeypatch.setattr(mod, "run_oc", raise_error)
+    json_path = tmp_path / "summary.json"
+    md_path = tmp_path / "summary.md"
+
+    exit_code = mod.main(
+        [
+            "--cluster-profile",
+            "rhoai2",
+            "--summary-json",
+            str(json_path),
+            "--summary-md",
+            str(md_path),
+        ]
+    )
+
+    assert exit_code == 1
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["passed"] is False
+    assert payload["checks"][0]["name"] == "oc_command"
+    assert "connection refused" in payload["checks"][0]["details"]
+    markdown = md_path.read_text(encoding="utf-8")
+    assert "overall: FAIL" in markdown
+
+
+def test_main_writes_failing_summary_when_oc_times_out(tmp_path, monkeypatch):
+    def raise_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(
+            cmd=["oc", "get", "--raw", "/healthz"], timeout=60
+        )
+
+    monkeypatch.setattr(mod, "run_oc", raise_timeout)
+    json_path = tmp_path / "summary.json"
+    md_path = tmp_path / "summary.md"
+
+    exit_code = mod.main(
+        [
+            "--cluster-profile",
+            "rhoai2",
+            "--summary-json",
+            str(json_path),
+            "--summary-md",
+            str(md_path),
+        ]
+    )
+
+    assert exit_code == 1
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["passed"] is False
+    assert payload["checks"][0]["name"] == "oc_command"
+    assert "timed out" in payload["checks"][0]["details"]
+    markdown = md_path.read_text(encoding="utf-8")
+    assert "overall: FAIL" in markdown
+
+
+def test_main_writes_passing_summary_on_happy_path(tmp_path, monkeypatch):
+    responses = iter(
+        [
+            "ok",  # api_health
+            "4.16.12",  # cluster_version
+            "worker-gpu-0 worker-gpu-1",  # gpu nodes
+            "ci-testing llama-serving",  # namespaces
+        ]
+    )
+
+    def fake_run_oc(*args, **kwargs):
+        return next(responses)
+
+    monkeypatch.setattr(mod, "run_oc", fake_run_oc)
+    json_path = tmp_path / "summary.json"
+    md_path = tmp_path / "summary.md"
+
+    exit_code = mod.main(
+        [
+            "--cluster-profile",
+            "rhoai2",
+            "--require-gpu",
+            "true",
+            "--required-namespaces",
+            "ci-testing",
+            "--summary-json",
+            str(json_path),
+            "--summary-md",
+            str(md_path),
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["cluster_profile"] == "rhoai2"
+    assert payload["passed"] is True
+    assert all(check["passed"] for check in payload["checks"])
+    markdown = md_path.read_text(encoding="utf-8")
+    assert "overall: PASS" in markdown
+
+
+def test_run_oc_passes_timeout_to_subprocess(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = mod.run_oc("get", "--raw", "/healthz")
+
+    assert result == "ok"
+    assert captured["timeout"] == mod.OC_TIMEOUT_SECONDS

--- a/.github/scripts/tests/test_qg1_workflow_contract.py
+++ b/.github/scripts/tests/test_qg1_workflow_contract.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ACTION_PATH = REPO_ROOT / ".github" / "actions" / "run-qg1" / "action.yml"
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "qg1-cluster-readiness.yml"
+
+
+def _resolve_require_gpu(env_overrides: dict[str, str], tmp_path: Path) -> str:
+    """Execute the workflow's real "Resolve QG1 inputs" bash step in isolation.
+
+    Reads the run: script straight out of the workflow YAML so a future edit to
+    the require_gpu resolution logic is exercised by this test automatically.
+    """
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    resolve_step = next(
+        step for step in workflow["jobs"]["qg1"]["steps"] if step.get("id") == "resolve"
+    )
+
+    output_path = tmp_path / "github_output"
+    output_path.write_text("", encoding="utf-8")
+    env = os.environ.copy()
+    env.pop("DISPATCH_REQUIRE_GPU", None)
+    env.pop("VARS_REQUIRE_GPU", None)
+    env["GITHUB_OUTPUT"] = str(output_path)
+    env.update(env_overrides)
+
+    subprocess.run(
+        ["bash", "-c", resolve_step["run"]],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    outputs = dict(
+        line.split("=", 1)
+        for line in output_path.read_text(encoding="utf-8").splitlines()
+        if line
+    )
+    return outputs["require-gpu"]
+
+
+def test_run_qg1_action_exists():
+    assert ACTION_PATH.is_file()
+
+
+def test_run_qg1_action_declares_expected_inputs():
+    action = yaml.safe_load(ACTION_PATH.read_text(encoding="utf-8"))
+    assert action["name"] == "Run QG1 Cluster Readiness"
+    assert action["runs"]["using"] == "composite"
+    inputs = action["inputs"]
+    assert set(inputs) == {
+        "cluster-profile",
+        "require-gpu",
+        "required-namespaces",
+        "summary-json-path",
+        "summary-md-path",
+    }
+
+
+def test_run_qg1_action_invokes_checker_script():
+    action = yaml.safe_load(ACTION_PATH.read_text(encoding="utf-8"))
+    bash_steps = [
+        step for step in action["runs"]["steps"] if step.get("shell") == "bash"
+    ]
+    assert any(
+        ".github/scripts/qg1_cluster_readiness.py" in step.get("run", "")
+        for step in bash_steps
+    )
+    assert any("GITHUB_STEP_SUMMARY" in step.get("run", "") for step in bash_steps)
+
+
+def test_run_qg1_action_passes_inputs_via_env_not_inline_interpolation():
+    action = yaml.safe_load(ACTION_PATH.read_text(encoding="utf-8"))
+    bash_steps = [
+        step for step in action["runs"]["steps"] if step.get("shell") == "bash"
+    ]
+    assert bash_steps, "expected at least one bash step in run-qg1 action"
+    for step in bash_steps:
+        assert "${{ inputs." not in step.get("run", ""), (
+            f"step {step.get('name')!r} interpolates inputs directly in run: "
+            "body; pass via env: instead"
+        )
+
+
+def test_qg1_workflow_exists():
+    assert WORKFLOW_PATH.is_file()
+
+
+def test_qg1_workflow_uses_shared_setup_and_qg1_action():
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert workflow["name"] == "QG1: Cluster Readiness"
+    qg1_job = workflow["jobs"]["qg1"]
+    steps = qg1_job["steps"]
+    uses_values = [step.get("uses", "") for step in steps]
+    assert "./.github/actions/setup-cluster" in uses_values
+    assert "./.github/actions/run-qg1" in uses_values
+
+
+def test_run_qg1_step_consumes_resolved_require_gpu_output():
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    run_qg1_step = next(
+        step
+        for step in workflow["jobs"]["qg1"]["steps"]
+        if step.get("uses") == "./.github/actions/run-qg1"
+    )
+    assert (
+        run_qg1_step["with"]["require-gpu"]
+        == "${{ steps.resolve.outputs.require-gpu }}"
+    )
+
+
+def test_qg1_workflow_includes_dispatch_and_schedule():
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    triggers = workflow[True] if True in workflow else workflow["on"]
+    assert "workflow_dispatch" in triggers
+    assert "schedule" in triggers
+
+
+def test_resolve_require_gpu_uses_dispatch_input_on_manual_run(tmp_path):
+    require_gpu = _resolve_require_gpu(
+        {
+            "EVENT_NAME": "workflow_dispatch",
+            "DISPATCH_REQUIRE_GPU": "false",
+            "VARS_REQUIRE_GPU": "true",
+        },
+        tmp_path,
+    )
+    assert require_gpu == "false"
+
+
+def test_resolve_require_gpu_falls_back_to_repo_variable_on_schedule(tmp_path):
+    require_gpu = _resolve_require_gpu(
+        {
+            "EVENT_NAME": "schedule",
+            "VARS_REQUIRE_GPU": "false",
+        },
+        tmp_path,
+    )
+    assert require_gpu == "false"
+
+
+def test_resolve_require_gpu_defaults_to_true_when_repo_variable_unset(tmp_path):
+    require_gpu = _resolve_require_gpu({"EVENT_NAME": "schedule"}, tmp_path)
+    assert require_gpu == "true"

--- a/.github/workflows/ci-health-pages.yml
+++ b/.github/workflows/ci-health-pages.yml
@@ -13,6 +13,7 @@ on:
       - Code Quality
       - Agent Tests
       - Inner Loop Gating
+      - "QG1: Cluster Readiness"
       - "QG4: Agent Deployment Integration Tests"
     types: [completed]
   workflow_dispatch:

--- a/.github/workflows/qg1-cluster-readiness.yml
+++ b/.github/workflows/qg1-cluster-readiness.yml
@@ -1,0 +1,116 @@
+name: "QG1: Cluster Readiness"
+
+on:
+  schedule:
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+    inputs:
+      cluster_profile:
+        description: "Logical cluster profile name"
+        type: string
+        default: "rhoai2"
+      require_gpu:
+        description: "Whether GPU nodes are required"
+        type: boolean
+        default: true
+      required_namespaces:
+        description: "Comma-separated namespaces that must exist"
+        type: string
+        default: "ci-testing"
+
+permissions:
+  contents: read
+
+jobs:
+  qg1:
+    name: "QG1 Cluster Readiness"
+    if: github.repository == 'red-hat-data-services/agentic-starter-kits'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup cluster tools
+        uses: ./.github/actions/setup-cluster
+        with:
+          oc-token: ${{ secrets.OC_TOKEN }}
+          cluster-api-url: ${{ secrets.CLUSTER_API_URL }}
+
+      - name: Resolve QG1 inputs
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_REQUIRE_GPU: ${{ inputs.require_gpu }}
+          VARS_REQUIRE_GPU: ${{ vars.QG1_REQUIRE_GPU }}
+        run: |
+          set -euo pipefail
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            require_gpu="${DISPATCH_REQUIRE_GPU}"
+          else
+            require_gpu="${VARS_REQUIRE_GPU:-true}"
+          fi
+          echo "require-gpu=${require_gpu}" >> "${GITHUB_OUTPUT}"
+
+      - name: Run QG1
+        uses: ./.github/actions/run-qg1
+        with:
+          cluster-profile: ${{ inputs.cluster_profile || vars.QG1_CLUSTER_PROFILE || 'rhoai2' }}
+          require-gpu: ${{ steps.resolve.outputs.require-gpu }}
+          required-namespaces: ${{ inputs.required_namespaces || vars.QG1_REQUIRED_NAMESPACES || 'ci-testing' }}
+          summary-json-path: qg1-results/summary.json
+          summary-md-path: qg1-results/summary.md
+
+      - name: Upload QG1 results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: qg1-results
+          path: qg1-results/**
+          if-no-files-found: warn
+
+      - name: Logout
+        if: always()
+        run: oc logout || true
+
+  notify-slack:
+    name: Notify Slack
+    if: >-
+      !cancelled() &&
+      github.repository == 'red-hat-data-services/agentic-starter-kits' &&
+      (github.event_name != 'workflow_dispatch' || github.ref_name == 'main')
+    needs: [qg1]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Decide notification status
+        id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          NEEDS_JSON: ${{ toJson(needs) }}
+        run: |
+          bash .github/actions/notify-slack/should_notify.sh >> "${GITHUB_OUTPUT}"
+
+      - name: Send Slack notification
+        if: steps.gate.outputs.should_notify == 'true'
+        uses: ./.github/actions/notify-slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          github_token: ${{ github.token }}
+          workflow_name: ${{ github.workflow }}
+          event_name: ${{ github.event_name }}
+          ref_name: ${{ github.ref_name }}
+          run_id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          dashboard_url: https://red-hat-data-services.github.io/agentic-starter-kits/
+          status: ${{ steps.gate.outputs.status }}

--- a/docs/ci-alert-policy.md
+++ b/docs/ci-alert-policy.md
@@ -18,6 +18,7 @@ repository:
 - `Code Quality`
 - `Agent Tests`
 - `Inner Loop Gating`
+- `QG1: Cluster Readiness`
 - `QG4: Agent Deployment Integration Tests`
 
 The current implementation sends alerts only for shared-branch failures:
@@ -72,8 +73,8 @@ flowchart TD
   QG9 -->|"retry from QG4"| QG4
 ```
 
-Only `QG4` and `QG7` emit alerts today. The remaining fingerprints are defined
-here for future use as more of the QG ladder becomes alert-backed.
+Only `QG1`, `QG4`, and `QG7` emit alerts today. The remaining fingerprints are
+defined here for future use as more of the QG ladder becomes alert-backed.
 
 ### Canonical ladder
 
@@ -100,10 +101,13 @@ marks the remaining signals as non-canonical supporting alerts.
 | `Code Quality` | `code-quality.yml` | Non-canonical supporting signal | None yet | `push` on `main`, `workflow_dispatch` on `main` | Shared CI route / `@aaet-tooling-experience` |
 | `Agent Tests` | `agent-tests.yml` | Non-canonical supporting signal | None yet | `push` on `main`, `workflow_dispatch` on `main` | Shared CI route / `@aaet-tooling-experience` |
 | `Inner Loop Gating` | `eval-gating.yml` | Canonical | `QG7` | `push` on `main` when matching behavioral/eval paths change, `workflow_dispatch` on `main` | Shared CI route / `@aaet-tooling-experience` |
+| `QG1: Cluster Readiness` | `qg1-cluster-readiness.yml` | Canonical | `QG1` | `schedule`, `workflow_dispatch` on `main` | Shared CI route / `@aaet-tooling-experience` |
 | `QG4: Agent Deployment Integration Tests` | `agent-deployment-test.yaml` | Canonical | `QG4` | `schedule`, `workflow_dispatch` on `main` | Shared CI route / `@aaet-tooling-experience` |
 
 ### Interpretation rules
 
+- `QG1` alerts outrank `QG4` and `QG7` alerts because lower-numbered QGs carry
+  higher priority.
 - `QG4` alerts outrank `QG7` alerts because lower-numbered QGs carry higher
   priority.
 - `Code Quality` and `Agent Tests` are still operationally important, but they

--- a/docs/ci-alert-runbook.md
+++ b/docs/ci-alert-runbook.md
@@ -10,6 +10,7 @@ This runbook covers the shared-branch CI Slack alerts for
 | `Code Quality` | Non-canonical supporting signal | None yet | `push` on `main`, `workflow_dispatch` on `main` |
 | `Agent Tests` | Non-canonical supporting signal | None yet | `push` on `main`, `workflow_dispatch` on `main` |
 | `Inner Loop Gating` | Canonical | `QG7` | `push` on `main` when matching eval/behavioral paths change, `workflow_dispatch` on `main` |
+| `QG1: Cluster Readiness` | Canonical | `QG1` | `schedule`, `workflow_dispatch` on `main` |
 | `QG4: Agent Deployment Integration Tests` | Canonical | `QG4` | `schedule`, `workflow_dispatch` on `main` |
 
 ## Routing and Ownership
@@ -27,8 +28,10 @@ This runbook covers the shared-branch CI Slack alerts for
 
 ## Severity Interpretation
 
-- `QG4` is the highest current action priority because lower-numbered canonical
+- `QG1` is the highest current action priority because lower-numbered canonical
   QGs outrank higher-numbered ones.
+- `QG4` is the next current canonical priority and should be triaged after
+  `QG1` but ahead of `QG7` and supporting signals.
 - `QG7` is the next current canonical priority and should be triaged after
   `QG4` but ahead of supporting signals.
 - `Code Quality` and `Agent Tests` are supporting signals without canonical
@@ -73,7 +76,8 @@ should inspect the GitHub Actions run directly.
 
 | Severity bucket | Current signal mapping | Proposed acknowledgement window | Proposed triage target |
 | --- | --- | --- | --- |
-| Highest current priority | `QG4` | Within 1 business hour | Same business day |
+| Highest current priority | `QG1` | Within 1 business hour | Same business day |
+| Next current priority | `QG4` | Within 1 business hour | Same business day |
 | Next current priority | `QG7` | Within 4 business hours | Next business half-day |
 | Supporting signals | `Code Quality`, `Agent Tests` | By next business day | Next business day or convert to backlog follow-up if duplicate |
 

--- a/docs/ci-health-dashboard.md
+++ b/docs/ci-health-dashboard.md
@@ -11,6 +11,7 @@ The dashboard covers these workflows on `main` and scheduled or manual shared-br
 | `code-quality.yml` | Code Quality |
 | `agent-tests.yml` | Agent Tests |
 | `eval-gating.yml` | Inner Loop Gating |
+| `qg1-cluster-readiness.yml` | QG1: Cluster Readiness |
 | `agent-deployment-test.yaml` | QG4: Agent Deployment Integration Tests |
 
 Pull request runs are excluded from the summary to keep the page focused on shared-branch health.
@@ -36,11 +37,12 @@ Responder workflow, dedupe semantics, and validation guidance live in
 
 ## Slack alerts
 
-The same four workflows also send immediate Slack alerts when a shared-branch run fails:
+The same five workflows also send immediate Slack alerts when a shared-branch run fails:
 
 - `Code Quality`
 - `Agent Tests`
 - `Inner Loop Gating`
+- `QG1: Cluster Readiness`
 - `QG4: Agent Deployment Integration Tests`
 
 The event list below is the union of the supported notification triggers across those workflows. Individual workflows do not all define the same trigger set.


### PR DESCRIPTION
## Description

- Add a reusable `run-qg1` composite action and standalone `QG1: Cluster Readiness` workflow
- Keep cluster setup/login shared via `setup-cluster` while keeping QG1 focused on readiness assertions
- Register QG1 in the CI health dashboard and update CI alerting docs

## Jira Ticket

- https://redhat.atlassian.net/browse/RHAIENG-5866
- https://redhat.atlassian.net/browse/RHAIENG-5827

## Testing

- [x] `make test` passes (run from the affected agent directory)
- [x] Manual testing performed (describe steps below)
- [ ] No testing required (documentation/config change only)

Verification:
- `uv run pytest .github/scripts/tests -v` (`62 passed`)
- `ruff check .github/scripts/qg1_cluster_readiness.py .github/scripts/tests/test_qg1_cluster_readiness.py .github/scripts/tests/test_qg1_workflow_contract.py .github/scripts/generate_ci_health_page.py .github/scripts/tests/test_generate_ci_health_page.py`
- `ruff format --check .github/scripts/qg1_cluster_readiness.py .github/scripts/tests/test_qg1_cluster_readiness.py .github/scripts/tests/test_qg1_workflow_contract.py .github/scripts/generate_ci_health_page.py .github/scripts/tests/test_generate_ci_health_page.py`
- Python YAML parse sanity check for the new action/workflows

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)

## Review Guidance

- QG1 is intentionally a singleton pre-matrix gate, but the composite action inputs are parameterized for future cluster/profile matrixing.
- `setup-cluster` remains the shared login/bootstrap layer; `run-qg1` owns only readiness assertions.
- AIA message: Implemented with Cursor in an isolated worktree using a subagent-driven flow, with final acceptance review and verification before push.


AI-Attribution: AIA PAI Nc Hin R gpt-5.4 v1.0
AI-Interpretation: https://aiattribution.github.io/statements/AIA-PAI-Nc-Hin-R-?model=gpt-5.4