### PR TITLE
ci: extract QG4 deployment tests into composite action (RHAIENG-6540)

### DIFF
--- a/.github/actions/run-qg4/action.yml
+++ b/.github/actions/run-qg4/action.yml
@@ -1,5 +1,5 @@
 name: "Run QG4 Agent Deployment Test"
-description: "Deploy an agent to OpenShift, run its integration test suite, and upload results."
+description: "Run an agent's integration test suite and upload results. Caller handles checkout, setup-cluster, and logout."
 
 inputs:
   agent-name:
@@ -8,86 +8,13 @@ inputs:
   agent-dir:
     description: "Path to the agent directory (relative to repo root)"
     required: true
-  oc-token:
-    description: "OpenShift service account token"
-    required: true
-  cluster-api-url:
-    description: "OpenShift cluster API URL"
-    required: true
-  api-key:
-    description: "LLM API key"
-    required: false
-    default: ""
-  base-url:
-    description: "LLM base URL"
-    required: false
-    default: ""
-  model-id:
-    description: "LLM model ID"
-    required: false
-    default: ""
-  postgres-host:
-    description: "PostgreSQL host"
-    required: false
-    default: ""
-  postgres-port:
-    description: "PostgreSQL port"
-    required: false
-    default: ""
-  postgres-db:
-    description: "PostgreSQL database name"
-    required: false
-    default: ""
-  postgres-user:
-    description: "PostgreSQL user"
-    required: false
-    default: ""
-  postgres-password:
-    description: "PostgreSQL password"
-    required: false
-    default: ""
-  mcp-server-url:
-    description: "MCP server URL (autogen agent)"
-    required: false
-    default: ""
-  langflow-agent-url:
-    description: "Langflow agent URL"
-    required: false
-    default: ""
-  nvidia-api-key:
-    description: "NVIDIA API key (guardrails)"
-    required: false
-    default: ""
-  guardrails-model-id:
-    description: "Guardrails model ID"
-    required: false
-    default: ""
 
 runs:
   using: "composite"
   steps:
-    - name: Setup cluster tools
-      uses: ./.github/actions/setup-cluster
-      with:
-        oc-token: ${{ inputs.oc-token }}
-        cluster-api-url: ${{ inputs.cluster-api-url }}
-
     - name: Run integration test
       shell: bash
       working-directory: ${{ inputs.agent-dir }}
-      env:
-        API_KEY: ${{ inputs.api-key }}
-        BASE_URL: ${{ inputs.base-url }}
-        MODEL_ID: ${{ inputs.model-id }}
-        POSTGRES_HOST: ${{ inputs.postgres-host }}
-        POSTGRES_PORT: ${{ inputs.postgres-port }}
-        POSTGRES_DB: ${{ inputs.postgres-db }}
-        POSTGRES_USER: ${{ inputs.postgres-user }}
-        POSTGRES_PASSWORD: ${{ inputs.postgres-password }}
-        MCP_SERVER_URL: ${{ inputs.mcp-server-url }}
-        LANGFLOW_AGENT_URL: ${{ inputs.langflow-agent-url }}
-        NVIDIA_API_KEY: ${{ inputs.nvidia-api-key }}
-        GUARDRAILS_MODEL_ID: ${{ inputs.guardrails-model-id }}
       run: make test-integration
 
     - name: Upload test results
@@ -96,8 +23,4 @@ runs:
       with:
         name: ${{ inputs.agent-name }}-results
         path: ${{ inputs.agent-dir }}/results.xml
-
-    - name: Logout
-      if: always()
-      shell: bash
-      run: oc logout || true
+        if-no-files-found: warn

--- a/.github/actions/run-qg4/action.yml
+++ b/.github/actions/run-qg4/action.yml
@@ -1,0 +1,103 @@
+name: "Run QG4 Agent Deployment Test"
+description: "Deploy an agent to OpenShift, run its integration test suite, and upload results."
+
+inputs:
+  agent-name:
+    description: "Agent display name (used for artifact naming)"
+    required: true
+  agent-dir:
+    description: "Path to the agent directory (relative to repo root)"
+    required: true
+  oc-token:
+    description: "OpenShift service account token"
+    required: true
+  cluster-api-url:
+    description: "OpenShift cluster API URL"
+    required: true
+  api-key:
+    description: "LLM API key"
+    required: false
+    default: ""
+  base-url:
+    description: "LLM base URL"
+    required: false
+    default: ""
+  model-id:
+    description: "LLM model ID"
+    required: false
+    default: ""
+  postgres-host:
+    description: "PostgreSQL host"
+    required: false
+    default: ""
+  postgres-port:
+    description: "PostgreSQL port"
+    required: false
+    default: ""
+  postgres-db:
+    description: "PostgreSQL database name"
+    required: false
+    default: ""
+  postgres-user:
+    description: "PostgreSQL user"
+    required: false
+    default: ""
+  postgres-password:
+    description: "PostgreSQL password"
+    required: false
+    default: ""
+  mcp-server-url:
+    description: "MCP server URL (autogen agent)"
+    required: false
+    default: ""
+  langflow-agent-url:
+    description: "Langflow agent URL"
+    required: false
+    default: ""
+  nvidia-api-key:
+    description: "NVIDIA API key (guardrails)"
+    required: false
+    default: ""
+  guardrails-model-id:
+    description: "Guardrails model ID"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup cluster tools
+      uses: ./.github/actions/setup-cluster
+      with:
+        oc-token: ${{ inputs.oc-token }}
+        cluster-api-url: ${{ inputs.cluster-api-url }}
+
+    - name: Run integration test
+      shell: bash
+      working-directory: ${{ inputs.agent-dir }}
+      env:
+        API_KEY: ${{ inputs.api-key }}
+        BASE_URL: ${{ inputs.base-url }}
+        MODEL_ID: ${{ inputs.model-id }}
+        POSTGRES_HOST: ${{ inputs.postgres-host }}
+        POSTGRES_PORT: ${{ inputs.postgres-port }}
+        POSTGRES_DB: ${{ inputs.postgres-db }}
+        POSTGRES_USER: ${{ inputs.postgres-user }}
+        POSTGRES_PASSWORD: ${{ inputs.postgres-password }}
+        MCP_SERVER_URL: ${{ inputs.mcp-server-url }}
+        LANGFLOW_AGENT_URL: ${{ inputs.langflow-agent-url }}
+        NVIDIA_API_KEY: ${{ inputs.nvidia-api-key }}
+        GUARDRAILS_MODEL_ID: ${{ inputs.guardrails-model-id }}
+      run: make test-integration
+
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.agent-name }}-results
+        path: ${{ inputs.agent-dir }}/results.xml
+
+    - name: Logout
+      if: always()
+      shell: bash
+      run: oc logout || true

--- a/.github/actions/run-qg4/action.yml
+++ b/.github/actions/run-qg4/action.yml
@@ -1,10 +1,7 @@
 name: "Run QG4 Agent Deployment Test"
-description: "Run an agent's integration test suite and upload results. Caller handles checkout, setup-cluster, and logout."
+description: "Run an agent's integration test suite. Caller handles checkout, setup-cluster, artifact upload, and logout."
 
 inputs:
-  agent-name:
-    description: "Agent display name (used for artifact naming)"
-    required: true
   agent-dir:
     description: "Path to the agent directory (relative to repo root)"
     required: true
@@ -16,11 +13,3 @@ runs:
       shell: bash
       working-directory: ${{ inputs.agent-dir }}
       run: make test-integration
-
-    - name: Upload test results
-      if: always()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: ${{ inputs.agent-name }}-results
-        path: ${{ inputs.agent-dir }}/results.xml
-        if-no-files-found: warn

--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -91,26 +91,35 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Setup cluster tools
+        uses: ./.github/actions/setup-cluster
+        with:
+          oc-token: ${{ secrets.OC_TOKEN }}
+          cluster-api-url: ${{ secrets.CLUSTER_API_URL }}
+
       - name: Run QG4 deployment test
         if: matrix.agent.name != 'autogen-mcp-agent' || vars.MCP_SERVER_URL != ''
         uses: ./.github/actions/run-qg4
         with:
           agent-name: ${{ matrix.agent.name }}
           agent-dir: ${{ matrix.agent.dir }}
-          oc-token: ${{ secrets.OC_TOKEN }}
-          cluster-api-url: ${{ secrets.CLUSTER_API_URL }}
-          api-key: ${{ matrix.agent.name == 'vanilla-python-openai-responses-agent' && secrets.OPENAI_API_KEY || vars.API_KEY }}
-          base-url: ${{ matrix.BASE_URL || vars.BASE_URL }}
-          model-id: ${{ matrix.MODEL_ID || vars.MODEL_ID }}
-          postgres-host: ${{ matrix.POSTGRES_HOST }}
-          postgres-port: ${{ matrix.POSTGRES_PORT }}
-          postgres-db: ${{ matrix.POSTGRES_DB }}
-          postgres-user: ${{ matrix.POSTGRES_USER }}
-          postgres-password: ${{ secrets.POSTGRES_PASSWORD }}
-          mcp-server-url: ${{ matrix.MCP_SERVER_URL }}
-          langflow-agent-url: ${{ matrix.LANGFLOW_AGENT_URL }}
-          nvidia-api-key: ${{ secrets.NVIDIA_API_KEY }}
-          guardrails-model-id: ${{ matrix.GUARDRAILS_MODEL_ID }}
+        env:
+          API_KEY: ${{ matrix.agent.name == 'vanilla-python-openai-responses-agent' && secrets.OPENAI_API_KEY || vars.API_KEY }}
+          BASE_URL: ${{ matrix.BASE_URL || vars.BASE_URL }}
+          MODEL_ID: ${{ matrix.MODEL_ID || vars.MODEL_ID }}
+          POSTGRES_HOST: ${{ matrix.POSTGRES_HOST }}
+          POSTGRES_PORT: ${{ matrix.POSTGRES_PORT }}
+          POSTGRES_DB: ${{ matrix.POSTGRES_DB }}
+          POSTGRES_USER: ${{ matrix.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          MCP_SERVER_URL: ${{ matrix.MCP_SERVER_URL }}
+          LANGFLOW_AGENT_URL: ${{ matrix.LANGFLOW_AGENT_URL }}
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          GUARDRAILS_MODEL_ID: ${{ matrix.GUARDRAILS_MODEL_ID }}
+
+      - name: Logout
+        if: always()
+        run: oc logout || true
 
   notify-slack:
     name: Notify Slack

--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -101,7 +101,6 @@ jobs:
         if: matrix.agent.name != 'autogen-mcp-agent' || vars.MCP_SERVER_URL != ''
         uses: ./.github/actions/run-qg4
         with:
-          agent-name: ${{ matrix.agent.name }}
           agent-dir: ${{ matrix.agent.dir }}
         env:
           API_KEY: ${{ matrix.agent.name == 'vanilla-python-openai-responses-agent' && secrets.OPENAI_API_KEY || vars.API_KEY }}
@@ -116,6 +115,14 @@ jobs:
           LANGFLOW_AGENT_URL: ${{ matrix.LANGFLOW_AGENT_URL }}
           NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
           GUARDRAILS_MODEL_ID: ${{ matrix.GUARDRAILS_MODEL_ID }}
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.agent.name }}-results
+          path: ${{ matrix.agent.dir }}/results.xml
+          if-no-files-found: warn
 
       - name: Logout
         if: always()

--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -87,48 +87,30 @@ jobs:
             timeout_minutes: '45'
             MODEL_ID: qwen2-5-7b-instruct
             GUARDRAILS_MODEL_ID: qwen2-5-7b-instruct
-    env:
-      API_KEY: ${{ vars.API_KEY }}
-      BASE_URL: ${{ vars.BASE_URL }}
-      MODEL_ID: ${{ vars.MODEL_ID }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Setup cluster tools
-        uses: ./.github/actions/setup-cluster
+      - name: Run QG4 deployment test
+        if: matrix.agent.name != 'autogen-mcp-agent' || vars.MCP_SERVER_URL != ''
+        uses: ./.github/actions/run-qg4
         with:
+          agent-name: ${{ matrix.agent.name }}
+          agent-dir: ${{ matrix.agent.dir }}
           oc-token: ${{ secrets.OC_TOKEN }}
           cluster-api-url: ${{ secrets.CLUSTER_API_URL }}
-
-      - name: Run integration test
-        if: matrix.agent.name != 'autogen-mcp-agent' || vars.MCP_SERVER_URL != ''
-        working-directory: ${{ matrix.agent.dir }}
-        env:
-          API_KEY: ${{ matrix.agent.name == 'vanilla-python-openai-responses-agent' && secrets.OPENAI_API_KEY || vars.API_KEY }}
-          BASE_URL: ${{ matrix.BASE_URL || vars.BASE_URL }}
-          MODEL_ID: ${{ matrix.MODEL_ID || vars.MODEL_ID }}
-          POSTGRES_HOST: ${{ matrix.POSTGRES_HOST }}
-          POSTGRES_PORT: ${{ matrix.POSTGRES_PORT }}
-          POSTGRES_DB: ${{ matrix.POSTGRES_DB }}
-          POSTGRES_USER: ${{ matrix.POSTGRES_USER }}
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-          MCP_SERVER_URL: ${{ matrix.MCP_SERVER_URL }}
-          LANGFLOW_AGENT_URL: ${{ matrix.LANGFLOW_AGENT_URL }}
-          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
-          GUARDRAILS_MODEL_ID: ${{ matrix.GUARDRAILS_MODEL_ID }}
-        run: make test-integration
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ matrix.agent.name }}-results
-          path: ${{ matrix.agent.dir }}/results.xml
-
-      - name: Logout
-        if: always()
-        run: oc logout || true
+          api-key: ${{ matrix.agent.name == 'vanilla-python-openai-responses-agent' && secrets.OPENAI_API_KEY || vars.API_KEY }}
+          base-url: ${{ matrix.BASE_URL || vars.BASE_URL }}
+          model-id: ${{ matrix.MODEL_ID || vars.MODEL_ID }}
+          postgres-host: ${{ matrix.POSTGRES_HOST }}
+          postgres-port: ${{ matrix.POSTGRES_PORT }}
+          postgres-db: ${{ matrix.POSTGRES_DB }}
+          postgres-user: ${{ matrix.POSTGRES_USER }}
+          postgres-password: ${{ secrets.POSTGRES_PASSWORD }}
+          mcp-server-url: ${{ matrix.MCP_SERVER_URL }}
+          langflow-agent-url: ${{ matrix.LANGFLOW_AGENT_URL }}
+          nvidia-api-key: ${{ secrets.NVIDIA_API_KEY }}
+          guardrails-model-id: ${{ matrix.GUARDRAILS_MODEL_ID }}
 
   notify-slack:
     name: Notify Slack


### PR DESCRIPTION
## Description

Extracts the QG4 agent deployment health-check logic from `agent-deployment-test.yaml` into a reusable composite action at `.github/actions/run-qg4/action.yml`. This enables the orchestrator workflow to call QG4 as a step while preserving the standalone workflow for ad-hoc/debug runs.

The composite action follows the same convention as `run-qg1` and `run-qg7`: it contains only the gate logic (`make test-integration`). The caller handles checkout, setup-cluster, artifact upload, and logout — so an orchestrator can share a single cluster session across multiple gates and decide how/when to collect artifacts.

**Changes:**
- **New:** `.github/actions/run-qg4/action.yml` — composite action with one input (`agent-dir`). Env vars (API keys, DB config, etc.) are passed via step-level `env:` on the calling step, matching the `notify-slack` pattern — no pass-through input declarations needed.
- **Updated:** `.github/workflows/agent-deployment-test.yaml` — `test-agent` job now calls the composite action; matrix, triggers, `verify-cluster-connection`, and `notify-slack` jobs are untouched.

**Minor behavior change:** the `if` guard for autogen-mcp-agent (skip when `MCP_SERVER_URL` is unset) now covers the composite action step (test only), not just the inline test step. Previously, an unset `MCP_SERVER_URL` still ran cluster setup, artifact upload of a nonexistent `results.xml`, and logout; now setup-cluster and logout still run but the test and upload are skipped. This is an intentional improvement.

## Jira Ticket

RHAIENG-6540

## Testing

- [ ] `make test` passes (run from the affected agent directory)
- [x] Manual testing performed (describe steps below)
- [ ] No testing required (documentation/config change only)

Triggered `workflow_dispatch` runs on this branch against upstream:
- **Run 1 (initial):** https://github.com/red-hat-data-services/agentic-starter-kits/actions/runs/32169430475 — all 11 agents passed ✅
- **Run 2 (review fixes — slim action, step-level env):** https://github.com/red-hat-data-services/agentic-starter-kits/actions/runs/32179183012 — all 11 agents passed ✅
- **Run 3 (move upload to caller):** https://github.com/red-hat-data-services/agentic-starter-kits/actions/runs/32183358684 — 10/11 passed ✅, a2a-langgraph-crewai failed due to Docker Hub rate limit (`toomanyrequests` on `python:3.12-slim` pull) — unrelated to this PR

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)

## Review Guidance

- The composite action is run-only: just `make test-integration` with `working-directory`. Caller handles checkout, setup-cluster, upload-artifact, and logout — matching QG1/QG7 convention.
- Env vars use step-level `env:` instead of input declarations — adding a new env var is a one-line change in the caller
- `if-no-files-found: warn` on upload-artifact for consistency