### PR TITLE
fix(ci): assume dedicated QG1 service account for readiness checks

### DIFF
--- a/.github/actions/assume-qg1-service-account/action.yml
+++ b/.github/actions/assume-qg1-service-account/action.yml
@@ -1,0 +1,38 @@
+name: "Assume QG1 Service Account"
+description: "Mint a short-lived token for the QG1 readiness service account and re-login with that identity."
+
+inputs:
+  service-account:
+    description: "Service account to assume for cluster-readiness checks"
+    required: false
+    default: "qg1-readiness"
+  namespace:
+    description: "Namespace that owns the service account"
+    required: false
+    default: "ci-testing"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Mint token and login as dedicated QG1 service account
+      shell: bash
+      env:
+        SERVICE_ACCOUNT: ${{ inputs.service-account }}
+        NAMESPACE: ${{ inputs.namespace }}
+      run: |
+        set -euo pipefail
+
+        server="$(oc whoami --show-server)"
+        qg1_token="$(oc create token "${SERVICE_ACCOUNT}" -n "${NAMESPACE}" --duration=20m)"
+
+        oc login \
+          --token="${qg1_token}" \
+          --server="${server}" \
+          --namespace="${NAMESPACE}" >/dev/null
+
+        expected_identity="system:serviceaccount:${NAMESPACE}:${SERVICE_ACCOUNT}"
+        actual_identity="$(oc whoami)"
+        if [[ "${actual_identity}" != "${expected_identity}" ]]; then
+          echo "Expected ${expected_identity}, got ${actual_identity}" >&2
+          exit 1
+        fi

--- a/.github/actions/assume-service-account/action.yml
+++ b/.github/actions/assume-service-account/action.yml
@@ -1,9 +1,9 @@
-name: "Assume QG1 Service Account"
-description: "Mint a short-lived token for the QG1 readiness service account and re-login with that identity."
+name: "Assume Service Account"
+description: "Mint a short-lived token for a service account and re-login with that identity."
 
 inputs:
   service-account:
-    description: "Service account to assume for cluster-readiness checks"
+    description: "Service account to assume; defaults to the qg1-readiness convention used by QG1"
     required: false
     default: "qg1-readiness"
   namespace:
@@ -14,7 +14,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Mint token and login as dedicated QG1 service account
+    - name: Mint token and login as service account
       shell: bash
       env:
         SERVICE_ACCOUNT: ${{ inputs.service-account }}
@@ -24,6 +24,7 @@ runs:
 
         server="$(oc whoami --show-server)"
         qg1_token="$(oc create token "${SERVICE_ACCOUNT}" -n "${NAMESPACE}" --duration=20m)"
+        echo "::add-mask::${qg1_token}"
 
         oc login \
           --token="${qg1_token}" \

--- a/.github/cluster/qg1-readiness-rbac.yaml
+++ b/.github/cluster/qg1-readiness-rbac.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: qg1-readiness
+  namespace: ci-testing
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: qg1-readiness-reader
+rules:
+  - apiGroups: ["config.openshift.io"]
+    resources: ["clusterversions"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: qg1-readiness-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: qg1-readiness-reader
+subjects:
+  - kind: ServiceAccount
+    name: qg1-readiness
+    namespace: ci-testing

--- a/.github/cluster/qg1-readiness-rbac.yaml
+++ b/.github/cluster/qg1-readiness-rbac.yaml
@@ -11,13 +11,13 @@ metadata:
 rules:
   - apiGroups: ["config.openshift.io"]
     resources: ["clusterversions"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["namespaces"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/.github/scripts/tests/test_qg1_workflow_contract.py
+++ b/.github/scripts/tests/test_qg1_workflow_contract.py
@@ -8,7 +8,11 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 ACTION_PATH = REPO_ROOT / ".github" / "actions" / "run-qg1" / "action.yml"
+ASSUME_ACTION_PATH = (
+    REPO_ROOT / ".github" / "actions" / "assume-qg1-service-account" / "action.yml"
+)
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "qg1-cluster-readiness.yml"
+RBAC_MANIFEST_PATH = REPO_ROOT / ".github" / "cluster" / "qg1-readiness-rbac.yaml"
 
 
 def _resolve_require_gpu(env_overrides: dict[str, str], tmp_path: Path) -> str:
@@ -50,6 +54,10 @@ def test_run_qg1_action_exists():
     assert ACTION_PATH.is_file()
 
 
+def test_assume_qg1_service_account_action_exists():
+    assert ASSUME_ACTION_PATH.is_file()
+
+
 def test_run_qg1_action_declares_expected_inputs():
     action = yaml.safe_load(ACTION_PATH.read_text(encoding="utf-8"))
     assert action["name"] == "Run QG1 Cluster Readiness"
@@ -64,6 +72,16 @@ def test_run_qg1_action_declares_expected_inputs():
     }
 
 
+def test_assume_qg1_service_account_action_declares_expected_inputs():
+    action = yaml.safe_load(ASSUME_ACTION_PATH.read_text(encoding="utf-8"))
+    assert action["name"] == "Assume QG1 Service Account"
+    assert action["runs"]["using"] == "composite"
+    inputs = action["inputs"]
+    assert set(inputs) == {"service-account", "namespace"}
+    assert inputs["service-account"]["default"] == "qg1-readiness"
+    assert inputs["namespace"]["default"] == "ci-testing"
+
+
 def test_run_qg1_action_invokes_checker_script():
     action = yaml.safe_load(ACTION_PATH.read_text(encoding="utf-8"))
     bash_steps = [
@@ -74,6 +92,16 @@ def test_run_qg1_action_invokes_checker_script():
         for step in bash_steps
     )
     assert any("GITHUB_STEP_SUMMARY" in step.get("run", "") for step in bash_steps)
+
+
+def test_assume_qg1_service_account_action_mints_token_and_relogs():
+    action = yaml.safe_load(ASSUME_ACTION_PATH.read_text(encoding="utf-8"))
+    bash_steps = [
+        step for step in action["runs"]["steps"] if step.get("shell") == "bash"
+    ]
+    assert any("oc create token" in step.get("run", "") for step in bash_steps)
+    assert any("oc whoami --show-server" in step.get("run", "") for step in bash_steps)
+    assert any("oc login" in step.get("run", "") for step in bash_steps)
 
 
 def test_run_qg1_action_passes_inputs_via_env_not_inline_interpolation():
@@ -100,7 +128,19 @@ def test_qg1_workflow_uses_shared_setup_and_qg1_action():
     steps = qg1_job["steps"]
     uses_values = [step.get("uses", "") for step in steps]
     assert "./.github/actions/setup-cluster" in uses_values
+    assert "./.github/actions/assume-qg1-service-account" in uses_values
     assert "./.github/actions/run-qg1" in uses_values
+
+
+def test_qg1_workflow_assumes_dedicated_service_account_before_checker():
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    uses_values = [
+        step.get("uses", "") for step in workflow["jobs"]["qg1"]["steps"] if "uses" in step
+    ]
+    setup_idx = uses_values.index("./.github/actions/setup-cluster")
+    assume_idx = uses_values.index("./.github/actions/assume-qg1-service-account")
+    run_idx = uses_values.index("./.github/actions/run-qg1")
+    assert setup_idx < assume_idx < run_idx
 
 
 def test_run_qg1_step_consumes_resolved_require_gpu_output():
@@ -121,6 +161,49 @@ def test_qg1_workflow_includes_dispatch_and_schedule():
     triggers = workflow[True] if True in workflow else workflow["on"]
     assert "workflow_dispatch" in triggers
     assert "schedule" in triggers
+
+
+def test_qg1_rbac_manifest_exists():
+    assert RBAC_MANIFEST_PATH.is_file()
+
+
+def test_qg1_rbac_manifest_declares_minimal_read_only_resources():
+    docs = list(yaml.safe_load_all(RBAC_MANIFEST_PATH.read_text(encoding="utf-8")))
+    service_account = next(doc for doc in docs if doc["kind"] == "ServiceAccount")
+    cluster_role = next(doc for doc in docs if doc["kind"] == "ClusterRole")
+    cluster_role_binding = next(
+        doc for doc in docs if doc["kind"] == "ClusterRoleBinding"
+    )
+
+    assert service_account["metadata"] == {
+        "name": "qg1-readiness",
+        "namespace": "ci-testing",
+    }
+    assert cluster_role["metadata"]["name"] == "qg1-readiness-reader"
+    assert cluster_role_binding["roleRef"] == {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "qg1-readiness-reader",
+    }
+    assert cluster_role_binding["subjects"] == [
+        {
+            "kind": "ServiceAccount",
+            "name": "qg1-readiness",
+            "namespace": "ci-testing",
+        }
+    ]
+
+    rule_map = {
+        (tuple(rule["apiGroups"]), tuple(rule["resources"])): set(rule["verbs"])
+        for rule in cluster_role["rules"]
+    }
+    assert rule_map[(("config.openshift.io",), ("clusterversions",))] == {
+        "get",
+        "list",
+        "watch",
+    }
+    assert rule_map[(("",), ("nodes",))] == {"get", "list", "watch"}
+    assert rule_map[(("",), ("namespaces",))] == {"get", "list", "watch"}
 
 
 def test_resolve_require_gpu_uses_dispatch_input_on_manual_run(tmp_path):

--- a/.github/scripts/tests/test_qg1_workflow_contract.py
+++ b/.github/scripts/tests/test_qg1_workflow_contract.py
@@ -9,7 +9,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[3]
 ACTION_PATH = REPO_ROOT / ".github" / "actions" / "run-qg1" / "action.yml"
 ASSUME_ACTION_PATH = (
-    REPO_ROOT / ".github" / "actions" / "assume-qg1-service-account" / "action.yml"
+    REPO_ROOT / ".github" / "actions" / "assume-service-account" / "action.yml"
 )
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "qg1-cluster-readiness.yml"
 RBAC_MANIFEST_PATH = REPO_ROOT / ".github" / "cluster" / "qg1-readiness-rbac.yaml"
@@ -74,7 +74,7 @@ def test_run_qg1_action_declares_expected_inputs():
 
 def test_assume_qg1_service_account_action_declares_expected_inputs():
     action = yaml.safe_load(ASSUME_ACTION_PATH.read_text(encoding="utf-8"))
-    assert action["name"] == "Assume QG1 Service Account"
+    assert action["name"] == "Assume Service Account"
     assert action["runs"]["using"] == "composite"
     inputs = action["inputs"]
     assert set(inputs) == {"service-account", "namespace"}
@@ -100,8 +100,14 @@ def test_assume_qg1_service_account_action_mints_token_and_relogs():
         step for step in action["runs"]["steps"] if step.get("shell") == "bash"
     ]
     assert any("oc create token" in step.get("run", "") for step in bash_steps)
+    assert any("--duration=20m" in step.get("run", "") for step in bash_steps)
     assert any("oc whoami --show-server" in step.get("run", "") for step in bash_steps)
     assert any("oc login" in step.get("run", "") for step in bash_steps)
+    assert any(
+        "expected_identity=" in step.get("run", "")
+        and "actual_identity=" in step.get("run", "")
+        for step in bash_steps
+    )
 
 
 def test_run_qg1_action_passes_inputs_via_env_not_inline_interpolation():
@@ -128,7 +134,7 @@ def test_qg1_workflow_uses_shared_setup_and_qg1_action():
     steps = qg1_job["steps"]
     uses_values = [step.get("uses", "") for step in steps]
     assert "./.github/actions/setup-cluster" in uses_values
-    assert "./.github/actions/assume-qg1-service-account" in uses_values
+    assert "./.github/actions/assume-service-account" in uses_values
     assert "./.github/actions/run-qg1" in uses_values
 
 
@@ -140,7 +146,7 @@ def test_qg1_workflow_assumes_dedicated_service_account_before_checker():
         if "uses" in step
     ]
     setup_idx = uses_values.index("./.github/actions/setup-cluster")
-    assume_idx = uses_values.index("./.github/actions/assume-qg1-service-account")
+    assume_idx = uses_values.index("./.github/actions/assume-service-account")
     run_idx = uses_values.index("./.github/actions/run-qg1")
     assert setup_idx < assume_idx < run_idx
 
@@ -199,13 +205,13 @@ def test_qg1_rbac_manifest_declares_minimal_read_only_resources():
         (tuple(rule["apiGroups"]), tuple(rule["resources"])): set(rule["verbs"])
         for rule in cluster_role["rules"]
     }
+    assert len(rule_map) == 3
     assert rule_map[(("config.openshift.io",), ("clusterversions",))] == {
         "get",
         "list",
-        "watch",
     }
-    assert rule_map[(("",), ("nodes",))] == {"get", "list", "watch"}
-    assert rule_map[(("",), ("namespaces",))] == {"get", "list", "watch"}
+    assert rule_map[(("",), ("nodes",))] == {"get", "list"}
+    assert rule_map[(("",), ("namespaces",))] == {"get", "list"}
 
 
 def test_resolve_require_gpu_uses_dispatch_input_on_manual_run(tmp_path):

--- a/.github/scripts/tests/test_qg1_workflow_contract.py
+++ b/.github/scripts/tests/test_qg1_workflow_contract.py
@@ -135,7 +135,9 @@ def test_qg1_workflow_uses_shared_setup_and_qg1_action():
 def test_qg1_workflow_assumes_dedicated_service_account_before_checker():
     workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
     uses_values = [
-        step.get("uses", "") for step in workflow["jobs"]["qg1"]["steps"] if "uses" in step
+        step.get("uses", "")
+        for step in workflow["jobs"]["qg1"]["steps"]
+        if "uses" in step
     ]
     setup_idx = uses_values.index("./.github/actions/setup-cluster")
     assume_idx = uses_values.index("./.github/actions/assume-qg1-service-account")

--- a/.github/workflows/qg1-cluster-readiness.yml
+++ b/.github/workflows/qg1-cluster-readiness.yml
@@ -37,6 +37,12 @@ jobs:
           oc-token: ${{ secrets.OC_TOKEN }}
           cluster-api-url: ${{ secrets.CLUSTER_API_URL }}
 
+      # Bootstrap with the shared ci-testing service account, then mint a
+      # short-lived token for the dedicated QG1 identity before cluster-scope
+      # readiness checks run.
+      - name: Assume dedicated QG1 service account
+        uses: ./.github/actions/assume-qg1-service-account
+
       - name: Resolve QG1 inputs
         id: resolve
         env:

--- a/.github/workflows/qg1-cluster-readiness.yml
+++ b/.github/workflows/qg1-cluster-readiness.yml
@@ -41,7 +41,7 @@ jobs:
       # short-lived token for the dedicated QG1 identity before cluster-scope
       # readiness checks run.
       - name: Assume dedicated QG1 service account
-        uses: ./.github/actions/assume-qg1-service-account
+        uses: ./.github/actions/assume-service-account
 
       - name: Resolve QG1 inputs
         id: resolve


### PR DESCRIPTION
## Description
  This PR fixes the immediate `QG1: Cluster Readiness` RBAC failure by keeping the existing shared `OC_TOKEN` only as a bootstrap identity, then minting a short-lived token for a dedicated `qg1-readiness` service account before the checker runs.
  It adds:
  - a dedicated QG1 assume-action in `.github/actions/assume-qg1-service-account/action.yml`
  - a minimal read-only cluster RBAC manifest in `.github/cluster/qg1-readiness-rbac.yaml`
  - workflow wiring in `.github/workflows/qg1-cluster-readiness.yml`
  - contract tests to lock in the new workflow/action/RBAC behavior
  This is the short-term working fix. The longer-term identity model is tracked separately in `RHAIENG-6993`, which covers replacing secret/bootstrap-based auth with a GitHub OIDC-based short-lived credential flow.
  ## Jira Ticket
  [RHAIENG-6993](https://redhat.atlassian.net/browse/RHAIENG-6993)
  ## Testing
  - [ ] `make test` passes (run from the affected agent directory)
  - [x] Manual testing performed (describe steps below)
  - [ ] No testing required (documentation/config change only)
  Additional verification performed:
  - `uv run pytest .github/scripts/tests/test_qg1_workflow_contract.py .github/scripts/tests/test_qg1_cluster_readiness.py -q`
  - Applied `.github/cluster/qg1-readiness-rbac.yaml` to the cluster
  - Verified effective permissions for `system:serviceaccount:ci-testing:qg1-readiness`:
    - can list `clusterversions.config.openshift.io`
    - can list `nodes`
    - can list `namespaces`
  - Verified `system:serviceaccount:ci-testing:github-actions` can mint `serviceaccounts/token` in `ci-testing`
  - Ran the QG1 checker end to end with a freshly minted short-lived `qg1-readiness` token:
    - `api_health: PASS`
    - `cluster_version: PASS`
    - `gpu_nodes: PASS`
    - `required_namespaces: PASS`
  ## Checklist
  - [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
  - [x] No `.env` or secret files are included in this PR
  - [ ] All changes are within scope of the linked Jira ticket (if not, explain in Description)
  ## Review Guidance
  Please review these together as one contract:
  - `.github/workflows/qg1-cluster-readiness.yml`
  - `.github/actions/assume-qg1-service-account/action.yml`
  - `.github/cluster/qg1-readiness-rbac.yaml`
  - `.github/scripts/tests/test_qg1_workflow_contract.py`
  Key design choice:
  - This PR intentionally keeps the short-term model on a bootstrap login plus a short-lived dedicated QG1 token.
  - It does **not** attempt to solve the longer-term GitHub OIDC identity model in this branch; that plan is tracked in `RHAIENG-6993`.
  ## Related PRs
  None.


[RHAIENG-6993]: https://redhat.atlassian.net/browse/RHAIENG-6993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ