### PR TITLE
fix(ci): assume dedicated QG2 service account for readiness checks

### DIFF
--- a/.github/cluster/qg2-readiness-rbac.yaml
+++ b/.github/cluster/qg2-readiness-rbac.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: qg2-readiness
+  namespace: ci-testing
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: qg2-readiness-reader
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list"]
+  - apiGroups: ["operators.coreos.com"]
+    resources: ["clusterserviceversions"]
+    verbs: ["get", "list"]
+  - apiGroups: ["datasciencecluster.opendatahub.io"]
+    resources: ["datascienceclusters"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: qg2-readiness-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: qg2-readiness-reader
+subjects:
+  - kind: ServiceAccount
+    name: qg2-readiness
+    namespace: ci-testing

--- a/.github/scripts/tests/test_qg2_workflow_contract.py
+++ b/.github/scripts/tests/test_qg2_workflow_contract.py
@@ -8,7 +8,11 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 ACTION_PATH = REPO_ROOT / ".github" / "actions" / "run-qg2" / "action.yml"
+ASSUME_ACTION_PATH = (
+    REPO_ROOT / ".github" / "actions" / "assume-service-account" / "action.yml"
+)
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "qg2-platform-readiness.yml"
+RBAC_MANIFEST_PATH = REPO_ROOT / ".github" / "cluster" / "qg2-readiness-rbac.yaml"
 
 
 def _resolve_qg2_inputs(
@@ -54,6 +58,10 @@ def test_run_qg2_action_exists():
     assert ACTION_PATH.is_file()
 
 
+def test_assume_qg2_service_account_action_exists():
+    assert ASSUME_ACTION_PATH.is_file()
+
+
 def test_run_qg2_action_declares_expected_inputs():
     action = yaml.safe_load(ACTION_PATH.read_text(encoding="utf-8"))
     assert action["name"] == "Run QG2 Platform Readiness"
@@ -68,6 +76,16 @@ def test_run_qg2_action_declares_expected_inputs():
     }
 
 
+def test_assume_qg2_service_account_action_declares_expected_inputs():
+    action = yaml.safe_load(ASSUME_ACTION_PATH.read_text(encoding="utf-8"))
+    assert action["name"] == "Assume Service Account"
+    assert action["runs"]["using"] == "composite"
+    inputs = action["inputs"]
+    assert set(inputs) == {"service-account", "namespace"}
+    assert inputs["service-account"]["default"] == "qg1-readiness"
+    assert inputs["namespace"]["default"] == "ci-testing"
+
+
 def test_run_qg2_action_invokes_checker_script():
     action = yaml.safe_load(ACTION_PATH.read_text(encoding="utf-8"))
     bash_steps = [
@@ -78,6 +96,22 @@ def test_run_qg2_action_invokes_checker_script():
         for step in bash_steps
     )
     assert any("GITHUB_STEP_SUMMARY" in step.get("run", "") for step in bash_steps)
+
+
+def test_assume_qg2_service_account_action_mints_token_and_relogs():
+    action = yaml.safe_load(ASSUME_ACTION_PATH.read_text(encoding="utf-8"))
+    bash_steps = [
+        step for step in action["runs"]["steps"] if step.get("shell") == "bash"
+    ]
+    assert any("oc create token" in step.get("run", "") for step in bash_steps)
+    assert any("--duration=20m" in step.get("run", "") for step in bash_steps)
+    assert any("oc whoami --show-server" in step.get("run", "") for step in bash_steps)
+    assert any("oc login" in step.get("run", "") for step in bash_steps)
+    assert any(
+        "expected_identity=" in step.get("run", "")
+        and "actual_identity=" in step.get("run", "")
+        for step in bash_steps
+    )
 
 
 def test_run_qg2_action_passes_inputs_via_env_not_inline_interpolation():
@@ -104,10 +138,34 @@ def test_qg2_workflow_uses_shared_setup_and_qg2_action():
     steps = qg2_job["steps"]
     uses_values = [step.get("uses", "") for step in steps]
     assert "./.github/actions/setup-cluster" in uses_values
+    assert "./.github/actions/assume-service-account" in uses_values
     assert "./.github/actions/run-qg2" in uses_values
     setup_idx = uses_values.index("./.github/actions/setup-cluster")
     run_idx = uses_values.index("./.github/actions/run-qg2")
     assert setup_idx < run_idx
+
+
+def test_qg2_workflow_assumes_dedicated_service_account_before_checker():
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    uses_values = [
+        step.get("uses", "")
+        for step in workflow["jobs"]["qg2"]["steps"]
+        if "uses" in step
+    ]
+    setup_idx = uses_values.index("./.github/actions/setup-cluster")
+    assume_idx = uses_values.index("./.github/actions/assume-service-account")
+    run_idx = uses_values.index("./.github/actions/run-qg2")
+    assert setup_idx < assume_idx < run_idx
+
+
+def test_qg2_workflow_assumes_qg2_readiness_service_account():
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assume_step = next(
+        step
+        for step in workflow["jobs"]["qg2"]["steps"]
+        if step.get("uses") == "./.github/actions/assume-service-account"
+    )
+    assert assume_step["with"]["service-account"] == "qg2-readiness"
 
 
 def test_run_qg2_step_consumes_resolved_require_dsc_ready_output():
@@ -141,6 +199,51 @@ def test_qg2_workflow_includes_dispatch_and_schedule():
     triggers = workflow[True] if True in workflow else workflow["on"]
     assert "workflow_dispatch" in triggers
     assert "schedule" in triggers
+
+
+def test_qg2_rbac_manifest_exists():
+    assert RBAC_MANIFEST_PATH.is_file()
+
+
+def test_qg2_rbac_manifest_declares_minimal_read_only_resources():
+    docs = list(yaml.safe_load_all(RBAC_MANIFEST_PATH.read_text(encoding="utf-8")))
+    service_account = next(doc for doc in docs if doc["kind"] == "ServiceAccount")
+    cluster_role = next(doc for doc in docs if doc["kind"] == "ClusterRole")
+    cluster_role_binding = next(
+        doc for doc in docs if doc["kind"] == "ClusterRoleBinding"
+    )
+
+    assert service_account["metadata"] == {
+        "name": "qg2-readiness",
+        "namespace": "ci-testing",
+    }
+    assert cluster_role["metadata"]["name"] == "qg2-readiness-reader"
+    assert cluster_role_binding["roleRef"] == {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "qg2-readiness-reader",
+    }
+    assert cluster_role_binding["subjects"] == [
+        {
+            "kind": "ServiceAccount",
+            "name": "qg2-readiness",
+            "namespace": "ci-testing",
+        }
+    ]
+
+    rule_map = {
+        (tuple(rule["apiGroups"]), tuple(rule["resources"])): set(rule["verbs"])
+        for rule in cluster_role["rules"]
+    }
+    assert len(rule_map) == 3
+    assert rule_map[(("apps",), ("deployments",))] == {"get", "list"}
+    assert rule_map[(("operators.coreos.com",), ("clusterserviceversions",))] == {
+        "get",
+        "list",
+    }
+    assert rule_map[
+        (("datasciencecluster.opendatahub.io",), ("datascienceclusters",))
+    ] == {"get", "list"}
 
 
 def test_resolve_qg2_inputs_uses_dispatch_inputs_on_manual_run(tmp_path):

--- a/.github/workflows/qg2-platform-readiness.yml
+++ b/.github/workflows/qg2-platform-readiness.yml
@@ -42,6 +42,14 @@ jobs:
           oc-token: ${{ secrets.OC_TOKEN }}
           cluster-api-url: ${{ secrets.CLUSTER_API_URL }}
 
+      # Bootstrap with the shared ci-testing service account, then mint a
+      # short-lived token for the dedicated QG2 identity before platform
+      # readiness checks run.
+      - name: Assume dedicated QG2 service account
+        uses: ./.github/actions/assume-service-account
+        with:
+          service-account: qg2-readiness
+
       - name: Resolve QG2 inputs
         id: resolve
         env:

--- a/docs/ci-alert-runbook.md
+++ b/docs/ci-alert-runbook.md
@@ -23,14 +23,18 @@ This runbook covers the shared-branch CI Slack alerts for
 ## QG2 Cluster Access Requirements
 
 `QG2: Platform Readiness` authenticates via the `OC_TOKEN` secret through
-`.github/actions/setup-cluster`, then queries live cluster resources with
-`oc`. That service account needs cluster-wide (not just namespace-scoped)
-read access to `deployments`, `clusterserviceversions` (`csv`), and
-`datasciencecluster` — QG2 lists `datasciencecluster` and the
-KServe-labeled `deployment` cluster-wide (`-A`) to distinguish a genuinely
-absent resource from an RBAC error, so a token scoped to a single namespace
-will misreport as `oc_command`/`Forbidden` failures instead of clean
+`.github/actions/setup-cluster` only as a bootstrap identity, then mints a
+short-lived token for the dedicated `qg2-readiness` service account in
+`ci-testing` before the checker runs. That dedicated identity needs
+cluster-wide (not just namespace-scoped) read access to `deployments`,
+`clusterserviceversions` (`csv`), and `datasciencecluster` — QG2 lists
+`datasciencecluster` and the KServe-labeled `deployment` cluster-wide
+(`-A`) to distinguish a genuinely absent resource from an RBAC error, so a
+token scoped to a single namespace will misreport as `oc_command`/`Forbidden`
+failures instead of clean
 `operator_health`/`kserve_controller`/`datasciencecluster_ready` results.
+The bootstrap `github-actions` service account only needs permission to
+mint `serviceaccounts/token` in `ci-testing`.
 
 ## Dedupe and Timing Semantics
 


### PR DESCRIPTION
## Description
This PR fixes the immediate `QG2: Platform Readiness` RBAC failure by keeping the existing shared `OC_TOKEN` only as a bootstrap identity, then minting a short-lived token for a dedicated `qg2-readiness` service account before the checker runs.

It adds:
- a minimal read-only cluster RBAC manifest in `.github/cluster/qg2-readiness-rbac.yaml`
- workflow wiring in `.github/workflows/qg2-platform-readiness.yml` that reuses `.github/actions/assume-service-account` with `service-account: qg2-readiness`
- contract tests to lock in the new workflow/RBAC behavior
- runbook updates so QG2 cluster access matches the dedicated-SA model

This is the short-term working fix, mirroring [#319](https://github.com/red-hat-data-services/agentic-starter-kits/pull/319). The longer-term identity model is tracked separately in `RHAIENG-6993`, which covers replacing secret/bootstrap-based auth with a GitHub OIDC-based short-lived credential flow.

The original failing run ([32243152519](https://github.com/red-hat-data-services/agentic-starter-kits/actions/runs/32243152519)) was:

`User "system:serviceaccount:ci-testing:github-actions" cannot get resource "deployments" in API group "apps" in the namespace "redhat-ods-operator"`

## Jira Ticket
[RHAIENG-5866](https://redhat.atlassian.net/browse/RHAIENG-5866)

## Testing
- [ ] `make test` passes (run from the affected agent directory)
- [x] Manual testing performed (describe steps below)
- [ ] No testing required (documentation/config change only)

Additional verification performed:
- `uv run pytest .github/scripts/tests/test_qg2_workflow_contract.py .github/scripts/tests/test_qg2_platform_readiness.py -q` (`57 passed`)
- Applied `.github/cluster/qg2-readiness-rbac.yaml` to the cluster
- Verified effective permissions for `system:serviceaccount:ci-testing:qg2-readiness`:
  - can list `deployments.apps`
  - can list `clusterserviceversions.operators.coreos.com`
  - can list `datascienceclusters.datasciencecluster.opendatahub.io`
- Verified `system:serviceaccount:ci-testing:github-actions` can mint `serviceaccounts/token` in `ci-testing`
- Ran the QG2 checker end to end with a freshly minted short-lived `qg2-readiness` token:
  - `operator_health: PASS` — Operator deployment ready replicas: 3/3 (`redhat-ods-operator`)
  - `kserve_controller: PASS` — KServe controller deployment ready replicas: 1/1
  - `datasciencecluster_ready: FAIL` — DataScienceCluster phase: `Not Ready` (`ogx` degraded). This is remaining platform state, not the original Forbidden RBAC failure.

## Checklist
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [ ] All changes are within scope of the linked Jira ticket (if not, explain in Description)

## Review Guidance
Please review these together as one contract:
- `.github/workflows/qg2-platform-readiness.yml`
- `.github/cluster/qg2-readiness-rbac.yaml`
- `.github/scripts/tests/test_qg2_workflow_contract.py`

Key design choice:
- This PR reuses the shared assume-action from #319 and passes `service-account: qg2-readiness` because that action still defaults to `qg1-readiness`.
- It does **not** attempt to solve the longer-term GitHub OIDC identity model in this branch; that plan is tracked in `RHAIENG-6993`.
- It does **not** change DataScienceCluster readiness criteria. After RBAC is fixed, QG2 still reports `datasciencecluster_ready` failure while `default-dsc` is `Not Ready`.

## Related PRs
#319


AI-Attribution: AIA PAI Nc Hin R grok-4.6 v1.0
AI-Interpretation: https://aiattribution.github.io/statements/AIA-PAI-Nc-Hin-R-?model=grok-4.6

[RHAIENG-5866]: https://redhat.atlassian.net/browse/RHAIENG-5866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ