### PR TITLE
fix(guardrailed): keep playground SSE working with NeMo passthrough tools

### DIFF
--- a/agents/langgraph/examples/guardrailed_agent/.gitignore
+++ b/agents/langgraph/examples/guardrailed_agent/.gitignore
@@ -5,10 +5,8 @@
 # from .env values — may contain API_KEY, never commit.
 guardrails/config/*/config.yaml
 
-# Cluster deploy — generated / local secrets (keep the .example template)
+# Cluster deploy — generated / local secrets
 deploy/overlays/ci-testing/cluster.env
-deploy/overlays/ci-testing/cluster.env.*
-!deploy/overlays/ci-testing/cluster.env.example
 deploy/manifests/02-guardrails-configmap.yaml
 
 # Tracing — filled-in production object-storage credentials (template is committed)

--- a/agents/langgraph/examples/guardrailed_agent/.gitignore
+++ b/agents/langgraph/examples/guardrailed_agent/.gitignore
@@ -5,8 +5,10 @@
 # from .env values — may contain API_KEY, never commit.
 guardrails/config/*/config.yaml
 
-# Cluster deploy — generated / local secrets
+# Cluster deploy — generated / local secrets (keep the .example template)
 deploy/overlays/ci-testing/cluster.env
+deploy/overlays/ci-testing/cluster.env.*
+!deploy/overlays/ci-testing/cluster.env.example
 deploy/manifests/02-guardrails-configmap.yaml
 
 # Tracing — filled-in production object-storage credentials (template is committed)

--- a/agents/langgraph/examples/guardrailed_agent/README.md
+++ b/agents/langgraph/examples/guardrailed_agent/README.md
@@ -130,8 +130,8 @@ After editing, restart `make guardrails-server-local` or `make guardrails-server
 - [uv](https://docs.astral.sh/uv/) — Python package manager
 - [Ollama](https://ollama.com/) — local LLM inference (or any OpenAI-compatible endpoint)
 - [Podman](https://podman.io/) or [Docker](https://www.docker.com/) — for container builds
-- [oc](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html) — for OpenShift AI deployment
-- [Helm](https://helm.sh/) — for deploying to Kubernetes/OpenShift AI
+- [oc](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html) — for OpenShift deployment
+- [Helm](https://helm.sh/) — for deploying to Kubernetes/OpenShift
 - [GNU Make](https://www.gnu.org/software/make/) and a bash-compatible shell
 
 ## Local Development

--- a/agents/langgraph/examples/guardrailed_agent/README.md
+++ b/agents/langgraph/examples/guardrailed_agent/README.md
@@ -130,8 +130,8 @@ After editing, restart `make guardrails-server-local` or `make guardrails-server
 - [uv](https://docs.astral.sh/uv/) — Python package manager
 - [Ollama](https://ollama.com/) — local LLM inference (or any OpenAI-compatible endpoint)
 - [Podman](https://podman.io/) or [Docker](https://www.docker.com/) — for container builds
-- [oc](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html) — for OpenShift deployment
-- [Helm](https://helm.sh/) — for deploying to Kubernetes/OpenShift
+- [oc](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html) — for OpenShift AI deployment
+- [Helm](https://helm.sh/) — for deploying to Kubernetes/OpenShift AI
 - [GNU Make](https://www.gnu.org/software/make/) and a bash-compatible shell
 
 ## Local Development
@@ -242,7 +242,7 @@ Tracing is **opt-in**: off by default, zero overhead when unset, and content cap
 
 Full setup for all three — manifests, `OTEL_*` env vars, reading traces, and PromQL queries — lives in **[deploy/tracing/README.md](deploy/tracing/README.md)**.
 
-## Deploying to OpenShift
+## Deploying to OpenShift AI
 
 On RHOAI, NeMo Guardrails runs as a separate pod managed by the `NemoGuardrails` CRD
 (TrustyAI Operator). The agent's `BASE_URL` must point at that guardrails Service —

--- a/agents/langgraph/examples/guardrailed_agent/deploy/README.md
+++ b/agents/langgraph/examples/guardrailed_agent/deploy/README.md
@@ -1,6 +1,6 @@
 # Deploying Guardrailed Agent on RHOAI
 
-This directory deploys the **nemoguard** NeMo Guardrails profile to OpenShift via the
+This directory deploys the **nemoguard** NeMo Guardrails profile to OpenShift AI via the
 `NemoGuardrails` CRD (TrustyAI operator), then wires the agent's `BASE_URL` to that
 in-cluster guardrails Service — not directly to vLLM.
 

--- a/agents/langgraph/examples/guardrailed_agent/main.py
+++ b/agents/langgraph/examples/guardrailed_agent/main.py
@@ -440,6 +440,7 @@ async def _handle_stream(
     created = int(time.time())
 
     async def event_generator() -> AsyncIterator[str]:
+        streamed_content = False
         try:
             async for event in agent_graph.astream_events(
                 {"messages": messages},
@@ -452,6 +453,7 @@ async def _handle_stream(
                 if kind == "on_chat_model_stream":
                     chunk = event["data"]["chunk"]
                     if chunk.content:
+                        streamed_content = True
                         data = {
                             "id": completion_id,
                             "object": "chat.completion.chunk",
@@ -467,7 +469,8 @@ async def _handle_stream(
                         }
                         yield f"data: {json.dumps(data)}\n\n"
 
-                # Tool calls (after LLM finishes generating the call)
+                # Tool calls (after LLM finishes generating the call), or
+                # full content when the proxy forbids streamed tool calls.
                 elif kind == "on_chat_model_end":
                     message = event["data"]["output"]
                     if hasattr(message, "tool_calls") and message.tool_calls:
@@ -500,6 +503,22 @@ async def _handle_stream(
                             ],
                         }
                         yield f"data: {json.dumps(data)}\n\n"
+                    elif (not streamed_content) and getattr(message, "content", None):
+                        data = {
+                            "id": completion_id,
+                            "object": "chat.completion.chunk",
+                            "created": created,
+                            "model": model_id,
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "delta": {"content": message.content},
+                                    "finish_reason": None,
+                                }
+                            ],
+                        }
+                        yield f"data: {json.dumps(data)}\n\n"
+                    streamed_content = False
 
                 # Tool execution results
                 elif kind == "on_tool_end":
@@ -592,6 +611,7 @@ async def _handle_stream(
                     }
                 }
                 yield f"data: {json.dumps(error_data)}\n\n"
+                yield "data: [DONE]\n\n"
 
     return StreamingResponse(
         event_generator(),

--- a/agents/langgraph/examples/guardrailed_agent/src/guardrailed_agent/agent.py
+++ b/agents/langgraph/examples/guardrailed_agent/src/guardrailed_agent/agent.py
@@ -117,11 +117,17 @@ def get_graph_closure(
 
     tools = [check_account_balance]
 
+    # NeMo Guardrails (passthrough) accepts tools only on non-streaming
+    # /v1/chat/completions. The playground always sets stream=true, which
+    # would otherwise 422: "tools ... only supported for non-streaming
+    # requests when ... passthrough: true". disable_streaming keeps the
+    # agent's SSE endpoint but sends non-streaming LLM calls to the proxy.
     chat = ChatOpenAI(
         model=model_id,
         temperature=0.01,
         api_key=api_key,
         base_url=base_url,
+        disable_streaming=True,
         http_client=make_nemo_compatible_http_client(),
         http_async_client=make_nemo_compatible_async_http_client(),
     )

--- a/agents/langgraph/examples/guardrailed_agent/tests/test_agent.py
+++ b/agents/langgraph/examples/guardrailed_agent/tests/test_agent.py
@@ -170,6 +170,7 @@ class TestGetGraphClosureHttpClients:
             )
 
         kwargs = mock_chat.call_args.kwargs
+        assert kwargs["disable_streaming"] is True
         assert isinstance(kwargs["http_client"], httpx.Client)
         assert isinstance(kwargs["http_async_client"], httpx.AsyncClient)
         prompt = mock_create.call_args.kwargs["system_prompt"]

--- a/agents/langgraph/examples/guardrailed_agent/tests/test_api_contract.py
+++ b/agents/langgraph/examples/guardrailed_agent/tests/test_api_contract.py
@@ -228,45 +228,6 @@ class TestChatCompletionsEndpoint:
                 content_parts.append(delta["content"])
         assert "".join(content_parts)
 
-    def test_sse_emits_content_when_llm_does_not_stream_tokens(self, api_client):
-        """NeMo passthrough + tools uses non-streaming LLM calls, so the
-        playground SSE path must surface content from on_chat_model_end."""
-        client, fake_graph = api_client
-        content = "Your checking balance is $2,450.00."
-
-        async def _astream_events_end_only(*_args, **_kwargs):
-            message = MagicMock()
-            message.content = content
-            message.tool_calls = []
-            yield {
-                "event": "on_chat_model_end",
-                "data": {"output": message},
-            }
-
-        fake_graph.astream_events = _astream_events_end_only
-
-        with client.stream(
-            "POST",
-            "/chat/completions",
-            json={
-                "messages": [{"role": "user", "content": "What is my balance?"}],
-                "stream": True,
-            },
-        ) as response:
-            assert response.status_code == 200
-            chunks = list(response.iter_lines())
-
-        assert any(line.strip() == "data: [DONE]" for line in chunks)
-        content_parts = []
-        for line in chunks:
-            if not line.startswith("data: ") or line.strip() == "data: [DONE]":
-                continue
-            payload = json.loads(line[len("data: ") :])
-            delta = payload.get("choices", [{}])[0].get("delta", {})
-            if delta.get("content"):
-                content_parts.append(delta["content"])
-        assert "".join(content_parts) == content
-
     def test_guardrails_block_returns_refusal(self, api_client):
         client, fake_graph = api_client
         request = MagicMock()

--- a/agents/langgraph/examples/guardrailed_agent/tests/test_api_contract.py
+++ b/agents/langgraph/examples/guardrailed_agent/tests/test_api_contract.py
@@ -228,6 +228,45 @@ class TestChatCompletionsEndpoint:
                 content_parts.append(delta["content"])
         assert "".join(content_parts)
 
+    def test_sse_emits_content_when_llm_does_not_stream_tokens(self, api_client):
+        """NeMo passthrough + tools uses non-streaming LLM calls, so the
+        playground SSE path must surface content from on_chat_model_end."""
+        client, fake_graph = api_client
+        content = "Your checking balance is $2,450.00."
+
+        async def _astream_events_end_only(*_args, **_kwargs):
+            message = MagicMock()
+            message.content = content
+            message.tool_calls = []
+            yield {
+                "event": "on_chat_model_end",
+                "data": {"output": message},
+            }
+
+        fake_graph.astream_events = _astream_events_end_only
+
+        with client.stream(
+            "POST",
+            "/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "What is my balance?"}],
+                "stream": True,
+            },
+        ) as response:
+            assert response.status_code == 200
+            chunks = list(response.iter_lines())
+
+        assert any(line.strip() == "data: [DONE]" for line in chunks)
+        content_parts = []
+        for line in chunks:
+            if not line.startswith("data: ") or line.strip() == "data: [DONE]":
+                continue
+            payload = json.loads(line[len("data: ") :])
+            delta = payload.get("choices", [{}])[0].get("delta", {})
+            if delta.get("content"):
+                content_parts.append(delta["content"])
+        assert "".join(content_parts) == content
+
     def test_guardrails_block_returns_refusal(self, api_client):
         client, fake_graph = api_client
         request = MagicMock()


### PR DESCRIPTION
## Description

NeMo Guardrails passthrough rejects streamed tool calls (`422`). This keeps the playground `stream=true` contract by sending **non-streaming** LLM calls to the proxy (`disable_streaming=True`) and emitting assistant text from `on_chat_model_end` when no token chunks arrive.

Also applies the PM docs nit: deploy guidance now says **OpenShift AI**.

## Jira Ticket

RHAISTRAT-1948

## Testing

- [x] `make test` passes (run from the affected agent directory)
- [x] Manual testing performed (describe steps below)
- [ ] No testing required (documentation/config change only)

`make test` in `agents/langgraph/examples/guardrailed_agent`: **186 passed**, 8 deselected.

Added `test_sse_emits_content_when_llm_does_not_stream_tokens` (fails if the `on_chat_model_end` fallback is removed). `test_agent.py` asserts `disable_streaming=True`.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)

Streaming/tool workaround is from the RHAISTRAT-1948 demo; docs wording is the PM review nit.

## Review Guidance

- `src/guardrailed_agent/agent.py` — why `disable_streaming=True`
- `main.py` — SSE fallback when the model does not stream tokens
- `tests/test_api_contract.py` — SSE path with `on_chat_model_end` only (no token chunks)