### PR TITLE
ci: add quality gates orchestrator workflow (RHAIENG-6542)

### DIFF
--- a/.github/actions/verify-cluster-connection/action.yml
+++ b/.github/actions/verify-cluster-connection/action.yml
@@ -1,0 +1,20 @@
+name: "Verify Cluster Connection"
+description: "Smoke-test the OpenShift cluster connection. Requires setup-cluster to have run first."
+
+runs:
+  using: "composite"
+  steps:
+    - name: Verify cluster connection
+      shell: bash
+      run: |
+        set -o pipefail
+        echo "--- Logged in as ---"
+        oc whoami
+        echo ""
+        echo "--- Current project ---"
+        oc project
+        echo ""
+        echo "--- Namespace resources ---"
+        oc get all -n ci-testing --no-headers 2>&1 | head -10 || true
+        echo ""
+        echo "Cluster connection verified successfully."

--- a/.github/actions/verify-cluster-connection/action.yml
+++ b/.github/actions/verify-cluster-connection/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Verify cluster connection
       shell: bash
       run: |
-        set -o pipefail
+        set -euo pipefail
         echo "--- Logged in as ---"
         oc whoami
         echo ""

--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -8,8 +8,6 @@
 name: "QG4: Agent Deployment Integration Tests"
 
 on:
-  schedule:
-    - cron: "0 3 * * *" # 11 PM EDT / 10 PM EST
   workflow_dispatch:
 
 permissions:
@@ -32,18 +30,7 @@ jobs:
           cluster-api-url: ${{ secrets.CLUSTER_API_URL }}
 
       - name: Verify cluster connection
-        run: |
-          set -o pipefail
-          echo "--- Logged in as ---"
-          oc whoami
-          echo ""
-          echo "--- Current project ---"
-          oc project
-          echo ""
-          echo "--- Namespace resources ---"
-          oc get all -n ci-testing --no-headers 2>&1 | head -10 || true
-          echo ""
-          echo "Cluster connection verified successfully."
+        uses: ./.github/actions/verify-cluster-connection
 
       - name: Logout
         if: always()
@@ -58,6 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # ⚠️  Keep in sync with quality-gates-pipeline.yml matrix
         agent:
           - { name: langgraph-react-agent, dir: agents/langgraph/templates/react_agent }
           - { name: langgraph-hitl-agent, dir: agents/langgraph/templates/human_in_the_loop }

--- a/.github/workflows/quality-gates-pipeline.yml
+++ b/.github/workflows/quality-gates-pipeline.yml
@@ -232,6 +232,34 @@ jobs:
       needs.collect-qg4.outputs.has_passing == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # QG7 deploys and tears down its own agents (run-qg7 action handles
+    # the full lifecycle). These env vars are consumed by the deploy step
+    # to write each agent's .env from its agent.yaml `env` block.
+    # Keep in sync with eval-gating.yml cluster-btests job env.
+    #
+    # NVIDIA_API_KEY / GUARDRAILS_MODEL_ID deliberately omitted:
+    # guardrailed_agent is excluded (RHAIENG-7081).
+    env:
+      API_KEY: ${{ vars.API_KEY }}
+      BASE_URL: ${{ vars.BASE_URL }}
+      MODEL_ID: ${{ vars.MODEL_ID }}
+      MLFLOW_TRACKING_URI: ${{ vars.MLFLOW_TRACKING_URI }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
+      OPENAI_MODEL_ID: ${{ vars.OPENAI_MODEL_ID }}
+      POSTGRES_HOST: ${{ vars.POSTGRES_HOST }}
+      POSTGRES_PORT: ${{ vars.POSTGRES_PORT }}
+      POSTGRES_DB: ${{ vars.POSTGRES_DB }}
+      POSTGRES_USER: ${{ vars.POSTGRES_USER }}
+      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+      MCP_SERVER_URL: ${{ vars.MCP_SERVER_URL }}
+      LANGFLOW_AGENT_URL: ${{ vars.LANGFLOW_AGENT_URL }}
+      OGX_BASE_URL: ${{ vars.OGX_BASE_URL }}
+      OGX_MODEL_ID: ${{ vars.OGX_MODEL_ID }}
+      EMBEDDING_MODEL: ${{ vars.EMBEDDING_MODEL }}
+      EMBEDDING_DIMENSION: ${{ vars.EMBEDDING_DIMENSION }}
+      VECTOR_STORE_PROVIDER: ${{ vars.VECTOR_STORE_PROVIDER }}
+      VECTOR_STORE_ID: ${{ vars.VECTOR_STORE_ID }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/quality-gates-pipeline.yml
+++ b/.github/workflows/quality-gates-pipeline.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup cluster tools
         uses: ./.github/actions/setup-cluster
@@ -90,6 +92,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup cluster tools
         uses: ./.github/actions/setup-cluster
@@ -170,6 +174,7 @@ jobs:
       has_passing: ${{ steps.filter.outputs.has_passing }}
     steps:
       - name: Download QG4 outcome artifacts
+        continue-on-error: true
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           pattern: qg4-outcome-*
@@ -222,6 +227,7 @@ jobs:
     needs: collect-qg4
     if: >-
       always() &&
+      github.repository == 'red-hat-data-services/agentic-starter-kits' &&
       needs.collect-qg4.result == 'success' &&
       needs.collect-qg4.outputs.has_passing == 'true'
     runs-on: ubuntu-latest
@@ -233,6 +239,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup cluster tools
         uses: ./.github/actions/setup-cluster

--- a/.github/workflows/quality-gates-pipeline.yml
+++ b/.github/workflows/quality-gates-pipeline.yml
@@ -41,18 +41,7 @@ jobs:
           cluster-api-url: ${{ secrets.CLUSTER_API_URL }}
 
       - name: Verify cluster connection
-        run: |
-          set -o pipefail
-          echo "--- Logged in as ---"
-          oc whoami
-          echo ""
-          echo "--- Current project ---"
-          oc project
-          echo ""
-          echo "--- Namespace resources ---"
-          oc get all -n ci-testing --no-headers 2>&1 | head -10 || true
-          echo ""
-          echo "Cluster connection verified successfully."
+        uses: ./.github/actions/verify-cluster-connection
 
       - name: Logout
         if: always()
@@ -68,6 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # ⚠️  Keep in sync with agent-deployment-test.yaml matrix
         agent:
           - { name: langgraph-react-agent, dir: agents/langgraph/templates/react_agent }
           - { name: langgraph-hitl-agent, dir: agents/langgraph/templates/human_in_the_loop }
@@ -108,7 +98,8 @@ jobs:
           cluster-api-url: ${{ secrets.CLUSTER_API_URL }}
 
       - name: Run QG4 deployment test
-        if: matrix.agent.name != 'autogen-mcp-agent' || vars.MCP_SERVER_URL != ''
+        id: qg4_test
+        if: matrix.agent.name != 'autogen-mcp-agent' || vars.MCP_SERVER_URL
         uses: ./.github/actions/run-qg4
         with:
           agent-dir: ${{ matrix.agent.dir }}
@@ -141,13 +132,18 @@ jobs:
           AGENT_NAME: ${{ matrix.agent.name }}
           AGENT_DIR: ${{ matrix.agent.dir }}
           JOB_STATUS: ${{ job.status }}
+          QG4_TEST_OUTCOME: ${{ steps.qg4_test.outcome }}
         run: |
           set -euo pipefail
+          status="${JOB_STATUS}"
+          if [[ "${QG4_TEST_OUTCOME}" == "skipped" ]]; then
+            status="skipped"
+          fi
           mkdir -p qg4-outcome
           jq -n \
             --arg name "${AGENT_NAME}" \
             --arg dir "${AGENT_DIR}" \
-            --arg status "${JOB_STATUS}" \
+            --arg status "${status}" \
             '{name: $name, dir: $dir, status: $status}' \
             > qg4-outcome/result.json
 
@@ -181,29 +177,23 @@ jobs:
 
       - name: Build pass-list from QG4 outcomes
         id: filter
+        shell: bash
         run: |
           set -euo pipefail
+          shopt -s nullglob
 
-          pass_list='[]'
-          fail_list='[]'
+          result_files=(qg4-outcomes/qg4-outcome-*/result.json)
+          if [[ ${#result_files[@]} -eq 0 ]]; then
+            echo "No QG4 outcome artifacts found (upstream jobs may have been skipped)."
+            echo "pass_list=[]" >> "${GITHUB_OUTPUT}"
+            echo "has_passing=false" >> "${GITHUB_OUTPUT}"
+            echo "## QG4 Results" >> "${GITHUB_STEP_SUMMARY}"
+            echo "No outcome artifacts — QG4 jobs did not run." >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
 
-          for result_file in qg4-outcomes/qg4-outcome-*/result.json; do
-            name=$(jq -r '.name' "${result_file}")
-            dir=$(jq -r '.dir' "${result_file}")
-            status=$(jq -r '.status' "${result_file}")
-
-            # Strip agents/ prefix to get the QG7-compatible template-layout ID
-            qg7_id="${dir#agents/}"
-
-            entry=$(jq -n --arg name "${name}" --arg qg7_id "${qg7_id}" \
-              '{name: $name, qg7_id: $qg7_id}')
-
-            if [[ "${status}" == "success" ]]; then
-              pass_list=$(echo "${pass_list}" | jq --argjson entry "${entry}" '. + [$entry]')
-            else
-              fail_list=$(echo "${fail_list}" | jq --arg name "${name}" '. + [$name]')
-            fi
-          done
+          pass_list=$(jq -s '[.[] | select(.status == "success") | {name: .name, qg7_id: (.dir | ltrimstr("agents/"))}]' "${result_files[@]}")
+          fail_list=$(jq -s '[.[] | select(.status != "success") | .name]' "${result_files[@]}")
 
           pass_count=$(echo "${pass_list}" | jq 'length')
           fail_count=$(echo "${fail_list}" | jq 'length')
@@ -249,6 +239,13 @@ jobs:
         with:
           oc-token: ${{ secrets.OC_TOKEN }}
           cluster-api-url: ${{ secrets.CLUSTER_API_URL }}
+
+      - name: Cache uv packages
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: uv-${{ runner.os }}-
 
       - name: Install btest runner dependencies
         run: |

--- a/.github/workflows/quality-gates-pipeline.yml
+++ b/.github/workflows/quality-gates-pipeline.yml
@@ -1,0 +1,316 @@
+# Quality Gates Pipeline
+#
+# Orchestrator that chains QG4 (deployment health) and QG7 (behavioral evals)
+# using staged fan-out with a dynamic matrix. Each gate handles its own
+# setup and teardown independently.
+#
+# Flow:
+#   verify-cluster-connection
+#     └─► qg4 (matrix, all agents, fail-fast: false)
+#           └─► collect-qg4 (build JSON pass-list from outcomes)
+#                 └─► qg7 (dynamic matrix, only QG4-passing agents)
+#                       └─► notify-slack
+#
+# Ref: RFC Discussion #285
+
+name: "Quality Gates Pipeline"
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # 11 PM EDT / 10 PM EST
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Pre-flight: verify cluster is reachable before fanning out ──────────
+  verify-cluster-connection:
+    name: "Verify Cluster Connection"
+    if: github.repository == 'red-hat-data-services/agentic-starter-kits'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup cluster tools
+        uses: ./.github/actions/setup-cluster
+        with:
+          oc-token: ${{ secrets.OC_TOKEN }}
+          cluster-api-url: ${{ secrets.CLUSTER_API_URL }}
+
+      - name: Verify cluster connection
+        run: |
+          set -o pipefail
+          echo "--- Logged in as ---"
+          oc whoami
+          echo ""
+          echo "--- Current project ---"
+          oc project
+          echo ""
+          echo "--- Namespace resources ---"
+          oc get all -n ci-testing --no-headers 2>&1 | head -10 || true
+          echo ""
+          echo "Cluster connection verified successfully."
+
+      - name: Logout
+        if: always()
+        run: oc logout || true
+
+  # ── Stage 1: QG4 — Deployment health checks ────────────────────────────
+  qg4:
+    name: "QG4: ${{ matrix.agent.name }}"
+    needs: verify-cluster-connection
+    if: github.repository == 'red-hat-data-services/agentic-starter-kits'
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ fromJSON(matrix.timeout_minutes || '20') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        agent:
+          - { name: langgraph-react-agent, dir: agents/langgraph/templates/react_agent }
+          - { name: langgraph-hitl-agent, dir: agents/langgraph/templates/human_in_the_loop }
+          - { name: crewai-websearch-agent, dir: agents/crewai/templates/websearch_agent }
+          - { name: google-adk-agent, dir: agents/google/templates/adk }
+          - { name: llamaindex-websearch-agent, dir: agents/llamaindex/templates/websearch_agent }
+          - { name: langgraph-db-memory-agent, dir: agents/langgraph/templates/react_with_database_memory }
+          - { name: autogen-mcp-agent, dir: agents/autogen/templates/mcp_agent }
+          - { name: vanilla-python-openai-responses-agent, dir: agents/vanilla_python/templates/openai_responses_agent }
+          - { name: a2a-langgraph-crewai, dir: agents/a2a/templates/langgraph_crewai_agent }
+          - { name: langflow-simple-tool-calling-agent, dir: agents/langflow/templates/simple_tool_calling_agent }
+          - { name: langgraph-guardrailed-agent, dir: agents/langgraph/examples/guardrailed_agent }
+        include:
+          - agent: { name: langgraph-db-memory-agent, dir: agents/langgraph/templates/react_with_database_memory }
+            POSTGRES_HOST: ${{ vars.POSTGRES_HOST }}
+            POSTGRES_PORT: ${{ vars.POSTGRES_PORT }}
+            POSTGRES_DB: ${{ vars.POSTGRES_DB }}
+            POSTGRES_USER: ${{ vars.POSTGRES_USER }}
+          - agent: { name: autogen-mcp-agent, dir: agents/autogen/templates/mcp_agent }
+            MCP_SERVER_URL: ${{ vars.MCP_SERVER_URL }}
+          - agent: { name: vanilla-python-openai-responses-agent, dir: agents/vanilla_python/templates/openai_responses_agent }
+            BASE_URL: ${{ vars.OPENAI_BASE_URL }}
+            MODEL_ID: ${{ vars.OPENAI_MODEL_ID }}
+          - agent: { name: langflow-simple-tool-calling-agent, dir: agents/langflow/templates/simple_tool_calling_agent }
+            LANGFLOW_AGENT_URL: ${{ vars.LANGFLOW_AGENT_URL }}
+          - agent: { name: langgraph-guardrailed-agent, dir: agents/langgraph/examples/guardrailed_agent }
+            timeout_minutes: '45'
+            MODEL_ID: qwen2-5-7b-instruct
+            GUARDRAILS_MODEL_ID: qwen2-5-7b-instruct
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup cluster tools
+        uses: ./.github/actions/setup-cluster
+        with:
+          oc-token: ${{ secrets.OC_TOKEN }}
+          cluster-api-url: ${{ secrets.CLUSTER_API_URL }}
+
+      - name: Run QG4 deployment test
+        if: matrix.agent.name != 'autogen-mcp-agent' || vars.MCP_SERVER_URL != ''
+        uses: ./.github/actions/run-qg4
+        with:
+          agent-dir: ${{ matrix.agent.dir }}
+        env:
+          API_KEY: ${{ matrix.agent.name == 'vanilla-python-openai-responses-agent' && secrets.OPENAI_API_KEY || vars.API_KEY }}
+          BASE_URL: ${{ matrix.BASE_URL || vars.BASE_URL }}
+          MODEL_ID: ${{ matrix.MODEL_ID || vars.MODEL_ID }}
+          POSTGRES_HOST: ${{ matrix.POSTGRES_HOST }}
+          POSTGRES_PORT: ${{ matrix.POSTGRES_PORT }}
+          POSTGRES_DB: ${{ matrix.POSTGRES_DB }}
+          POSTGRES_USER: ${{ matrix.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          MCP_SERVER_URL: ${{ matrix.MCP_SERVER_URL }}
+          LANGFLOW_AGENT_URL: ${{ matrix.LANGFLOW_AGENT_URL }}
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          GUARDRAILS_MODEL_ID: ${{ matrix.GUARDRAILS_MODEL_ID }}
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: qg4-results-${{ matrix.agent.name }}
+          path: ${{ matrix.agent.dir }}/results.xml
+          if-no-files-found: warn
+
+      - name: Record QG4 outcome
+        if: always()
+        shell: bash
+        env:
+          AGENT_NAME: ${{ matrix.agent.name }}
+          AGENT_DIR: ${{ matrix.agent.dir }}
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          set -euo pipefail
+          mkdir -p qg4-outcome
+          jq -n \
+            --arg name "${AGENT_NAME}" \
+            --arg dir "${AGENT_DIR}" \
+            --arg status "${JOB_STATUS}" \
+            '{name: $name, dir: $dir, status: $status}' \
+            > qg4-outcome/result.json
+
+      - name: Upload QG4 outcome
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: qg4-outcome-${{ matrix.agent.name }}
+          path: qg4-outcome/result.json
+
+      - name: Logout
+        if: always()
+        run: oc logout || true
+
+  # ── Collect QG4 results and build pass-list for QG7 ────────────────────
+  collect-qg4:
+    name: "Collect QG4 Results"
+    needs: qg4
+    if: always() && github.repository == 'red-hat-data-services/agentic-starter-kits'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      pass_list: ${{ steps.filter.outputs.pass_list }}
+      has_passing: ${{ steps.filter.outputs.has_passing }}
+    steps:
+      - name: Download QG4 outcome artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          pattern: qg4-outcome-*
+          path: qg4-outcomes/
+
+      - name: Build pass-list from QG4 outcomes
+        id: filter
+        run: |
+          set -euo pipefail
+
+          pass_list='[]'
+          fail_list='[]'
+
+          for result_file in qg4-outcomes/qg4-outcome-*/result.json; do
+            name=$(jq -r '.name' "${result_file}")
+            dir=$(jq -r '.dir' "${result_file}")
+            status=$(jq -r '.status' "${result_file}")
+
+            # Strip agents/ prefix to get the QG7-compatible template-layout ID
+            qg7_id="${dir#agents/}"
+
+            entry=$(jq -n --arg name "${name}" --arg qg7_id "${qg7_id}" \
+              '{name: $name, qg7_id: $qg7_id}')
+
+            if [[ "${status}" == "success" ]]; then
+              pass_list=$(echo "${pass_list}" | jq --argjson entry "${entry}" '. + [$entry]')
+            else
+              fail_list=$(echo "${fail_list}" | jq --arg name "${name}" '. + [$name]')
+            fi
+          done
+
+          pass_count=$(echo "${pass_list}" | jq 'length')
+          fail_count=$(echo "${fail_list}" | jq 'length')
+          has_passing=$(echo "${pass_list}" | jq 'length > 0')
+
+          echo "pass_list=$(echo "${pass_list}" | jq -c '.')" >> "${GITHUB_OUTPUT}"
+          echo "has_passing=${has_passing}" >> "${GITHUB_OUTPUT}"
+
+          {
+            echo "## QG4 Results"
+            echo ""
+            echo "**Passed:** ${pass_count} agent(s)"
+            echo "${pass_list}" | jq -r '.[] | "- ✅ \(.name)"'
+            echo ""
+            if [[ "${fail_count}" -gt 0 ]]; then
+              echo "**Failed:** ${fail_count} agent(s) — excluded from QG7"
+              echo "${fail_list}" | jq -r '.[] | "- ❌ \(.)"'
+            else
+              echo "**Failed:** none"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  # ── Stage 2: QG7 — Behavioral evals (QG4-passing agents only) ──────────
+  qg7:
+    name: "QG7: ${{ matrix.agent.name }}"
+    needs: collect-qg4
+    if: >-
+      always() &&
+      needs.collect-qg4.result == 'success' &&
+      needs.collect-qg4.outputs.has_passing == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        agent: ${{ fromJson(needs.collect-qg4.outputs.pass_list) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup cluster tools
+        uses: ./.github/actions/setup-cluster
+        with:
+          oc-token: ${{ secrets.OC_TOKEN }}
+          cluster-api-url: ${{ secrets.CLUSTER_API_URL }}
+
+      - name: Install btest runner dependencies
+        run: |
+          set -euo pipefail
+          uv sync --frozen --extra test --extra test-mlflow
+
+      - name: Run QG7 behavioral eval
+        uses: ./.github/actions/run-qg7
+        env:
+          QG7_AGENT_NAME: ${{ matrix.agent.qg7_id }}
+
+      - name: Upload btest artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: qg7-results-${{ matrix.agent.name }}
+          path: btest-results/**
+          if-no-files-found: warn
+
+      - name: Logout
+        if: always()
+        run: oc logout || true
+
+  # ── Notify Slack ────────────────────────────────────────────────────────
+  notify-slack:
+    name: Notify Slack
+    if: >-
+      !cancelled() &&
+      github.repository == 'red-hat-data-services/agentic-starter-kits' &&
+      (github.event_name != 'workflow_dispatch' || github.ref_name == 'main')
+    needs: [verify-cluster-connection, qg4, collect-qg4, qg7]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Decide notification status
+        id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          NEEDS_JSON: ${{ toJson(needs) }}
+        run: |
+          bash .github/actions/notify-slack/should_notify.sh >> "${GITHUB_OUTPUT}"
+
+      - name: Send Slack notification
+        if: steps.gate.outputs.should_notify == 'true'
+        uses: ./.github/actions/notify-slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          github_token: ${{ github.token }}
+          workflow_name: ${{ github.workflow }}
+          event_name: ${{ github.event_name }}
+          ref_name: ${{ github.ref_name }}
+          run_id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          dashboard_url: https://red-hat-data-services.github.io/agentic-starter-kits/
+          status: ${{ steps.gate.outputs.status }}

--- a/.github/workflows/quality-gates-pipeline.yml
+++ b/.github/workflows/quality-gates-pipeline.yml
@@ -12,6 +12,7 @@
 #                       └─► notify-slack
 #
 # Ref: RFC Discussion #285
+# Depends on: .github/actions/run-qg4, .github/actions/run-qg7
 
 name: "Quality Gates Pipeline"
 


### PR DESCRIPTION
## Description

Adds the quality gates orchestrator workflow (`quality-gates-pipeline.yml`) that chains QG4 and QG7 using the staged fan-out pattern with dynamic matrix, as designed in RFC Discussion #285.

Each gate handles its own setup and teardown independently. The orchestrator provides:

- **Staged fan-out**: QG4 runs all 11 agents in parallel (`fail-fast: false`), then a `collect-qg4` job gathers per-agent outcomes via uploaded artifacts and builds a JSON pass-list
- **Dynamic matrix**: QG7 uses `fromJson()` to run only for agents that passed QG4
- **Scoped secrets**: QG4 and QG7 each receive only the secrets they need. QG7 receives cluster credentials plus agent deployment credentials (`API_KEY`, `OPENAI_API_KEY`, `POSTGRES_PASSWORD`, etc.) because it deploys and tears down its own agents via the `run-qg7` action
- **Per-agent visibility**: Both QG4 and QG7 run as matrix jobs, giving clear per-agent pass/fail in the GitHub Actions UI

**Jobs:**

| Job | Purpose |
|---|---|
| `verify-cluster-connection` | Pre-flight cluster smoke test (extracted to composite action) |
| `qg4` | Matrix: deployment health checks (11 agents) |
| `collect-qg4` | Build JSON pass-list from QG4 outcome artifacts |
| `qg7` | Dynamic matrix: behavioral evals (QG4-passing agents only, with uv cache) |
| `notify-slack` | Standard Slack notification |

**Also in this PR:**
- `agent-deployment-test.yaml`: schedule trigger removed (orchestrator owns nightly), uses new `verify-cluster-connection` action
- `.github/actions/verify-cluster-connection/action.yml`: new composite action extracted from inline steps

Depends on: RHAIENG-6540 (#317), RHAIENG-6541 (#321)
Compatible with: #325 (QG7 deploy lifecycle — env vars synced)
Ref: RFC Discussion #285

## Jira Ticket

RHAIENG-6542

## Testing

- [ ] `make test` passes (run from the affected agent directory)
- [x] Manual testing performed (describe steps below)
- [ ] No testing required (documentation/config change only)

**Structural verification performed locally:**
- YAML parses successfully (pyyaml `safe_load`)
- Job dependency graph verified: `verify-cluster-connection` → `qg4` → `collect-qg4` → `qg7` → `notify-slack`
- QG4 agent matrix matches `agent-deployment-test.yaml` exactly (11 agents + `include` overrides)
- `collect-qg4` outputs `pass_list` and `has_passing` consumed by QG7 `fromJson()`
- `fail-fast: false` on both QG4 and QG7 matrix strategies
- Skipped QG4 steps (e.g. autogen-mcp-agent when MCP_SERVER_URL unset) recorded as `"skipped"` via `steps.qg4_test.outcome`
- `collect-qg4` handles empty artifacts gracefully (nullglob + early exit)
- QG7 env block matches `eval-gating.yml` cluster-btests job (PR #325 compatibility)

**End-to-end validation:** requires `workflow_dispatch` run on upstream — will document run ID and outcome here after merge.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)

## Review Guidance

- **`quality-gates-pipeline.yml`** (new): the orchestrator. QG4 job mirrors `agent-deployment-test.yaml`'s `test-agent` with two added steps (`Record QG4 outcome` and `Upload QG4 outcome`). `collect-qg4` uses `jq -s` slurp to build the pass-list in two calls. QG7 matrix entries have `name` (job label) and `qg7_id` (template-layout agent ID for `QG7_AGENT_NAME`). QG7 has a job-level `env:` block with agent deployment credentials — needed because `run-qg7` deploys agents before testing (per PR #325).
- **`verify-cluster-connection/action.yml`** (new): extracted from inline steps shared between both workflows.
- **`agent-deployment-test.yaml`** (modified): schedule trigger removed, verify step replaced with composite action call, sync comment added to matrix.

## Related PRs

- #317 — ci: extract QG4 deployment tests into composite action (RHAIENG-6540)
- #321 — ci: extract run-qg7 action (RHAIENG-6541)
- #325 — QG7 deploy lifecycle (env vars synced in this PR)