### PR TITLE
fix(autogen/mcp_agent): pin mcp<2 to fix crash loop on fresh builds

### DIFF
--- a/agents/autogen/templates/mcp_agent/pyproject.toml
+++ b/agents/autogen/templates/mcp_agent/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "uvicorn[standard]>=0.41.0",
     "pydantic>=2.0.0",
     "python-dotenv>=1.2.0",
-    "mcp>=1.1.3",
+    "mcp>=1.1.3,<2",
     "setuptools>=80.9.0,<83.0.0",
     "starlette>=1.0.1",
 ]

--- a/agents/autogen/templates/mcp_agent/uv.lock
+++ b/agents/autogen/templates/mcp_agent/uv.lock
@@ -202,7 +202,7 @@ requires-dist = [
     { name = "autogen-agentchat", specifier = ">=0.4.6" },
     { name = "autogen-ext", extras = ["openai", "mcp"], specifier = ">=0.4.6" },
     { name = "fastapi", specifier = ">=0.135.1" },
-    { name = "mcp", specifier = ">=1.1.3" },
+    { name = "mcp", specifier = ">=1.1.3,<2" },
     { name = "mlflow", marker = "extra == 'tracing'", specifier = ">=3.10.0" },
     { name = "openai", specifier = ">=1.52.2" },
     { name = "pydantic", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary

- Pins `mcp>=1.1.3,<2` in `agents/autogen/templates/mcp_agent/pyproject.toml` to prevent fresh container builds from resolving mcp 2.x, which removed `mcp.shared.context.RequestContext` that `autogen-ext` 0.4.x imports at startup
- The Dockerfile doesn't copy `uv.lock`, so `uv pip install` resolved the uncapped `mcp>=1.1.3` to 2.1.1 — causing an `ImportError` crash loop before uvicorn could start
- Regenerated `uv.lock` to reflect the new constraint

Closes RHAIENG-7094

## Test plan

- [x] Reproduced crash: fresh `make build` → `podman run` → `ImportError: cannot import name 'RequestContext' from 'mcp.shared.context'`
- [x] Applied pin, rebuilt with no cached layers → container installs mcp 1.29.1
- [x] Verified `from mcp.shared.context import RequestContext` and `from autogen_ext.tools.mcp import McpWorkbench` both succeed inside the fresh container
- [x] Verified uvicorn starts cleanly (fails gracefully on MCP server connection as expected, no import crash)
- [ ] CI passes
- [ ] Remove from `EXCLUDED_AGENTS` in `deploy_agents.py` once MCP server is available in ci-testing (separate ticket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)