### PR TITLE
fix(ci): mitigate QG4 build timeouts from S3 push contention (RHAIENG-7217)

### DIFF
--- a/.github/workflows/agent-deployment-test.yaml
+++ b/.github/workflows/agent-deployment-test.yaml
@@ -41,9 +41,10 @@ jobs:
     needs: verify-cluster-connection
     if: github.repository == 'red-hat-data-services/agentic-starter-kits'
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ fromJSON(matrix.timeout_minutes || '20') }}
+    timeout-minutes: ${{ fromJSON(matrix.timeout_minutes || '25') }}
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         # ⚠️  Keep in sync with quality-gates-pipeline.yml matrix
         agent:

--- a/.github/workflows/quality-gates-pipeline.yml
+++ b/.github/workflows/quality-gates-pipeline.yml
@@ -56,9 +56,10 @@ jobs:
     needs: verify-cluster-connection
     if: github.repository == 'red-hat-data-services/agentic-starter-kits'
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ fromJSON(matrix.timeout_minutes || '20') }}
+    timeout-minutes: ${{ fromJSON(matrix.timeout_minutes || '25') }}
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         # ⚠️  Keep in sync with agent-deployment-test.yaml matrix
         agent:

--- a/agents/a2a/templates/langgraph_crewai_agent/tests/integration/conftest.py
+++ b/agents/a2a/templates/langgraph_crewai_agent/tests/integration/conftest.py
@@ -77,7 +77,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
         try:
             logger.info("Building image on cluster via build-openshift...")
             build_attempted = True
-            run_make("build-openshift", cwd=agent_dir, timeout=600)
+            run_make("build-openshift", cwd=agent_dir, timeout=900)
 
             logger.info("Deploying to cluster (two-phase Helm)...")
             run_make("deploy", cwd=agent_dir, timeout=600)

--- a/agents/autogen/templates/mcp_agent/tests/integration/conftest.py
+++ b/agents/autogen/templates/mcp_agent/tests/integration/conftest.py
@@ -62,7 +62,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
         try:
             logger.info("Building image on cluster via build-openshift...")
             build_attempted = True
-            run_make("build-openshift", cwd=agent_dir, timeout=600)
+            run_make("build-openshift", cwd=agent_dir, timeout=900)
 
             logger.info("Deploying to cluster...")
             run_make("deploy", cwd=agent_dir, timeout=300)

--- a/agents/crewai/templates/websearch_agent/tests/integration/test_deployment.py
+++ b/agents/crewai/templates/websearch_agent/tests/integration/test_deployment.py
@@ -57,7 +57,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
     try:
         logger.info("Building image on cluster via build-openshift...")
         build_attempted = True
-        run_make("build-openshift", cwd=agent_dir, timeout=600)
+        run_make("build-openshift", cwd=agent_dir, timeout=900)
 
         logger.info("Deploying to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)

--- a/agents/google/templates/adk/tests/integration/test_deployment.py
+++ b/agents/google/templates/adk/tests/integration/test_deployment.py
@@ -57,7 +57,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
     try:
         logger.info("Building image on cluster via build-openshift...")
         build_attempted = True
-        run_make("build-openshift", cwd=agent_dir, timeout=600)
+        run_make("build-openshift", cwd=agent_dir, timeout=900)
 
         logger.info("Deploying to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)

--- a/agents/langgraph/examples/guardrailed_agent/tests/integration/test_deployment.py
+++ b/agents/langgraph/examples/guardrailed_agent/tests/integration/test_deployment.py
@@ -70,7 +70,7 @@ def deployed_agent(cluster_auth, deployed_guardrails, agent_dir, agent_name):
     try:
         logger.info("Building image on cluster via build-openshift...")
         build_attempted = True
-        run_make("build-openshift", cwd=agent_dir, timeout=600)
+        run_make("build-openshift", cwd=agent_dir, timeout=900)
 
         logger.info("Deploying agent to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)

--- a/agents/langgraph/templates/agentic_rag/tests/integration/conftest.py
+++ b/agents/langgraph/templates/agentic_rag/tests/integration/conftest.py
@@ -72,7 +72,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
         try:
             logger.info("Building image on cluster via build-openshift...")
             build_attempted = True
-            run_make("build-openshift", cwd=agent_dir, timeout=600)
+            run_make("build-openshift", cwd=agent_dir, timeout=900)
 
             logger.info("Deploying to cluster...")
             run_make("deploy", cwd=agent_dir, timeout=300)

--- a/agents/langgraph/templates/ci_failure_summarizer/tests/integration/conftest.py
+++ b/agents/langgraph/templates/ci_failure_summarizer/tests/integration/conftest.py
@@ -100,7 +100,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
         try:
             logger.info("Building image on cluster via build-openshift...")
             build_attempted = True
-            run_make("build-openshift", cwd=agent_dir, timeout=600)
+            run_make("build-openshift", cwd=agent_dir, timeout=900)
 
             logger.info("Deploying to cluster...")
             run_make("deploy", cwd=agent_dir, timeout=300)

--- a/agents/langgraph/templates/human_in_the_loop/tests/integration/test_deployment.py
+++ b/agents/langgraph/templates/human_in_the_loop/tests/integration/test_deployment.py
@@ -57,7 +57,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
     try:
         logger.info("Building image on cluster via build-openshift...")
         build_attempted = True
-        run_make("build-openshift", cwd=agent_dir, timeout=600)
+        run_make("build-openshift", cwd=agent_dir, timeout=900)
 
         logger.info("Deploying to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)

--- a/agents/langgraph/templates/react_agent/tests/integration/test_deployment.py
+++ b/agents/langgraph/templates/react_agent/tests/integration/test_deployment.py
@@ -61,7 +61,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
     try:
         logger.info("Building image on cluster via build-openshift...")
         build_attempted = True
-        run_make("build-openshift", cwd=agent_dir, timeout=600)
+        run_make("build-openshift", cwd=agent_dir, timeout=900)
 
         logger.info("Deploying to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)

--- a/agents/langgraph/templates/react_with_database_memory/tests/integration/conftest.py
+++ b/agents/langgraph/templates/react_with_database_memory/tests/integration/conftest.py
@@ -73,7 +73,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):  # noqa: F811
         try:
             logger.info("Building image on cluster via build-openshift...")
             build_attempted = True
-            run_make("build-openshift", cwd=agent_dir, timeout=600)
+            run_make("build-openshift", cwd=agent_dir, timeout=900)
 
             logger.info("Deploying to cluster...")
             run_make("deploy", cwd=agent_dir, timeout=300)

--- a/agents/llamaindex/templates/websearch_agent/tests/integration/test_deployment.py
+++ b/agents/llamaindex/templates/websearch_agent/tests/integration/test_deployment.py
@@ -61,7 +61,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
     try:
         logger.info("Building image on cluster via build-openshift...")
         build_attempted = True
-        run_make("build-openshift", cwd=agent_dir, timeout=600)
+        run_make("build-openshift", cwd=agent_dir, timeout=900)
 
         logger.info("Deploying to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)

--- a/agents/vanilla_python/templates/openai_responses_agent/tests/integration/test_deployment.py
+++ b/agents/vanilla_python/templates/openai_responses_agent/tests/integration/test_deployment.py
@@ -62,7 +62,7 @@ def deployed_agent(cluster_auth, agent_dir, agent_name):
     try:
         logger.info("Building image on cluster via build-openshift...")
         build_attempted = True
-        run_make("build-openshift", cwd=agent_dir, timeout=600)
+        run_make("build-openshift", cwd=agent_dir, timeout=900)
 
         logger.info("Deploying to cluster...")
         run_make("deploy", cwd=agent_dir, timeout=300)


### PR DESCRIPTION
## Description

QG4 nightly runs failed on Aug 31 (run 33353515650) with 9 of 11 agents timing out at the `build-openshift` step. Investigation showed the bottleneck is **not** `uv pip install` or CPU/memory contention — the Dockerfile builds complete in ~2.5 minutes. The timeout occurs during the **image push to the S3-backed internal registry**: all agents push ~630 MiB images simultaneously (~6.9 GiB total), saturating S3 throughput.

This PR:
- Adds `max-parallel: 3` to the QG4 matrix strategy in both `quality-gates-pipeline.yml` and `agent-deployment-test.yaml`, reducing concurrent S3 pushes from 11 to 3
- Increases the `build-openshift` subprocess timeout from 600s to 900s across all 12 agent integration tests
- Bumps the job-level timeout from 20 to 25 minutes to accommodate the higher subprocess timeout

**Trade-off:** Total QG4 wall-clock time increases from ~8 min (all parallel) to ~28 min (4 batches of 3). This is acceptable for a nightly pipeline.

**Future improvements (out of scope):**
- QG7 redundantly rebuilds the same images QG4 just built — skipping the rebuild would halve S3 writes
- Persisting BuildConfigs between runs would enable layer caching, reducing push sizes from ~630 MiB to ~1-2 MiB per agent

## Jira Ticket

RHAIENG-7217

## Testing

- [x] `make test` passes (run from the affected agent directory)
- [x] Manual testing performed (describe steps below)
- [ ] No testing required (documentation/config change only)

Ran `make test-integration` for `langgraph-react-agent` against the CI cluster (`ci-testing` namespace) from this branch. Build + push + deploy + health check + teardown completed in **2m45s**, well within the new 900s subprocess timeout and 25-min job timeout. See [verification comment](https://github.com/red-hat-data-services/agentic-starter-kits/pull/333#issuecomment-5482647248).

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)

## Review Guidance

- The `max-parallel: 3` and timeout changes are in two workflow files — check both are in sync
- The 12 integration test files all have the same one-line change (`timeout=600` → `timeout=900`)
- The `guardrailed_agent` has a separate `timeout_minutes: '45'` override at the matrix level, which is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)