### PR TITLE
fix(ci): track Quality Gates Pipeline on the CI health dashboard

### DIFF
--- a/.github/scripts/fixtures/ci-runs-sample.json
+++ b/.github/scripts/fixtures/ci-runs-sample.json
@@ -82,10 +82,10 @@
       "run_started_at": "2026-07-05T01:15:18Z"
     }
   ],
-  "agent-deployment-test.yaml": [
+  "quality-gates-pipeline.yml": [
     {
       "id": 10031,
-      "name": "QG4: Agent Deployment Integration Tests",
+      "name": "Quality Gates Pipeline",
       "event": "schedule",
       "head_branch": "main",
       "status": "completed",
@@ -97,7 +97,7 @@
     },
     {
       "id": 10030,
-      "name": "QG4: Agent Deployment Integration Tests",
+      "name": "Quality Gates Pipeline",
       "event": "schedule",
       "head_branch": "main",
       "status": "completed",
@@ -106,6 +106,20 @@
       "created_at": "2026-07-04T03:04:44Z",
       "updated_at": "2026-07-04T03:58:12Z",
       "run_started_at": "2026-07-04T03:04:52Z"
+    }
+  ],
+  "agent-deployment-test.yaml": [
+    {
+      "id": 10032,
+      "name": "QG4: Agent Deployment Integration Tests",
+      "event": "workflow_dispatch",
+      "head_branch": "main",
+      "status": "completed",
+      "conclusion": "success",
+      "html_url": "https://github.com/red-hat-data-services/agentic-starter-kits/actions/runs/10032",
+      "created_at": "2026-07-05T09:12:00Z",
+      "updated_at": "2026-07-05T10:01:33Z",
+      "run_started_at": "2026-07-05T09:12:08Z"
     }
   ]
 }

--- a/.github/scripts/generate_ci_health_page.py
+++ b/.github/scripts/generate_ci_health_page.py
@@ -53,9 +53,14 @@ WORKFLOWS = (
         "description": "Operator, DataScienceCluster, and KServe platform readiness checks.",
     },
     {
+        "file": "quality-gates-pipeline.yml",
+        "name": "Quality Gates Pipeline",
+        "description": "Nightly QG4 deploy/health checks fanning out into QG7 behavioral evals.",
+    },
+    {
         "file": "agent-deployment-test.yaml",
         "name": "QG4: Agent Deployment Integration Tests",
-        "description": "Nightly OpenShift deploy, /health checks, and teardown.",
+        "description": "Manual (workflow_dispatch-only) QG4 deploy/health check run.",
     },
 )
 RELEVANT_EVENTS = frozenset({"push", "schedule", "workflow_dispatch"})

--- a/.github/scripts/generate_ci_health_page.py
+++ b/.github/scripts/generate_ci_health_page.py
@@ -25,43 +25,79 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import yaml
+
 API_ROOT = "https://api.github.com"
-WORKFLOWS = (
+WORKFLOWS_DIR = Path(__file__).resolve().parent.parent / "workflows"
+
+
+class GHWorkflowLoader(yaml.SafeLoader):
+    """YAML loader for GitHub Actions workflow files.
+
+    Disables implicit bool resolution so a bare `on:` key (YAML 1.1 treats
+    on/off/yes/no as booleans) round-trips as the string "on" instead of
+    silently becoming the key `True`.
+    """
+
+
+GHWorkflowLoader.yaml_implicit_resolvers = {
+    key: [(tag, regexp) for tag, regexp in resolvers if tag != "tag:yaml.org,2002:bool"]
+    for key, resolvers in GHWorkflowLoader.yaml_implicit_resolvers.items()
+}
+
+
+def load_workflow_yaml(path: Path) -> dict:
+    return yaml.load(path.read_text(encoding="utf-8"), Loader=GHWorkflowLoader)
+
+
+def _workflow_display_name(file: str) -> str:
+    path = WORKFLOWS_DIR / file
+    name = load_workflow_yaml(path).get("name")
+    if not name:
+        raise ValueError(f"{path} has no top-level 'name:' field")
+    return name
+
+
+_WORKFLOW_SPECS = (
     {
         "file": "code-quality.yml",
-        "name": "Code Quality",
         "description": "Lint, format, and markdown checks on main and PRs.",
     },
     {
         "file": "agent-tests.yml",
-        "name": "Agent Tests",
         "description": "Unit tests for agent templates.",
     },
     {
         "file": "eval-gating.yml",
-        "name": "Inner Loop Gating",
         "description": "Behavioral pytest gating on selected paths.",
     },
     {
         "file": "qg1-cluster-readiness.yml",
-        "name": "QG1: Cluster Readiness",
         "description": "Cluster API, GPU, and namespace readiness checks before downstream gates.",
     },
     {
         "file": "qg2-platform-readiness.yml",
-        "name": "QG2: Platform Readiness",
         "description": "Operator, DataScienceCluster, and KServe platform readiness checks.",
     },
     {
         "file": "quality-gates-pipeline.yml",
-        "name": "Quality Gates Pipeline",
         "description": "Nightly QG4 deploy/health checks fanning out into QG7 behavioral evals.",
     },
     {
         "file": "agent-deployment-test.yaml",
-        "name": "QG4: Agent Deployment Integration Tests",
-        "description": "Manual (workflow_dispatch-only) QG4 deploy/health check run.",
+        "description": (
+            "Ad hoc, manual-only QG4 deploy/health check — not the nightly "
+            "QG4 signal (see Quality Gates Pipeline)."
+        ),
     },
+)
+
+# Each entry's display name is read from its own workflow file's `name:`
+# field rather than duplicated as a literal here, so it can't drift from
+# what GitHub actually uses to match the workflow_run trigger in
+# ci-health-pages.yml.
+WORKFLOWS = tuple(
+    {**spec, "name": _workflow_display_name(spec["file"])} for spec in _WORKFLOW_SPECS
 )
 RELEVANT_EVENTS = frozenset({"push", "schedule", "workflow_dispatch"})
 

--- a/.github/scripts/tests/test_generate_ci_health_page.py
+++ b/.github/scripts/tests/test_generate_ci_health_page.py
@@ -5,6 +5,8 @@ import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import yaml
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from generate_ci_health_page import (  # noqa: E402
     WORKFLOWS,
@@ -20,6 +22,9 @@ from generate_ci_health_page import (  # noqa: E402
 )
 
 FIXTURE = Path(__file__).resolve().parent.parent / "fixtures" / "ci-runs-sample.json"
+CI_HEALTH_PAGES_WORKFLOW = (
+    Path(__file__).resolve().parents[2] / "workflows" / "ci-health-pages.yml"
+)
 
 
 def test_fixture_loads_all_workflows():
@@ -48,13 +53,27 @@ def test_qg1_fixture_entry_is_included():
     assert qg1.latest is not None
 
 
-def test_qg4_latest_failure_is_surfaced():
+def test_quality_gates_pipeline_latest_failure_is_surfaced():
     summaries = summaries_from_fixture(FIXTURE)
-    qg4 = next(
+    pipeline = next(
         item for item in summaries if item.workflow_file == "quality-gates-pipeline.yml"
     )
+    assert pipeline.latest is not None
+    assert pipeline.latest.conclusion == "failure"
+
+
+def test_qg4_manual_dispatch_entry_is_included():
+    summaries = summaries_from_fixture(FIXTURE)
+    qg4 = next(
+        item for item in summaries if item.workflow_file == "agent-deployment-test.yaml"
+    )
+    assert qg4.display_name == "QG4: Agent Deployment Integration Tests"
+    assert (
+        qg4.description
+        == "Manual (workflow_dispatch-only) QG4 deploy/health check run."
+    )
     assert qg4.latest is not None
-    assert qg4.latest.conclusion == "failure"
+    assert qg4.latest.conclusion == "success"
 
 
 def test_pass_rate_ignores_pull_requests():
@@ -171,5 +190,17 @@ def test_main_writes_html(tmp_path):
     content = output.read_text(encoding="utf-8")
     assert "agentic-starter-kits CI Health" in content
     assert "Quality Gates Pipeline" in content
+    assert "QG4: Agent Deployment Integration Tests" in content
     assert "QG1: Cluster Readiness" in content
     assert "QG2: Platform Readiness" in content
+
+
+def test_workflow_names_match_ci_health_pages_trigger_list():
+    workflow_doc = yaml.safe_load(CI_HEALTH_PAGES_WORKFLOW.read_text(encoding="utf-8"))
+    triggered_names = set(workflow_doc[True]["workflow_run"]["workflows"])
+    tracked_names = {workflow["name"] for workflow in WORKFLOWS}
+    assert tracked_names == triggered_names, (
+        "WORKFLOWS in generate_ci_health_page.py must match the workflow_run "
+        "trigger list in ci-health-pages.yml, or the dashboard will silently "
+        "stop updating for the mismatched workflow."
+    )

--- a/.github/scripts/tests/test_generate_ci_health_page.py
+++ b/.github/scripts/tests/test_generate_ci_health_page.py
@@ -24,7 +24,7 @@ FIXTURE = Path(__file__).resolve().parent.parent / "fixtures" / "ci-runs-sample.
 
 def test_fixture_loads_all_workflows():
     summaries = summaries_from_fixture(FIXTURE)
-    assert len(summaries) == 6
+    assert len(summaries) == 7
     assert summaries[0].display_name == "Code Quality"
     assert summaries[0].latest is not None
     assert summaries[0].latest.conclusion == "success"
@@ -51,7 +51,7 @@ def test_qg1_fixture_entry_is_included():
 def test_qg4_latest_failure_is_surfaced():
     summaries = summaries_from_fixture(FIXTURE)
     qg4 = next(
-        item for item in summaries if item.workflow_file == "agent-deployment-test.yaml"
+        item for item in summaries if item.workflow_file == "quality-gates-pipeline.yml"
     )
     assert qg4.latest is not None
     assert qg4.latest.conclusion == "failure"
@@ -112,7 +112,7 @@ def test_workflow_dispatch_on_feature_branch_is_ignored():
 def test_schedule_run_is_always_relevant():
     run = WorkflowRun(
         id=4,
-        name="QG4: Agent Deployment Integration Tests",
+        name="Quality Gates Pipeline",
         event="schedule",
         head_branch="",
         status="completed",
@@ -158,7 +158,7 @@ def test_summaries_from_api_continues_after_workflow_failure(monkeypatch):
     summaries = summaries_from_api(
         "red-hat-data-services/agentic-starter-kits", "token"
     )
-    assert len(summaries) == 6
+    assert len(summaries) == 7
     gating = next(item for item in summaries if item.workflow_file == "eval-gating.yml")
     assert gating.error_message is not None
     assert "404" in gating.error_message
@@ -170,6 +170,6 @@ def test_main_writes_html(tmp_path):
     assert main(["--input", str(FIXTURE), "--output", str(output)]) == 0
     content = output.read_text(encoding="utf-8")
     assert "agentic-starter-kits CI Health" in content
-    assert "QG4: Agent Deployment Integration Tests" in content
+    assert "Quality Gates Pipeline" in content
     assert "QG1: Cluster Readiness" in content
     assert "QG2: Platform Readiness" in content

--- a/.github/scripts/tests/test_generate_ci_health_page.py
+++ b/.github/scripts/tests/test_generate_ci_health_page.py
@@ -5,14 +5,14 @@ import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-import yaml
-
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from generate_ci_health_page import (  # noqa: E402
     WORKFLOWS,
+    WORKFLOWS_DIR,
     WorkflowRun,
     compute_pass_rate,
     is_relevant_run,
+    load_workflow_yaml,
     main,
     render_workflow_card,
     summaries_from_api,
@@ -68,10 +68,7 @@ def test_qg4_manual_dispatch_entry_is_included():
         item for item in summaries if item.workflow_file == "agent-deployment-test.yaml"
     )
     assert qg4.display_name == "QG4: Agent Deployment Integration Tests"
-    assert (
-        qg4.description
-        == "Manual (workflow_dispatch-only) QG4 deploy/health check run."
-    )
+    assert qg4.description.startswith("Ad hoc, manual-only QG4")
     assert qg4.latest is not None
     assert qg4.latest.conclusion == "success"
 
@@ -195,10 +192,18 @@ def test_main_writes_html(tmp_path):
     assert "QG2: Platform Readiness" in content
 
 
-def test_workflow_names_match_ci_health_pages_trigger_list():
-    workflow_doc = yaml.safe_load(CI_HEALTH_PAGES_WORKFLOW.read_text(encoding="utf-8"))
-    triggered_names = set(workflow_doc[True]["workflow_run"]["workflows"])
-    tracked_names = {workflow["name"] for workflow in WORKFLOWS}
+def test_workflow_catalog_names_match_their_source_files_and_trigger_list():
+    trigger_doc = load_workflow_yaml(CI_HEALTH_PAGES_WORKFLOW)
+    triggered_names = set(trigger_doc["on"]["workflow_run"]["workflows"])
+
+    for entry in WORKFLOWS:
+        actual_name = load_workflow_yaml(WORKFLOWS_DIR / entry["file"]).get("name")
+        assert entry["name"] == actual_name, (
+            f"{entry['file']}: catalog name {entry['name']!r} does not match "
+            f"the workflow file's own name: {actual_name!r}"
+        )
+
+    tracked_names = {entry["name"] for entry in WORKFLOWS}
     assert tracked_names == triggered_names, (
         "WORKFLOWS in generate_ci_health_page.py must match the workflow_run "
         "trigger list in ci-health-pages.yml, or the dashboard will silently "

--- a/.github/workflows/ci-health-pages.yml
+++ b/.github/workflows/ci-health-pages.yml
@@ -15,6 +15,7 @@ on:
       - Inner Loop Gating
       - "QG1: Cluster Readiness"
       - "QG2: Platform Readiness"
+      - "Quality Gates Pipeline"
       - "QG4: Agent Deployment Integration Tests"
     types: [completed]
   workflow_dispatch:

--- a/.github/workflows/ci-health-pages.yml
+++ b/.github/workflows/ci-health-pages.yml
@@ -73,6 +73,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install dependencies
+        run: pip install pyyaml
+
       - name: Generate CI health page
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/ci-alert-policy.md
+++ b/docs/ci-alert-policy.md
@@ -20,6 +20,7 @@ repository:
 - `Inner Loop Gating`
 - `QG1: Cluster Readiness`
 - `QG2: Platform Readiness`
+- `Quality Gates Pipeline`
 - `QG4: Agent Deployment Integration Tests`
 
 The current implementation sends alerts only for shared-branch failures:
@@ -104,7 +105,13 @@ marks the remaining signals as non-canonical supporting alerts.
 | `Inner Loop Gating` | `eval-gating.yml` | Canonical | `QG7` | `push` on `main` when matching behavioral/eval paths change, `workflow_dispatch` on `main` | Shared CI route / `@aaet-tooling-experience` |
 | `QG1: Cluster Readiness` | `qg1-cluster-readiness.yml` | Canonical | `QG1` | `schedule`, `workflow_dispatch` on `main` | Shared CI route / `@aaet-tooling-experience` |
 | `QG2: Platform Readiness` | `qg2-platform-readiness.yml` | Canonical | `QG2` | `schedule`, `workflow_dispatch` on `main` | Shared CI route / `@aaet-tooling-experience` |
-| `QG4: Agent Deployment Integration Tests` | `agent-deployment-test.yaml` | Canonical | `QG4` | `schedule`, `workflow_dispatch` on `main` | Shared CI route / `@aaet-tooling-experience` |
+| `Quality Gates Pipeline` | `quality-gates-pipeline.yml` | Canonical | `QG4` / `QG7` | `schedule`, `workflow_dispatch` on `main` | Shared CI route / `@aaet-tooling-experience` |
+| `QG4: Agent Deployment Integration Tests` | `agent-deployment-test.yaml` | Canonical | `QG4` | `workflow_dispatch` on `main` | Shared CI route / `@aaet-tooling-experience` |
+
+`agent-deployment-test.yaml` no longer has a `schedule` trigger — nightly QG4
+now runs inside `Quality Gates Pipeline`. `agent-deployment-test.yaml` is kept
+for manual, QG4-only dispatch (e.g. to check deployment health without also
+running QG7), so it only alerts on a manual `workflow_dispatch` on `main`.
 
 ### Interpretation rules
 

--- a/docs/ci-alert-runbook.md
+++ b/docs/ci-alert-runbook.md
@@ -12,7 +12,12 @@ This runbook covers the shared-branch CI Slack alerts for
 | `Inner Loop Gating` | Canonical | `QG7` | `push` on `main` when matching eval/behavioral paths change, `workflow_dispatch` on `main` |
 | `QG1: Cluster Readiness` | Canonical | `QG1` | `schedule`, `workflow_dispatch` on `main` |
 | `QG2: Platform Readiness` | Canonical | `QG2` | `schedule`, `workflow_dispatch` on `main` |
-| `QG4: Agent Deployment Integration Tests` | Canonical | `QG4` | `schedule`, `workflow_dispatch` on `main` |
+| `Quality Gates Pipeline` | Canonical | `QG4` / `QG7` | `schedule`, `workflow_dispatch` on `main` |
+| `QG4: Agent Deployment Integration Tests` | Canonical | `QG4` | `workflow_dispatch` on `main` |
+
+`agent-deployment-test.yaml` is manual-only (no `schedule` trigger) — nightly
+QG4 alerting comes from `Quality Gates Pipeline`. `agent-deployment-test.yaml`
+only alerts when someone runs it by hand on `main`.
 
 ## Routing and Ownership
 

--- a/docs/ci-health-dashboard.md
+++ b/docs/ci-health-dashboard.md
@@ -13,7 +13,13 @@ The dashboard covers these workflows on `main` and scheduled or manual shared-br
 | `eval-gating.yml` | Inner Loop Gating |
 | `qg1-cluster-readiness.yml` | QG1: Cluster Readiness |
 | `qg2-platform-readiness.yml` | QG2: Platform Readiness |
+| `quality-gates-pipeline.yml` | Quality Gates Pipeline |
 | `agent-deployment-test.yaml` | QG4: Agent Deployment Integration Tests |
+
+`agent-deployment-test.yaml` is `workflow_dispatch`-only (nightly QG4 now runs inside
+`Quality Gates Pipeline`) — expect its card to show "No completed runs" between ad hoc
+manual runs. That's expected, not a recurrence of the staleness bug this dashboard
+previously had.
 
 Pull request runs are excluded from the summary to keep the page focused on shared-branch health.
 
@@ -38,13 +44,14 @@ Responder workflow, dedupe semantics, and validation guidance live in
 
 ## Slack alerts
 
-The same six workflows also send immediate Slack alerts when a shared-branch run fails:
+The same seven workflows also send immediate Slack alerts when a shared-branch run fails:
 
 - `Code Quality`
 - `Agent Tests`
 - `Inner Loop Gating`
 - `QG1: Cluster Readiness`
 - `QG2: Platform Readiness`
+- `Quality Gates Pipeline`
 - `QG4: Agent Deployment Integration Tests`
 
 The event list below is the union of the supported notification triggers across those workflows. Individual workflows do not all define the same trigger set.

--- a/docs/ci-health-dashboard.md
+++ b/docs/ci-health-dashboard.md
@@ -16,10 +16,12 @@ The dashboard covers these workflows on `main` and scheduled or manual shared-br
 | `quality-gates-pipeline.yml` | Quality Gates Pipeline |
 | `agent-deployment-test.yaml` | QG4: Agent Deployment Integration Tests |
 
-`agent-deployment-test.yaml` is `workflow_dispatch`-only (nightly QG4 now runs inside
-`Quality Gates Pipeline`) — expect its card to show "No completed runs" between ad hoc
-manual runs. That's expected, not a recurrence of the staleness bug this dashboard
-previously had.
+`agent-deployment-test.yaml` is an **ad hoc, manual-only** QG4 check, not the
+nightly QG4 signal — nightly QG4 (and QG7) runs inside `Quality Gates
+Pipeline`. Between manual dispatches, expect its card to read "No recent runs
+on `main` or scheduled triggers." (latest run) and "No completed runs in the
+last 7 days" (7-day health). That's expected, not a recurrence of the
+staleness bug this dashboard previously had.
 
 Pull request runs are excluded from the summary to keep the page focused on shared-branch health.
 


### PR DESCRIPTION
## Summary
- The QG4 orchestrator was renamed to `Quality Gates Pipeline` in #328 and now runs nightly via cron; the old standalone `agent-deployment-test.yaml` lost its `schedule` trigger and became `workflow_dispatch`-only.
- The CI health dashboard (`ci-health-pages.yml` / `generate_ci_health_page.py`) only listened for the old standalone workflow's name, so the QG4 section silently stopped updating after the orchestrator was introduced.
- Now the dashboard tracks both: the nightly `Quality Gates Pipeline` run, and the manual-only `QG4: Agent Deployment Integration Tests` dispatch (kept around for one-off QG4 checks without triggering QG7).
- Added a regression test asserting `WORKFLOWS` in `generate_ci_health_page.py` stays in sync with the `workflow_run` trigger list in `ci-health-pages.yml`, to catch this exact class of silent-drift bug in the future.
- Updated `docs/ci-health-dashboard.md` to reflect all 7 tracked workflows and clarify that `agent-deployment-test.yaml`'s card showing "No completed runs" between manual dispatches is expected.

## Test plan
- [x] `pytest .github/scripts/tests/test_generate_ci_health_page.py` — 13 passed
- [x] Regenerated the dashboard from the fixture locally and confirmed both QG4 cards render distinctly
- [x] `ruff check` / `ruff format --check` on changed files

## Follow-up after merge
- Confirm a `Quality Gates Pipeline` or `QG4: Agent Deployment Integration Tests` run triggers a Pages rebuild in production.

Assisted by Claude Sonnet 5