### PR TITLE
feat(react_with_database_memory): add config-driven MLflow GenAI evaluation

### DIFF
--- a/agents/langgraph/templates/react_with_database_memory/.env.example
+++ b/agents/langgraph/templates/react_with_database_memory/.env.example
@@ -23,3 +23,16 @@ POSTGRES_PASSWORD=
 # MLFLOW_TRACKING_INSECURE_TLS=
 # MLFLOW_WORKSPACE=default
 # MLFLOW_TRACKING_AUTH= # Use Kubernetes service account for authentication (if running inside the cluster)
+
+# Optional — Evaluation (only needed for `make eval`)
+# The judge model scores agent responses. Can be the same as the agent's model or a different one.
+# EVAL_JUDGE_MODEL=openai:/gpt-4o-mini
+# EVAL_JUDGE_API_KEY=<your-api-key>
+# EVAL_JUDGE_BASE_URL=https://api.openai.com/v1
+# EVAL_PII_MODEL=openai:/gpt-4.1-mini
+# EVAL_ENABLE_PII=false
+# EVAL_REQUEST_TIMEOUT=60
+# EVAL_TRACE_TIMEOUT=60
+# EVAL_POLL_INTERVAL=4
+DEEPEVAL_TELEMETRY_OPT_OUT=YES
+# AGENT_URL=http://localhost:8000

--- a/agents/langgraph/templates/react_with_database_memory/Makefile
+++ b/agents/langgraph/templates/react_with_database_memory/Makefile
@@ -6,7 +6,7 @@ VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 MODEL          ?= llama3.1:8b
 
-.PHONY: init re-init env ollama ogx-server run-app run-app-fresh run-cli build push build-openshift deploy undeploy test test-integration dry-run help
+.PHONY: init re-init env ollama ogx-server run-app run-app-fresh run-cli build push build-openshift deploy undeploy eval test test-integration dry-run help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-12s %s\n", $$1, $$2}'
@@ -191,6 +191,9 @@ undeploy: ## Remove deployment from cluster
 	fi; \
 	if [ $$helm_status -ne 0 ]; then exit $$helm_status; fi; \
 	exit $$cleanup_status
+
+eval: ## Run MLflow GenAI evaluation
+	@uv run --extra eval python evaluation/run_eval.py
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)

--- a/agents/langgraph/templates/react_with_database_memory/README.md
+++ b/agents/langgraph/templates/react_with_database_memory/README.md
@@ -371,6 +371,157 @@ pytest tests/behavioral/ -v
 
 Skip slow pass@k tests with `-m "not slow"`.
 
+## Evaluation
+
+This template includes a config-driven MLflow GenAI evaluation setup. The eval script reads existing traces from MLflow and scores them using scorers defined in `evaluation/eval_config.yaml`.
+
+### Eval Directory Structure
+
+```text
+evaluation/
+├── eval_config.yaml   # Scorer configuration (core, use-case, guidelines)
+├── eval_data.yaml     # Golden queries with expected results
+├── scorers.py         # Custom scorer definitions (add your own here)
+└── run_eval.py        # Evaluation logic (no need to edit)
+```
+
+### Prerequisites
+
+- Agent must be running with tracing enabled (`MLFLOW_TRACKING_URI` set in `.env`)
+- Complete the Setup steps below
+
+### Setup
+
+**Set environment variables** in `.env`:
+
+```ini
+# Required for eval
+EVAL_JUDGE_MODEL=<provider>:/<model>
+EVAL_JUDGE_API_KEY=<api-key>
+EVAL_JUDGE_BASE_URL=<endpoint-url>  # only needed for OpenAI-compatible endpoints
+```
+
+The judge model format is `<provider>:/<model>`. The eval script automatically sets the correct API key env var based on the provider. Examples:
+
+- **OpenAI:** `EVAL_JUDGE_MODEL=openai:/gpt-4o-mini`, `EVAL_JUDGE_BASE_URL=https://api.openai.com/v1`
+- **vLLM / RHOAI:** `EVAL_JUDGE_MODEL=openai:/<served-model-name>`, `EVAL_JUDGE_BASE_URL=https://<your-vllm-route>/v1`
+- **Anthropic:** `EVAL_JUDGE_MODEL=anthropic:/claude-sonnet-4-20250514` (no `BASE_URL` needed)
+
+### Running Evaluation
+
+1. Add your golden queries and expectations to `evaluation/eval_data.yaml`. Keep queries single-turn — each one starts a fresh conversation thread, so there is no prior context for the agent's database-backed memory to draw on.
+2. Customize the guidelines in `evaluation/eval_config.yaml` for your domain
+3. Start your agent with tracing enabled (`make run-app`) if it's not already running
+4. Run:
+
+   ```bash
+   make eval
+   ```
+
+   This will:
+   - Send each golden query from `eval_data.yaml` to the running agent
+   - Wait for traces to be recorded in MLflow
+   - Attach expectations (e.g., `expected_facts`) to matching traces
+   - Score all traces with the configured scorers
+
+   By default, the eval script connects to the agent at `http://localhost:8000`. To target a deployed agent, set `AGENT_URL` in `.env`:
+
+   ```ini
+   AGENT_URL=https://<your-agent-route>
+   ```
+
+   Request/trace timeouts and poll interval are configurable via `EVAL_REQUEST_TIMEOUT`, `EVAL_TRACE_TIMEOUT`, and `EVAL_POLL_INTERVAL` (all in seconds, default `60`/`60`/`4`) if the defaults don't fit your environment.
+
+### Scorer Configuration
+
+Scorers are configured in `evaluation/eval_config.yaml`, organized into three sections. Scorers in both **core** and **use-case** sections can come from any of three sources:
+
+| Source | `module` value | Example |
+|--------|---------------|---------|
+| MLflow built-in | `mlflow.genai.scorers` | Safety, Correctness |
+| Third-party (any MLflow-integrated framework) | `mlflow.genai.scorers.<framework>` | DeepEval PIILeakage, Phoenix Hallucination |
+| Custom (defined in `scorers.py`) | `scorers` | Your own domain-specific scorers |
+
+#### Core Scorers
+
+Cover universal failure modes. Pre-configured for all agents — remove only with a specific reason.
+
+| Scorer | What it checks |
+|--------|---------------|
+| **Safety** | Responses are free of harmful or toxic content |
+| **RelevanceToQuery** | Responses directly address the user's question |
+| **Completeness** | All parts of the user's request are addressed |
+| **Correctness** | Responses match expected facts (requires `expected_facts` in eval data) |
+| **ToolCallCorrectness** | Agent selects appropriate tools with correct arguments |
+| **ToolCallEfficiency** | No redundant or duplicate tool calls |
+| **PIILeakage** *(opt-in)* | Responses don't leak personally identifiable information |
+
+> **PIILeakage** is disabled by default. Enable it by setting `EVAL_ENABLE_PII=true` in `.env`. It uses DeepEval and defaults to `openai:/gpt-4.1-mini` (override with `EVAL_PII_MODEL`). DeepEval has a known JSON parsing issue with `gpt-4o` — use `gpt-4.1-mini` or `gpt-4o-mini`.
+
+#### Use-case Scorers
+
+Add scorers specific to your agent's domain. Like core scorers, these can come from MLflow, third-party MLflow integrations, or custom definitions in `scorers.py`. Each entry needs a `name` and `module`:
+
+```yaml
+use_case:
+  # MLflow scorer
+  - name: RetrievalGroundedness
+    module: mlflow.genai.scorers
+
+  # Third-party scorer (any MLflow-integrated framework)
+  - name: Faithfulness
+    module: mlflow.genai.scorers.deepeval
+
+  # Custom scorer (defined in scorers.py)
+  - name: my_domain_scorer
+    module: scorers
+```
+
+#### Guidelines
+
+A list of plain-text rules evaluated by the `Guidelines` scorer. Customize these for your agent:
+
+```yaml
+guidelines:
+  - "The response should be helpful and informative"
+  - "The response should not fabricate information"
+  - "The response should cite sources when available"
+```
+
+### Adding a Custom Scorer
+
+1. Define your scorer in `evaluation/scorers.py`:
+
+   ```python
+   from mlflow.entities import Feedback
+   from mlflow.genai.scorers import scorer
+
+   @scorer
+   def my_domain_scorer(*, inputs, outputs, expectations=None, trace=None):
+       """Check domain-specific quality criteria."""
+       # Your scoring logic here
+       return Feedback(value=1.0, rationale="Meets criteria")
+   ```
+
+2. Add it to `evaluation/eval_config.yaml` under `core` or `use_case`:
+
+   ```yaml
+   use_case:
+     - name: my_domain_scorer
+       module: scorers
+   ```
+
+3. Run `make eval` — your scorer will be picked up automatically.
+
+### Viewing Results
+
+Results are logged to MLflow. View them in the MLflow UI under the Traces tab.
+
+### Advanced Evaluation
+
+For failure mode deep-dives, custom scorer patterns, and end-to-end evaluation, see the
+[Agentic Evaluation Enablement Material](https://github.com/red-hat-data-services/red-hat-ai-examples/tree/main/examples/agentic-evaluation).
+
 ## API Endpoints
 
 ### POST /chat/completions

--- a/agents/langgraph/templates/react_with_database_memory/evaluation/eval_config.yaml
+++ b/agents/langgraph/templates/react_with_database_memory/evaluation/eval_config.yaml
@@ -1,0 +1,69 @@
+# Evaluation scorer configuration.
+#
+# Each scorer entry requires:
+#   name:   Class or function name to import
+#   module: Python module to import from
+#
+# Optional:
+#   enabled_by_env: Only load this scorer if the specified env var is set to "true"
+#   model_env:      Read the judge model from this env var instead of EVAL_JUDGE_MODEL
+#
+# Sources:
+#   MLflow scorers:     module: mlflow.genai.scorers
+#   Third-party:        module: mlflow.genai.scorers.<framework> (any MLflow-integrated framework, e.g., deepeval, ragas, phoenix etc.)
+#   Custom (scorers.py): module: scorers (custom built scorers)
+
+scorers:
+  # Core scorers — cover universal failure modes, apply to all agents.
+  # These come pre-configured. Remove only if you have a specific reason.
+  core:
+    - name: Safety
+      module: mlflow.genai.scorers
+
+    - name: RelevanceToQuery
+      module: mlflow.genai.scorers
+
+    - name: Completeness
+      module: mlflow.genai.scorers
+
+    - name: Correctness
+      module: mlflow.genai.scorers
+
+    - name: ToolCallCorrectness
+      module: mlflow.genai.scorers
+
+    - name: ToolCallEfficiency
+      module: mlflow.genai.scorers
+
+    - name: PIILeakage
+      module: mlflow.genai.scorers.deepeval
+      enabled_by_env: EVAL_ENABLE_PII
+      model_env: EVAL_PII_MODEL
+
+  # Use-case specific scorers — add scorers relevant to your agent's domain.
+  # Can be MLflow, third-party, or custom (defined in scorers.py).
+  use_case:
+    # RAG agents — uncomment these:
+    # - name: RetrievalGroundedness
+    #   module: mlflow.genai.scorers
+    #
+    # - name: RetrievalRelevance
+    #   module: mlflow.genai.scorers
+    #
+    # - name: RetrievalSufficiency
+    #   module: mlflow.genai.scorers
+    #
+    # Third-party example:
+    # - name: Faithfulness
+    #   module: mlflow.genai.scorers.deepeval
+    #
+    # Custom scorer (defined in scorers.py):
+    # - name: my_domain_scorer
+    #   module: scorers
+
+  # Domain-specific rules for the Guidelines scorer.
+  # Customize these for your agent's expected behavior.
+  guidelines:
+    - "The response should be helpful and informative"
+    - "The response should not fabricate information"
+    - "The response should stay consistent with earlier turns in the conversation"

--- a/agents/langgraph/templates/react_with_database_memory/evaluation/eval_config.yaml
+++ b/agents/langgraph/templates/react_with_database_memory/evaluation/eval_config.yaml
@@ -64,6 +64,6 @@ scorers:
   # Domain-specific rules for the Guidelines scorer.
   # Customize these for your agent's expected behavior.
   guidelines:
-    - "The response should be helpful and informative"
-    - "The response should not fabricate information"
-    - "The response should stay consistent with earlier turns in the conversation"
+    - "The response should be helpful and directly address the user's question"
+    - "The response should not fabricate information or present uncertain claims as facts"
+    - "The response should use the appropriate tools when needed rather than guessing"

--- a/agents/langgraph/templates/react_with_database_memory/evaluation/eval_data.yaml
+++ b/agents/langgraph/templates/react_with_database_memory/evaluation/eval_data.yaml
@@ -1,0 +1,38 @@
+# Golden queries for MLflow GenAI evaluation.
+#
+# Add your test queries below. Each query is sent to the running agent,
+# and the resulting trace is scored by the configured scorers.
+#
+# Fields:
+#   inputs:       Dict with the user query (required)
+#   expectations: Dict with ground truth (required for Correctness scorer)
+#     expected_facts:    List of facts the response should contain
+#     expected_response: Reference response text
+#
+# Trace-based scorers (ToolCallCorrectness, ToolCallEfficiency)
+# extract data from MLflow traces automatically — no expected tools needed here.
+#
+# Keep queries single-turn — each query starts a fresh conversation thread,
+# so there is no prior context for the agent's database-backed memory to draw on.
+
+queries:
+  # Example: query that requires a tool call
+  # - inputs:
+  #     question: "Your test question here"
+  #   expectations:
+  #     expected_facts:
+  #       - "Expected fact 1"
+  #       - "Expected fact 2"
+
+  # Example: query that should NOT trigger a tool call
+  # - inputs:
+  #     question: "A simple greeting or general question"
+  #   expectations:
+  #     expected_response: "A friendly response without using any tools"
+
+  # Example: edge case
+  # - inputs:
+  #     question: "A query that tests error handling or boundaries"
+  #   expectations:
+  #     expected_facts:
+  #       - "Expected behavior description"

--- a/agents/langgraph/templates/react_with_database_memory/evaluation/run_eval.py
+++ b/agents/langgraph/templates/react_with_database_memory/evaluation/run_eval.py
@@ -1,0 +1,315 @@
+"""MLflow GenAI evaluation script.
+
+Reads existing traces from MLflow and evaluates them using scorers
+configured in eval_config.yaml.
+
+Usage:
+    make eval
+"""
+
+import importlib
+import inspect
+import json
+import os
+import time
+from pathlib import Path
+
+import httpx
+import mlflow
+import yaml
+from dotenv import load_dotenv
+from mlflow.genai.scorers import Guidelines
+
+
+def load_eval_config(path: str | None = None) -> dict:
+    """Load scorer configuration from YAML."""
+    if path is None:
+        path = str(Path(__file__).parent / "eval_config.yaml")
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+def load_eval_data(path: str | None = None) -> list[dict]:
+    """Load golden queries with expectations from YAML."""
+    if path is None:
+        path = str(Path(__file__).parent / "eval_data.yaml")
+    with open(path) as f:
+        data = yaml.safe_load(f) or {}
+    return data.get("queries") or []
+
+
+def _get_int_env(name: str, default: int) -> int:
+    """Read an integer env var, exiting with a friendly message if invalid or negative."""
+    value = os.getenv(name, str(default))
+    try:
+        result = int(value)
+    except ValueError:
+        print(f"ERROR: {name}={value!r} is not a valid integer.")
+        raise SystemExit(1)
+    if result < 0:
+        print(f"ERROR: {name}={result} must not be negative.")
+        raise SystemExit(1)
+    return result
+
+
+def generate_traces(eval_data: list[dict], agent_url: str) -> None:
+    """Send golden queries to the running agent to generate traces."""
+    request_timeout = _get_int_env("EVAL_REQUEST_TIMEOUT", 60)
+    print(f"Sending {len(eval_data)} golden queries to {agent_url}...")
+    for query in eval_data:
+        question = query["inputs"]["question"]
+        try:
+            response = httpx.post(
+                f"{agent_url}/chat/completions",
+                json={
+                    "messages": [{"role": "user", "content": question}],
+                    "stream": False,
+                },
+                timeout=request_timeout,
+            )
+            response.raise_for_status()
+        except httpx.ConnectError:
+            print(
+                f"\nERROR: Could not connect to agent at {agent_url}."
+                "\nIs the agent running? Start it with: make run-app"
+            )
+            raise SystemExit(1)
+        except httpx.TimeoutException:
+            print(
+                f"\nERROR: Agent at {agent_url} did not respond within {request_timeout}s."
+                "\nThe agent may be overloaded or the model endpoint may be slow."
+            )
+            raise SystemExit(1)
+        except httpx.HTTPStatusError as e:
+            print(f"\nERROR: Agent returned HTTP {e.response.status_code}.")
+            print("Check the agent logs for details.")
+            raise SystemExit(1)
+        except httpx.RequestError as e:
+            print(f"\nERROR: Request to {agent_url} failed: {e}")
+            raise SystemExit(1)
+        print(f"  -> {question}")
+    print(f"Generated {len(eval_data)} traces.\n")
+
+
+def _extract_question(trace):
+    """Extract the user question from a trace's request data."""
+    try:
+        request = json.loads(trace.data.request)
+        return request["messages"][0]["content"]
+    except (json.JSONDecodeError, KeyError, IndexError, TypeError):
+        return None
+
+
+def attach_expectations(traces, eval_data):
+    """Match traces to golden queries by content and log expectations.
+
+    Each golden query's question is matched against the question extracted
+    from trace.data.request using exact string comparison. This is immune
+    to interleaved traces from concurrent agent traffic.
+
+    Returns the set of trace IDs that matched a golden query.
+    """
+    matched_ids = set()
+
+    for query in eval_data:
+        question = query["inputs"]["question"]
+        for trace in traces:
+            if trace.info.trace_id in matched_ids:
+                continue
+            if _extract_question(trace) == question:
+                expectations = query.get("expectations", {})
+                for name, value in expectations.items():
+                    mlflow.log_expectation(
+                        trace_id=trace.info.trace_id,
+                        name=name,
+                        value=value,
+                    )
+                matched_ids.add(trace.info.trace_id)
+                break
+
+    print(
+        f"Matched {len(matched_ids)}/{len(traces)} traces to golden queries with expectations."
+    )
+    return matched_ids
+
+
+def resolve_scorer(entry: dict, judge_model: str):
+    """Resolve a scorer entry from config into a scorer instance."""
+    env_flag = entry.get("enabled_by_env")
+    if env_flag and os.getenv(env_flag, "").lower() != "true":
+        return None
+
+    model = judge_model
+    if entry.get("model_env"):
+        model = os.getenv(entry["model_env"], model)
+
+    module = importlib.import_module(entry["module"])
+    cls_or_obj = getattr(module, entry["name"])
+
+    if inspect.isclass(cls_or_obj):
+        try:
+            return cls_or_obj(model=model)
+        except TypeError:
+            return cls_or_obj()
+    return cls_or_obj
+
+
+def _add_scorer(scorers: list, entry: dict, judge_model: str) -> None:
+    """Resolve a scorer entry and append it, skipping with a warning on config errors."""
+    try:
+        s = resolve_scorer(entry, judge_model)
+    except (ModuleNotFoundError, AttributeError, TypeError) as e:
+        name = entry.get("name") if isinstance(entry, dict) else "<invalid entry>"
+        print(f"WARNING: Could not load scorer '{name}': {e}. Skipping.")
+        return
+    if s:
+        scorers.append(s)
+
+
+def get_scorers(config: dict, judge_model: str) -> list:
+    """Build the scorer list from eval_config.yaml."""
+    scorers = []
+    scorer_config = config.get("scorers", {})
+
+    for entry in scorer_config.get("core") or []:
+        _add_scorer(scorers, entry, judge_model)
+
+    for entry in scorer_config.get("use_case") or []:
+        _add_scorer(scorers, entry, judge_model)
+
+    guidelines = scorer_config.get("guidelines") or []
+    if guidelines:
+        scorers.append(
+            Guidelines(
+                name="domain_guidelines",
+                model=judge_model,
+                guidelines=guidelines,
+            )
+        )
+
+    return scorers
+
+
+def main():
+    """Read traces from MLflow, attach expectations, and evaluate with scorers."""
+    load_dotenv()
+
+    judge_model = os.getenv("EVAL_JUDGE_MODEL", "openai:/gpt-4o-mini")
+    judge_api_key = os.getenv("EVAL_JUDGE_API_KEY")
+    judge_base_url = os.getenv("EVAL_JUDGE_BASE_URL")
+    provider = judge_model.split(":/")[0] if ":/" in judge_model else "openai"
+
+    if judge_api_key:
+        os.environ[f"{provider.upper()}_API_KEY"] = judge_api_key
+    if judge_base_url:
+        env_var = f"{provider.upper()}_BASE_URL"
+        os.environ[env_var] = judge_base_url
+        print(f"  Set {env_var} for judge model base URL")
+
+    tracking_uri = os.getenv("MLFLOW_TRACKING_URI")
+    if not tracking_uri:
+        print("ERROR: MLFLOW_TRACKING_URI is not set. Cannot read traces.")
+        print("Set it in .env and ensure the agent has been run with tracing enabled.")
+        return
+
+    mlflow.set_tracking_uri(tracking_uri)
+
+    experiment_name = os.getenv("MLFLOW_EXPERIMENT_NAME")
+    if not experiment_name:
+        print("ERROR: MLFLOW_EXPERIMENT_NAME is not set.")
+        return
+
+    experiment = mlflow.get_experiment_by_name(experiment_name)
+    if experiment is None:
+        print(f"ERROR: Experiment '{experiment_name}' not found on MLflow server.")
+        print("Run the agent first to create traces, then re-run eval.")
+        return
+
+    mlflow.set_experiment(experiment_name)
+
+    config = load_eval_config()
+    scorers = get_scorers(config, judge_model)
+    print(f"Loaded {len(scorers)} scorers from eval_config.yaml.")
+
+    eval_data = load_eval_data()
+    agent_url = os.getenv("AGENT_URL", "http://localhost:8000")
+
+    existing = mlflow.search_traces(
+        locations=[experiment.experiment_id],
+        return_type="list",
+        max_results=1,
+        order_by=["timestamp_ms DESC"],
+    )
+    baseline_ms = existing[0].info.timestamp_ms if existing else 0
+
+    if eval_data:
+        generate_traces(eval_data, agent_url)
+
+    expected_count = len(eval_data) if eval_data else 0
+    trace_timeout = _get_int_env("EVAL_TRACE_TIMEOUT", 60)
+    poll_interval = max(_get_int_env("EVAL_POLL_INTERVAL", 4), 1)
+    max_attempts = max(trace_timeout // poll_interval, 1)
+    golden_questions = (
+        {q["inputs"]["question"] for q in eval_data} if eval_data else set()
+    )
+
+    traces = []
+    for attempt in range(max_attempts):
+        traces = mlflow.search_traces(
+            locations=[experiment.experiment_id],
+            return_type="list",
+            filter_string=f"trace.timestamp_ms > {baseline_ms}",
+        )
+        if len(traces) >= expected_count:
+            matched = [t for t in traces if _extract_question(t) in golden_questions]
+            if len(matched) >= expected_count:
+                break
+        time.sleep(poll_interval)
+
+    if len(traces) < expected_count and expected_count > 0:
+        print(
+            f"WARNING: Expected {expected_count} traces but only found "
+            f"{len(traces)} after {trace_timeout}s. Some queries may not have "
+            f"been recorded."
+        )
+
+    if not traces:
+        print(f"No traces found in experiment '{experiment_name}' for this run.")
+        print("Ensure the agent is running with tracing enabled, then re-run eval.")
+        return
+
+    print(f"Found {len(traces)} traces from this run to evaluate.")
+
+    if eval_data:
+        matched_ids = attach_expectations(traces, eval_data)
+        traces = mlflow.search_traces(
+            locations=[experiment.experiment_id],
+            return_type="list",
+            filter_string=f"trace.timestamp_ms > {baseline_ms}",
+        )
+        traces = [t for t in traces if t.info.trace_id in matched_ids]
+
+        if not traces:
+            print("WARNING: No traces matched golden queries. Skipping evaluation.")
+            print("This can happen if traces were not fully written when matching ran.")
+            return
+
+    print(f"Evaluating {len(traces)} traces with {len(scorers)} scorers...")
+
+    with mlflow.start_run(run_name="eval-run"):
+        results = mlflow.genai.evaluate(
+            data=traces,
+            scorers=scorers,
+        )
+
+    print("\n" + "=" * 60)
+    print("EVALUATION RESULTS")
+    print("=" * 60)
+    for metric_name, value in sorted(results.metrics.items()):
+        print(f"  {metric_name}: {value}")
+    print("=" * 60)
+    print(f"\nDetailed results logged to MLflow experiment: {experiment_name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/agents/langgraph/templates/react_with_database_memory/evaluation/run_eval.py
+++ b/agents/langgraph/templates/react_with_database_memory/evaluation/run_eval.py
@@ -148,9 +148,13 @@ def resolve_scorer(entry: dict, judge_model: str):
 
     if inspect.isclass(cls_or_obj):
         try:
-            return cls_or_obj(model=model)
-        except TypeError:
-            return cls_or_obj()
+            init_params = inspect.signature(cls_or_obj.__init__).parameters
+        except (TypeError, ValueError):
+            init_params = {}
+        accepts_model = "model" in init_params or any(
+            p.kind == inspect.Parameter.VAR_KEYWORD for p in init_params.values()
+        )
+        return cls_or_obj(model=model) if accepts_model else cls_or_obj()
     return cls_or_obj
 
 
@@ -210,20 +214,20 @@ def main():
     if not tracking_uri:
         print("ERROR: MLFLOW_TRACKING_URI is not set. Cannot read traces.")
         print("Set it in .env and ensure the agent has been run with tracing enabled.")
-        return
+        raise SystemExit(1)
 
     mlflow.set_tracking_uri(tracking_uri)
 
     experiment_name = os.getenv("MLFLOW_EXPERIMENT_NAME")
     if not experiment_name:
         print("ERROR: MLFLOW_EXPERIMENT_NAME is not set.")
-        return
+        raise SystemExit(1)
 
     experiment = mlflow.get_experiment_by_name(experiment_name)
     if experiment is None:
         print(f"ERROR: Experiment '{experiment_name}' not found on MLflow server.")
         print("Run the agent first to create traces, then re-run eval.")
-        return
+        raise SystemExit(1)
 
     mlflow.set_experiment(experiment_name)
 
@@ -232,6 +236,19 @@ def main():
     print(f"Loaded {len(scorers)} scorers from eval_config.yaml.")
 
     eval_data = load_eval_data()
+    if not eval_data:
+        print("ERROR: No golden queries in evaluation/eval_data.yaml.")
+        print("Add at least one query under 'queries:' before running make eval.")
+        raise SystemExit(1)
+
+    golden_questions = {q["inputs"]["question"] for q in eval_data}
+    if len(golden_questions) < len(eval_data):
+        dupes = len(eval_data) - len(golden_questions)
+        print(
+            f"WARNING: eval_data.yaml contains {dupes} duplicate question(s). "
+            f"Only {len(golden_questions)} unique queries will be sent and matched."
+        )
+
     agent_url = os.getenv("AGENT_URL", "http://localhost:8000")
 
     existing = mlflow.search_traces(
@@ -242,16 +259,12 @@ def main():
     )
     baseline_ms = existing[0].info.timestamp_ms if existing else 0
 
-    if eval_data:
-        generate_traces(eval_data, agent_url)
+    generate_traces(eval_data, agent_url)
 
-    expected_count = len(eval_data) if eval_data else 0
+    expected_count = len(golden_questions)
     trace_timeout = _get_int_env("EVAL_TRACE_TIMEOUT", 60)
     poll_interval = max(_get_int_env("EVAL_POLL_INTERVAL", 4), 1)
     max_attempts = max(trace_timeout // poll_interval, 1)
-    golden_questions = (
-        {q["inputs"]["question"] for q in eval_data} if eval_data else set()
-    )
 
     traces = []
     for attempt in range(max_attempts):
@@ -280,19 +293,18 @@ def main():
 
     print(f"Found {len(traces)} traces from this run to evaluate.")
 
-    if eval_data:
-        matched_ids = attach_expectations(traces, eval_data)
-        traces = mlflow.search_traces(
-            locations=[experiment.experiment_id],
-            return_type="list",
-            filter_string=f"trace.timestamp_ms > {baseline_ms}",
-        )
-        traces = [t for t in traces if t.info.trace_id in matched_ids]
+    matched_ids = attach_expectations(traces, eval_data)
+    traces = mlflow.search_traces(
+        locations=[experiment.experiment_id],
+        return_type="list",
+        filter_string=f"trace.timestamp_ms > {baseline_ms}",
+    )
+    traces = [t for t in traces if t.info.trace_id in matched_ids]
 
-        if not traces:
-            print("WARNING: No traces matched golden queries. Skipping evaluation.")
-            print("This can happen if traces were not fully written when matching ran.")
-            return
+    if not traces:
+        print("WARNING: No traces matched golden queries. Skipping evaluation.")
+        print("This can happen if traces were not fully written when matching ran.")
+        return
 
     print(f"Evaluating {len(traces)} traces with {len(scorers)} scorers...")
 

--- a/agents/langgraph/templates/react_with_database_memory/evaluation/scorers.py
+++ b/agents/langgraph/templates/react_with_database_memory/evaluation/scorers.py
@@ -1,0 +1,19 @@
+"""Custom scorers for this agent.
+
+Define your scorers here and add their function name to eval_config.yaml
+under scorers.core or scorers.use_case to activate them.
+
+See: https://mlflow.org/docs/latest/genai/eval-monitor/scorers/custom
+"""
+
+from mlflow.genai.scorers import scorer  # noqa: F401
+
+# Example:
+#
+# from mlflow.entities import Feedback
+#
+# @scorer
+# def my_domain_scorer(*, inputs, outputs, expectations=None, trace=None):
+#     """Check domain-specific quality criteria."""
+#     # Your scoring logic here
+#     return Feedback(value=1.0, rationale="Meets criteria")

--- a/agents/langgraph/templates/react_with_database_memory/pyproject.toml
+++ b/agents/langgraph/templates/react_with_database_memory/pyproject.toml
@@ -37,6 +37,12 @@ tracing = [
 dev = [
     "pytest>=9.0.2",
 ]
+eval = [
+    "mlflow[kubernetes]>=3.11.0",
+    "pyyaml>=6.0",
+    "httpx>=0.27",
+    "deepeval>=4.2,<5",
+]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/agents/langgraph/templates/react_with_database_memory/tests/test_eval.py
+++ b/agents/langgraph/templates/react_with_database_memory/tests/test_eval.py
@@ -1,0 +1,295 @@
+"""Tests for evaluation/run_eval.py — config loading, data loading, scorer resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip(
+    "mlflow", reason="eval dependencies not installed (install with --extra eval)"
+)
+
+import json  # noqa: E402
+import sys  # noqa: E402
+import textwrap  # noqa: E402
+from pathlib import Path  # noqa: E402
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+import yaml  # noqa: E402
+
+EVAL_DIR = Path(__file__).resolve().parents[1] / "evaluation"
+sys.path.insert(0, str(EVAL_DIR.parent))
+
+from evaluation.run_eval import (  # noqa: E402
+    attach_expectations,
+    get_scorers,
+    load_eval_config,
+    load_eval_data,
+    resolve_scorer,
+)
+
+# ---------------------------------------------------------------------------
+# load_eval_config
+# ---------------------------------------------------------------------------
+
+
+class TestLoadEvalConfig:
+    def test_loads_default_config(self) -> None:
+        config = load_eval_config()
+        assert "scorers" in config
+        assert "core" in config["scorers"]
+        assert "guidelines" in config["scorers"]
+
+    def test_loads_from_custom_path(self, tmp_path: Path) -> None:
+        custom = tmp_path / "custom.yaml"
+        custom.write_text(
+            yaml.dump({"scorers": {"core": [], "use_case": [], "guidelines": []}})
+        )
+        config = load_eval_config(str(custom))
+        assert config["scorers"]["core"] == []
+
+    def test_core_scorers_have_name_and_module(self) -> None:
+        config = load_eval_config()
+        for entry in config["scorers"]["core"]:
+            assert "name" in entry, f"Missing 'name' in core scorer: {entry}"
+            assert "module" in entry, f"Missing 'module' in core scorer: {entry}"
+
+
+# ---------------------------------------------------------------------------
+# load_eval_data
+# ---------------------------------------------------------------------------
+
+
+class TestLoadEvalData:
+    def test_returns_empty_list_when_queries_is_none(self, tmp_path: Path) -> None:
+        """Regression: YAML `queries:` with no items parses as None, not []."""
+        data_file = tmp_path / "eval_data.yaml"
+        data_file.write_text("queries:\n")
+        result = load_eval_data(str(data_file))
+        assert result == []
+
+    def test_returns_empty_list_when_key_missing(self, tmp_path: Path) -> None:
+        data_file = tmp_path / "eval_data.yaml"
+        data_file.write_text("other_key: value\n")
+        result = load_eval_data(str(data_file))
+        assert result == []
+
+    def test_returns_queries_list(self, tmp_path: Path) -> None:
+        data_file = tmp_path / "eval_data.yaml"
+        data_file.write_text(
+            textwrap.dedent("""\
+                queries:
+                  - inputs:
+                      question: "What is 2+2?"
+                    expectations:
+                      expected_facts:
+                        - "4"
+            """)
+        )
+        result = load_eval_data(str(data_file))
+        assert len(result) == 1
+        assert result[0]["inputs"]["question"] == "What is 2+2?"
+
+    def test_loads_default_placeholder_data(self) -> None:
+        result = load_eval_data()
+        assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# resolve_scorer
+# ---------------------------------------------------------------------------
+
+
+class TestResolveScorer:
+    def test_skips_scorer_when_env_flag_not_set(self) -> None:
+        entry = {
+            "name": "PIILeakage",
+            "module": "mlflow.genai.scorers.deepeval",
+            "enabled_by_env": "EVAL_ENABLE_PII",
+        }
+        with patch.dict("os.environ", {}, clear=True):
+            result = resolve_scorer(entry, "openai:/gpt-4o-mini")
+        assert result is None
+
+    def test_loads_scorer_when_env_flag_is_true(self) -> None:
+        captured = {}
+
+        class FakePIILeakage:
+            def __init__(self, model):
+                captured["model"] = model
+
+        mock_module = MagicMock()
+        mock_module.PIILeakage = FakePIILeakage
+
+        entry = {
+            "name": "PIILeakage",
+            "module": "mlflow.genai.scorers.deepeval",
+            "enabled_by_env": "EVAL_ENABLE_PII",
+        }
+        with (
+            patch.dict("os.environ", {"EVAL_ENABLE_PII": "true"}, clear=True),
+            patch("importlib.import_module", return_value=mock_module),
+        ):
+            result = resolve_scorer(entry, "openai:/gpt-4o-mini")
+        assert isinstance(result, FakePIILeakage)
+        assert captured["model"] == "openai:/gpt-4o-mini"
+
+    def test_uses_model_env_override(self) -> None:
+        captured = {}
+
+        class FakePIILeakage:
+            def __init__(self, model):
+                captured["model"] = model
+
+        mock_module = MagicMock()
+        mock_module.PIILeakage = FakePIILeakage
+
+        entry = {
+            "name": "PIILeakage",
+            "module": "mlflow.genai.scorers.deepeval",
+            "enabled_by_env": "EVAL_ENABLE_PII",
+            "model_env": "EVAL_PII_MODEL",
+        }
+        with (
+            patch.dict(
+                "os.environ",
+                {"EVAL_ENABLE_PII": "true", "EVAL_PII_MODEL": "openai:/gpt-4.1-mini"},
+                clear=True,
+            ),
+            patch("importlib.import_module", return_value=mock_module),
+        ):
+            resolve_scorer(entry, "openai:/gpt-4o-mini")
+        assert captured["model"] == "openai:/gpt-4.1-mini"
+
+    def test_custom_scorer_function_not_called_with_model(self) -> None:
+        """Regression: @scorer decorated functions don't accept model= argument."""
+
+        def my_custom_scorer():
+            pass
+
+        mock_module = MagicMock()
+        mock_module.my_custom_scorer = my_custom_scorer
+
+        entry = {"name": "my_custom_scorer", "module": "scorers"}
+        with patch("importlib.import_module", return_value=mock_module):
+            result = resolve_scorer(entry, "openai:/gpt-4o-mini")
+        assert result is my_custom_scorer
+
+    def test_class_scorer_instantiated_with_model(self) -> None:
+        mock_class = type("MockScorer", (), {"__init__": lambda self, model: None})
+        mock_module = MagicMock()
+        mock_module.Safety = mock_class
+
+        entry = {"name": "Safety", "module": "mlflow.genai.scorers"}
+        with patch("importlib.import_module", return_value=mock_module):
+            result = resolve_scorer(entry, "openai:/gpt-4o-mini")
+        assert isinstance(result, mock_class)
+
+
+# ---------------------------------------------------------------------------
+# get_scorers
+# ---------------------------------------------------------------------------
+
+
+class TestGetScorers:
+    def test_includes_guidelines_scorer(self) -> None:
+        config = {
+            "scorers": {
+                "core": [],
+                "use_case": [],
+                "guidelines": ["Be helpful", "Be safe"],
+            }
+        }
+        scorers = get_scorers(config, "openai:/gpt-4o-mini")
+        assert len(scorers) == 1
+        assert scorers[0].name == "domain_guidelines"
+
+    def test_empty_guidelines_skips_scorer(self) -> None:
+        config = {"scorers": {"core": [], "use_case": [], "guidelines": []}}
+        scorers = get_scorers(config, "openai:/gpt-4o-mini")
+        assert len(scorers) == 0
+
+    def test_none_use_case_handled(self) -> None:
+        config = {"scorers": {"core": [], "use_case": None, "guidelines": []}}
+        scorers = get_scorers(config, "openai:/gpt-4o-mini")
+        assert scorers == []
+
+    def test_missing_scorers_key_handled(self) -> None:
+        """Regression: empty YAML returns {}, bracket access to 'scorers' crashes."""
+        config = {}
+        scorers = get_scorers(config, "openai:/gpt-4o-mini")
+        assert scorers == []
+
+
+# ---------------------------------------------------------------------------
+# attach_expectations
+# ---------------------------------------------------------------------------
+
+
+def _make_trace(trace_id: str, timestamp_ms: int, question: str = "") -> MagicMock:
+    """Create a mock trace with the given ID, timestamp, and request content."""
+    trace = MagicMock()
+    trace.info.trace_id = trace_id
+    trace.info.timestamp_ms = timestamp_ms
+    trace.data.request = json.dumps({"messages": [{"content": question}]})
+    return trace
+
+
+class TestAttachExpectations:
+    def test_matches_by_content(self) -> None:
+        """Traces are matched to eval_data by question content."""
+        traces = [
+            _make_trace("t1", 1000, "Q1"),
+            _make_trace("t2", 2000, "Q2"),
+            _make_trace("t3", 3000, "Q3"),
+        ]
+        eval_data = [
+            {"inputs": {"question": "Q1"}, "expectations": {"expected_facts": ["A1"]}},
+            {"inputs": {"question": "Q2"}, "expectations": {"expected_facts": ["A2"]}},
+            {"inputs": {"question": "Q3"}, "expectations": {"expected_facts": ["A3"]}},
+        ]
+        with patch("evaluation.run_eval.mlflow") as mock_mlflow:
+            matched_ids = attach_expectations(traces, eval_data)
+
+        assert matched_ids == {"t1", "t2", "t3"}
+        assert mock_mlflow.log_expectation.call_count == 3
+
+    def test_ignores_unrelated_traces(self) -> None:
+        """Traces that don't match any golden query are skipped."""
+        traces = [
+            _make_trace("t1", 1000, "Q1"),
+            _make_trace("stray", 1500, "Some other question"),
+            _make_trace("t2", 2000, "Q2"),
+        ]
+        eval_data = [
+            {"inputs": {"question": "Q1"}, "expectations": {"expected_facts": ["A1"]}},
+            {"inputs": {"question": "Q2"}, "expectations": {"expected_facts": ["A2"]}},
+        ]
+        with patch("evaluation.run_eval.mlflow") as mock_mlflow:
+            matched_ids = attach_expectations(traces, eval_data)
+
+        assert matched_ids == {"t1", "t2"}
+        assert "stray" not in matched_ids
+        assert mock_mlflow.log_expectation.call_count == 2
+
+    def test_more_queries_than_traces(self) -> None:
+        """If fewer traces than queries, only match what we have."""
+        traces = [_make_trace("t1", 1000, "Q1")]
+        eval_data = [
+            {"inputs": {"question": "Q1"}, "expectations": {"expected_facts": ["A1"]}},
+            {"inputs": {"question": "Q2"}, "expectations": {"expected_facts": ["A2"]}},
+        ]
+        with patch("evaluation.run_eval.mlflow"):
+            matched_ids = attach_expectations(traces, eval_data)
+
+        assert matched_ids == {"t1"}
+
+    def test_query_without_expectations(self) -> None:
+        """Queries with no expectations still match (trace ID tracked)."""
+        traces = [_make_trace("t1", 1000, "Q1")]
+        eval_data = [{"inputs": {"question": "Q1"}}]
+
+        with patch("evaluation.run_eval.mlflow") as mock_mlflow:
+            matched_ids = attach_expectations(traces, eval_data)
+
+        assert matched_ids == {"t1"}
+        mock_mlflow.log_expectation.assert_not_called()

--- a/agents/langgraph/templates/react_with_database_memory/uv.lock
+++ b/agents/langgraph/templates/react_with_database_memory/uv.lock
@@ -130,6 +130,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "blinker"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -390,6 +399,45 @@ wheels = [
 ]
 
 [[package]]
+name = "deepeval"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "grpcio" },
+    { name = "jinja2" },
+    { name = "nest-asyncio" },
+    { name = "openai" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "portalocker" },
+    { name = "posthog" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyfiglet" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-repeat" },
+    { name = "pytest-rerunfailures" },
+    { name = "pytest-xdist" },
+    { name = "python-dotenv" },
+    { name = "questionary" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "setuptools" },
+    { name = "tabulate" },
+    { name = "tenacity" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "wheel" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/95/44596d1e9853756346b4f82f6d3fca9d3a35dc421f253b89382544fb40f1/deepeval-4.2.0.tar.gz", hash = "sha256:07840ef5bc6db3242866ffae0969cca7cafe4a8c3e4e19e3a508283053a0b968", size = 855681, upload-time = "2026-08-24T21:54:17.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/09/18975670bcabf2fca174621db1f95bee79c091de1df0b6395e02b1f491b5/deepeval-4.2.0-py3-none-any.whl", hash = "sha256:7e10ea7ffdbe5506fde9e981c76184134079b586ef6bfc78049cd78112083a0e", size = 1216872, upload-time = "2026-08-24T21:54:19.532Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -410,6 +458,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
+name = "durationpy"
+version = "0.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/5d/5f8571bd5dedc80863191621ac4be001f3f3dd8315d2ec078705dab7dec1/durationpy-0.11.tar.gz", hash = "sha256:181898e1ae282e288f0a2291829656bf1b6b3aadf30a97993b85db4943642905", size = 3582, upload-time = "2026-08-26T13:56:00.991Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/c4/ebdf7837bc4ef6fd98cfb013c28855bb358467bf86c1af011bbc21e21df0/durationpy-0.11-py3-none-any.whl", hash = "sha256:a739fe2b8972c250ff72f8e2c488d18cf25f7b852f49ee76048775d5171df30c", size = 4133, upload-time = "2026-08-26T13:55:59.456Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -926,6 +992,27 @@ wheels = [
 ]
 
 [[package]]
+name = "kubernetes"
+version = "36.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "certifi" },
+    { name = "durationpy" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "six" },
+    { name = "urllib3" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/57/b07b96353f902aa1bdbe00e878e3a12a137977d03a962479785576aa8ec9/kubernetes-36.0.3.tar.gz", hash = "sha256:36993ed25ce59b789c9341473a228fcf268504a2fec7c2b2b1531d73072e5ce7", size = 2337528, upload-time = "2026-07-13T20:38:12.128Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/30/a96d47df739689ac0001ade0afefc16e3b477fc2fb426b568515fdc8afce/kubernetes-36.0.3-py2.py3-none-any.whl", hash = "sha256:8fde9241c4b298e6374a069dcf728359b4e72c2fb29489a975ba4e1c047cf10f", size = 4618066, upload-time = "2026-07-13T20:38:10.172Z" },
+]
+
+[[package]]
 name = "langchain"
 version = "1.2.18"
 source = { registry = "https://pypi.org/simple" }
@@ -1089,6 +1176,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1170,6 +1269,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "milvus-lite"
 version = "2.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1212,6 +1320,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/69/d71afc475fa7e7b22bb27392247d2a3015c9da202dea44f150a54be4bd67/mlflow-3.13.0.tar.gz", hash = "sha256:a95198d592a8a15fad3db7f56b228acc9422c09f0daa7c6c976a9996ab73c3e2", size = 10086808, upload-time = "2026-06-01T05:55:09.555Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/1f/d44140128356f2f5db37f9fb4d9da31123d839d49f3fe00a079cd35bfe20/mlflow-3.13.0-py3-none-any.whl", hash = "sha256:7ca9cb2f623f300dabadaf5e985c85af77c5db3d7c36f56769d22c101b132f6c", size = 10788121, upload-time = "2026-06-01T05:55:06.86Z" },
+]
+
+[package.optional-dependencies]
+kubernetes = [
+    { name = "kubernetes" },
 ]
 
 [[package]]
@@ -1328,6 +1441,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1365,6 +1487,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008", size = 6083477, upload-time = "2026-03-29T13:20:20.195Z" },
     { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8", size = 12457487, upload-time = "2026-03-29T13:20:22.946Z" },
     { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233", size = 10292002, upload-time = "2026-03-29T13:20:25.909Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
 ]
 
 [[package]]
@@ -1599,6 +1730,30 @@ wheels = [
 ]
 
 [[package]]
+name = "portalocker"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/8e/27672cd2dde9d2345ead0352146a401be4ec0af132be86ca7a2db24afb09/portalocker-4.3.0.tar.gz", hash = "sha256:69bf8e46769d66eb0a23219b9550253d2c3b5f03400202a2333784c1e6395e32", size = 263582, upload-time = "2026-08-25T18:05:20.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/76/57be9bb352b3f91c80671a7b7ce2cd51f99ad324c89df82a098df9b9e609/portalocker-4.3.0-py3-none-any.whl", hash = "sha256:aa91709ccfc322b8225171392d64a2f9fc833f15f5ab741cfba6d3fba285ce31", size = 129554, upload-time = "2026-08-25T18:05:18.64Z" },
+]
+
+[[package]]
+name = "posthog"
+version = "7.45.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/57/dc169d6b05f3ea486f0a6b74deb08961687f3cd1eb36bf72cf208b0325e6/posthog-7.45.3.tar.gz", hash = "sha256:98d79f116c68c4e710ad6f97de6d66cb384347261b9046961e41e3a71122485d", size = 506164, upload-time = "2026-09-01T10:34:01.985Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/ff/b8cd7a5650b40335f05321e7124e7094bf3979bfa145ab6e8289cec65153/posthog-7.45.3-py3-none-any.whl", hash = "sha256:92641e86198005438daa2f83ae46f2bcd2bb5d43a34b7d63900d471239c6c5ac", size = 598437, upload-time = "2026-09-01T10:34:00.027Z" },
+]
+
+[[package]]
 name = "prettytable"
 version = "3.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1608,6 +1763,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892, upload-time = "2025-11-14T17:33:20.212Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/8c/83087ebc47ab0396ce092363001fa37c17153119ee282700c0713a195853/prettytable-3.17.0-py3-none-any.whl", hash = "sha256:aad69b294ddbe3e1f95ef8886a060ed1666a0b83018bbf56295f6f226c43d287", size = 34433, upload-time = "2025-11-14T17:33:19.093Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.53"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ea/39b988c938f75cb75d7045b5c69f8bfed47ee2152c8837fb403de29d6fb8/prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6", size = 435492, upload-time = "2026-07-26T20:56:14.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2", size = 392288, upload-time = "2026-07-26T20:56:12.512Z" },
 ]
 
 [[package]]
@@ -1867,6 +2034,29 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
+]
+
+[[package]]
+name = "pyfiglet"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/e3/0a86276ad2c383ce08d76110a8eec2fe22e7051c4b8ba3fa163a0b08c428/pyfiglet-1.0.4.tar.gz", hash = "sha256:db9c9940ed1bf3048deff534ed52ff2dafbbc2cd7610b17bb5eca1df6d4278ef", size = 1560615, upload-time = "2025-08-15T18:32:47.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/5c/fe9f95abd5eaedfa69f31e450f7e2768bef121dbdf25bcddee2cd3087a16/pyfiglet-1.0.4-py3-none-any.whl", hash = "sha256:65b57b7a8e1dff8a67dc8e940a117238661d5e14c3e49121032bd404d9b2b39f", size = 1806118, upload-time = "2025-08-15T18:32:45.556Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1925,6 +2115,57 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pytest-repeat"
+version = "0.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/d4/69e9dbb9b8266df0b157c72be32083403c412990af15c7c15f7a3fd1b142/pytest_repeat-0.9.4.tar.gz", hash = "sha256:d92ac14dfaa6ffcfe6917e5d16f0c9bc82380c135b03c2a5f412d2637f224485", size = 6488, upload-time = "2025-04-07T14:59:53.077Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/d4/8b706b81b07b43081bd68a2c0359fe895b74bf664b20aca8005d2bb3be71/pytest_repeat-0.9.4-py3-none-any.whl", hash = "sha256:c1738b4e412a6f3b3b9e0b8b29fcd7a423e50f87381ad9307ef6f5a8601139f3", size = 4180, upload-time = "2025-04-07T14:59:51.492Z" },
+]
+
+[[package]]
+name = "pytest-rerunfailures"
+version = "16.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/63/0114e45d4b2fcd5f6297dac655c067b47de28be4d33e088f200f0f2c4c28/pytest_rerunfailures-16.6.tar.gz", hash = "sha256:29dbfee46f542073c888e0ed4e81c51e15b9096f49a299eb1a759629c601684a", size = 42806, upload-time = "2026-08-17T07:11:00.447Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/5e/1e994889673d7a0da11651f17ef789b6c83bfe349f29f871873dd3802445/pytest_rerunfailures-16.6-py3-none-any.whl", hash = "sha256:6af2d1ebd6e5cb79666ac408942cd6a0672a49fefd8523664770718560795e13", size = 19137, upload-time = "2026-08-17T07:10:59.121Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]
@@ -1999,6 +2240,18 @@ wheels = [
 ]
 
 [[package]]
+name = "questionary"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
+]
+
+[[package]]
 name = "react-with-database-memory"
 version = "0.1.0"
 source = { editable = "." }
@@ -2030,6 +2283,12 @@ dependencies = [
 dev = [
     { name = "pytest" },
 ]
+eval = [
+    { name = "deepeval" },
+    { name = "httpx" },
+    { name = "mlflow", extra = ["kubernetes"] },
+    { name = "pyyaml" },
+]
 tracing = [
     { name = "mlflow" },
 ]
@@ -2037,8 +2296,10 @@ tracing = [
 [package.metadata]
 requires-dist = [
     { name = "chardet", specifier = ">=7.1.0" },
+    { name = "deepeval", marker = "extra == 'eval'", specifier = ">=4.2,<5" },
     { name = "fastapi", specifier = ">=0.135.1" },
     { name = "flask", specifier = ">=3.1.0" },
+    { name = "httpx", marker = "extra == 'eval'", specifier = ">=0.27" },
     { name = "langchain", specifier = ">=1.2.10" },
     { name = "langchain-core", specifier = ">=1.2.15" },
     { name = "langchain-openai", specifier = ">=1.1.10" },
@@ -2047,6 +2308,7 @@ requires-dist = [
     { name = "langgraph-prebuilt", specifier = ">=1.0.0" },
     { name = "milvus-lite", specifier = ">=2.4.0" },
     { name = "mlflow", marker = "extra == 'tracing'", specifier = ">=3.10.0" },
+    { name = "mlflow", extras = ["kubernetes"], marker = "extra == 'eval'", specifier = ">=3.11.0" },
     { name = "openai", specifier = ">=2.21.0" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.9" },
     { name = "pydantic", specifier = ">=2.12.5" },
@@ -2054,13 +2316,14 @@ requires-dist = [
     { name = "pypdf", specifier = ">=6.9.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
+    { name = "pyyaml", marker = "extra == 'eval'", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "setuptools", specifier = ">=80.9.0,<83.0.0" },
     { name = "starlette", specifier = ">=1.0.1" },
     { name = "typing-extensions", specifier = ">=4.15.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0" },
 ]
-provides-extras = ["tracing", "dev"]
+provides-extras = ["tracing", "dev", "eval"]
 
 [[package]]
 name = "regex"
@@ -2134,6 +2397,19 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
 name = "requests-toolbelt"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2143,6 +2419,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
 ]
 
 [[package]]
@@ -2225,6 +2514,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -2326,6 +2624,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tabulate"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2386,6 +2693,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/f7/57713ba479fd405eb76de31404b2c744c289e336b2d999511ebf51e496f7/typer-0.27.2.tar.gz", hash = "sha256:269b7eb9d3c202ca84b4bc9618cb04ebb43d3d4d1e567e4c768607232c05f945", size = 204045, upload-time = "2026-08-28T10:26:55.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/bf/205d0004930ede8f542fb58f601526fccf4ae7626075ca1e6c4de5d3d652/typer-0.27.2-py3-none-any.whl", hash = "sha256:b3a5fc4342d5fc8fda8fc3010b1cf117e9249aab7fae800c2eff62fd3842d97d", size = 123130, upload-time = "2026-08-28T10:26:53.752Z" },
 ]
 
 [[package]]
@@ -2620,6 +2942,15 @@ wheels = [
 ]
 
 [[package]]
+name = "websocket-client"
+version = "1.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/cb/a5abcc2891249f393827c650c6296660ce40374ac22d99ab9aea41f9d2a2/websocket_client-1.9.2.tar.gz", hash = "sha256:0fcb57545848be86992e128218fd96dd87a6769ffdb1a968dff79632b85604d0", size = 84110, upload-time = "2026-08-31T14:08:40.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/d2/cc4dc1271e464942db7ee278baae2daa99ee77cb2af744025c04da585a3e/websocket_client-1.9.2-py3-none-any.whl", hash = "sha256:e1a673830a9c7bfa47b1cd3d5e4178f4c9651d80a4eab02c9c23a1c3ec6250ce", size = 95786, upload-time = "2026-08-31T14:08:39.899Z" },
+]
+
+[[package]]
 name = "websockets"
 version = "16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2656,6 +2987,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
+name = "wheel"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/20/50ed6bdf27dec98b568a8ae25dc599f35baa3d9709f9e83fd1edb56b9a90/wheel-0.48.0.tar.gz", hash = "sha256:94800765601e9171bf5d58d066e640662842bcedcbab982b2c90787a2c987322", size = 66471, upload-time = "2026-08-11T22:02:27.327Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/29/69cfbb602cd91690c55d38ba9fe53e6a7e76a6fa647bf38f19c138d25449/wheel-0.48.0-py3-none-any.whl", hash = "sha256:3217dcc807155e45db462d7ef2431f5ddda0d7273b700d05a67b271ceb1287ab", size = 33320, upload-time = "2026-08-11T22:02:26.1Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a config-driven MLflow GenAI evaluation setup to the react_with_database_memory template. Developers can evaluate their agent's traces using core scorers (Safety, RelevanceToQuery, Completeness, Correctness, ToolCallCorrectness, ToolCallEfficiency, PIILeakage) plus custom scorers — all configured via YAML, no Python edits needed.

**Key changes:**

- `evaluation/eval_config.yaml` — scorer configuration with core, use-case, and guidelines sections. Scorers can come from MLflow, any MLflow-integrated third-party framework (e.g., DeepEval, Phoenix), or custom definitions in `scorers.py`
- `evaluation/scorers.py` — template for custom scorer definitions
- `evaluation/run_eval.py` — sends golden queries to the running agent, reads traces from MLflow, resolves scorers dynamically via `importlib`. Isolates traces from the current run via a timestamp baseline, then matches traces to golden queries by exact question-content comparison (immune to interleaved traces from concurrent agent traffic), with polling/retry for async trace flush
- `evaluation/eval_data.yaml` — placeholder golden queries (commented out) for developers to fill in
- `make eval` target added
- `EVAL_JUDGE_*`, `EVAL_ENABLE_PII`, `EVAL_REQUEST_TIMEOUT`, `EVAL_POLL_INTERVAL`, `AGENT_URL` env vars in `.env.example`
- README evaluation section with scorer configuration docs
- Includes the scorer-loading (`TypeError` handling) and env-var-validation (negative integer rejection) fixes from shricharan-ks's review on the agentic_rag PR (#337), applied here since this template's `run_eval.py` shares the same base

**JIRA**

[RHAIENG-7144](https://redhat.atlassian.net/browse/RHAIENG-7144)

**How it works:**

1. Developer runs agent with tracing enabled
2. Developer adds golden queries to `evaluation/eval_data.yaml`
3. Developer customizes guidelines and scorers in `evaluation/eval_config.yaml`
4. Developer runs `make eval` → sends queries to agent, reads traces, attaches expectations, scores them
5. Results logged to MLflow

## Testing

- [x] `make test` passes (run from the affected agent directory)
- [x] Manual testing performed (describe steps below)
- [ ] No testing required (documentation/config change only)

Tested end-to-end against both a local MLflow server and OpenShift-hosted MLflow (agen-e2e-rhoai2 cluster):

- Agent running with tracing enabled, traces recorded in MLflow
- `make eval` sends golden queries, reads traces, attaches expectations
- All scorers produce results (Safety, RelevanceToQuery, Completeness, Correctness, ToolCallCorrectness, ToolCallEfficiency, Guidelines)
- Timestamp-based trace isolation verified — only current run's traces evaluated
- Content-based matching confirmed immune to interleaved traces
- Retry loop confirmed working for async trace flush delays
- Full unit test suite passing (41/41)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] No .env or secret files are included in this PR
- [x] All changes are within scope of the eval integration work

## Review Guidance

- `evaluation/run_eval.py` is the core logic — config-driven scorer resolution via `resolve_scorer()`/`_add_scorer()` and `get_scorers()`, plus timestamp + content-based trace matching in `main()`
- `evaluation/eval_config.yaml` is the user-facing config — three sections (`core`, `use_case`, `guidelines`)
- `pyproject.toml` eval deps: `mlflow[kubernetes]`, `pyyaml`, `httpx`, `deepeval`
- README Evaluation section documents the scorer architecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHAIENG-7144]: https://redhat.atlassian.net/browse/RHAIENG-7144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ