### PR TITLE
feat(human-in-the-loop): add MLflow GenAI evaluation

### DIFF
--- a/agents/langgraph/templates/human_in_the_loop/.env.example
+++ b/agents/langgraph/templates/human_in_the_loop/.env.example
@@ -21,3 +21,16 @@ MODEL_ID=ollama/Llama3.1:8B
 # MLFLOW_TRACKING_INSECURE_TLS=
 # MLFLOW_WORKSPACE=default
 # MLFLOW_TRACKING_AUTH= # Use Kubernetes service account for authentication (if running inside the cluster)
+
+# Optional — Evaluation (only needed for `make eval`)
+# The judge model scores agent responses. Can be the same as the agent's model or a different one.
+# EVAL_JUDGE_MODEL=openai:/gpt-4o-mini
+# EVAL_JUDGE_API_KEY=<your-api-key>
+# EVAL_JUDGE_BASE_URL=https://api.openai.com/v1
+# EVAL_PII_MODEL=openai:/gpt-4.1-mini
+# EVAL_ENABLE_PII=false
+# EVAL_REQUEST_TIMEOUT=60
+# EVAL_TRACE_TIMEOUT=60
+# EVAL_POLL_INTERVAL=4
+DEEPEVAL_TELEMETRY_OPT_OUT=YES
+# AGENT_URL=http://localhost:8000

--- a/agents/langgraph/templates/human_in_the_loop/Makefile
+++ b/agents/langgraph/templates/human_in_the_loop/Makefile
@@ -6,7 +6,7 @@ VALUES_FILE    := values.yaml
 CONTAINER_CLI  := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 MODEL          ?= llama3.1:8b
 
-.PHONY: init re-init env ollama ogx-server run-app run-app-fresh run-cli build push build-openshift deploy undeploy test test-integration dry-run help
+.PHONY: init re-init env ollama ogx-server run-app run-app-fresh run-cli build push build-openshift deploy undeploy test eval test-integration dry-run help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-12s %s\n", $$1, $$2}'
@@ -185,6 +185,9 @@ undeploy: ## Remove deployment from cluster
 
 test: ## Run unit tests
 	uv run --extra dev python -m pytest tests/ --ignore=tests/integration --ignore=tests/behavioral $(PYTEST_ARGS)
+
+eval: ## Run MLflow GenAI evaluation
+	@uv run --extra eval python evaluation/run_eval.py
 
 test-integration: ## Run integration deployment test
 	PYTHONPATH=$$(git rev-parse --show-toplevel)/tests \

--- a/agents/langgraph/templates/human_in_the_loop/README.md
+++ b/agents/langgraph/templates/human_in_the_loop/README.md
@@ -321,6 +321,157 @@ uv run --extra test --extra test-mlflow python -m pytest agents/langgraph/templa
 
 Thresholds are configured in `tests/behavioral/configs/thresholds.yaml` under the `langgraph_hitl` section.
 
+## Evaluation
+
+This template includes a config-driven MLflow GenAI evaluation setup. The eval script sends golden queries to a running agent, reads the resulting traces from MLflow, and scores them using scorers defined in `evaluation/eval_config.yaml`.
+
+### Eval Directory Structure
+
+```text
+evaluation/
+├── eval_config.yaml   # Scorer configuration (core, use-case, guidelines)
+├── eval_data.yaml     # Golden queries with expected results
+├── scorers.py         # Custom scorer definitions (add your own here)
+└── run_eval.py        # Evaluation logic (no need to edit)
+```
+
+### Prerequisites
+
+- Agent must be running with tracing enabled (`MLFLOW_TRACKING_URI` set in `.env`)
+- Complete the Setup steps below
+
+### Setup
+
+**Set environment variables** in `.env`:
+
+```ini
+# Required for eval
+EVAL_JUDGE_MODEL=<provider>:/<model>
+EVAL_JUDGE_API_KEY=<api-key>
+EVAL_JUDGE_BASE_URL=<endpoint-url>  # only needed for OpenAI-compatible endpoints
+```
+
+The judge model format is `<provider>:/<model>`. The eval script automatically sets the correct API key env var based on the provider. Examples:
+
+- **OpenAI:** `EVAL_JUDGE_MODEL=openai:/gpt-4o-mini`, `EVAL_JUDGE_BASE_URL=https://api.openai.com/v1`
+- **vLLM / RHOAI:** `EVAL_JUDGE_MODEL=openai:/<served-model-name>`, `EVAL_JUDGE_BASE_URL=https://<your-vllm-route>/v1`
+- **Anthropic:** `EVAL_JUDGE_MODEL=anthropic:/claude-sonnet-4-20250514` (no `BASE_URL` needed)
+
+### Running Evaluation
+
+1. Add your golden queries and expectations to `evaluation/eval_data.yaml`. For this HITL template, use prompts that complete without triggering human approval. Avoid prompts like "create a file" unless your evaluation flow explicitly handles the approval and resume cycle.
+2. Customize the guidelines in `evaluation/eval_config.yaml` for your domain
+3. Start your agent with tracing enabled (`make run-app`) if it's not already running
+4. Run:
+
+   ```bash
+   make eval
+   ```
+
+   This will:
+   - Send each golden query from `eval_data.yaml` to the running agent
+   - Wait for traces to be recorded in MLflow
+   - Attach expectations (e.g., `expected_facts`) to matching traces
+   - Score all traces with the configured scorers
+
+   By default, the eval script connects to the agent at `http://localhost:8000`. To target a deployed agent, set `AGENT_URL` in `.env`:
+
+   ```ini
+   AGENT_URL=https://<your-agent-route>
+   ```
+
+   Request/trace timeouts and poll interval are configurable via `EVAL_REQUEST_TIMEOUT`, `EVAL_TRACE_TIMEOUT`, and `EVAL_POLL_INTERVAL` (all in seconds, default `60`/`60`/`4`) if the defaults don't fit your environment.
+
+### Scorer Configuration
+
+Scorers are configured in `evaluation/eval_config.yaml`, organized into three sections. Scorers in both **core** and **use-case** sections can come from any of three sources:
+
+| Source | `module` value | Example |
+|--------|---------------|---------|
+| MLflow built-in | `mlflow.genai.scorers` | Safety, Correctness |
+| Third-party (any MLflow-integrated framework) | `mlflow.genai.scorers.<framework>` | DeepEval PIILeakage, Phoenix Hallucination |
+| Custom (defined in `scorers.py`) | `scorers` | Your own domain-specific scorers |
+
+#### Core Scorers
+
+Cover universal failure modes. Pre-configured for all agents -- remove only with a specific reason.
+
+| Scorer | What it checks |
+|--------|---------------|
+| **Safety** | Responses are free of harmful or toxic content |
+| **RelevanceToQuery** | Responses directly address the user's question |
+| **Completeness** | All parts of the user's request are addressed |
+| **Correctness** | Responses match expected facts (requires `expected_facts` in eval data) |
+| **ToolCallCorrectness** | Agent selects appropriate tools with correct arguments |
+| **ToolCallEfficiency** | No redundant or duplicate tool calls |
+| **PIILeakage** *(opt-in)* | Responses don't leak personally identifiable information |
+
+> **PIILeakage** is disabled by default. Enable it by setting `EVAL_ENABLE_PII=true` in `.env`. It uses DeepEval and defaults to `openai:/gpt-4.1-mini` (override with `EVAL_PII_MODEL`). DeepEval has a known JSON parsing issue with `gpt-4o` -- use `gpt-4.1-mini` or `gpt-4o-mini`.
+
+#### Use-case Scorers
+
+Add scorers specific to your agent's domain. Like core scorers, these can come from MLflow, third-party MLflow integrations, or custom definitions in `scorers.py`. Each entry needs a `name` and `module`:
+
+```yaml
+use_case:
+  # MLflow scorer
+  - name: RetrievalGroundedness
+    module: mlflow.genai.scorers
+
+  # Third-party scorer (any MLflow-integrated framework)
+  - name: Faithfulness
+    module: mlflow.genai.scorers.deepeval
+
+  # Custom scorer (defined in scorers.py)
+  - name: my_domain_scorer
+    module: scorers
+```
+
+#### Guidelines
+
+A list of plain-text rules evaluated by the `Guidelines` scorer. Customize these for your agent:
+
+```yaml
+guidelines:
+  - "The response should be helpful and directly address the user's question"
+  - "The response should not fabricate information or present uncertain claims as facts"
+  - "The response should use the appropriate tools when needed rather than guessing"
+```
+
+### Adding a Custom Scorer
+
+1. Define your scorer in `evaluation/scorers.py`:
+
+   ```python
+   from mlflow.entities import Feedback
+   from mlflow.genai.scorers import scorer
+
+   @scorer
+   def my_domain_scorer(*, inputs, outputs, expectations=None, trace=None):
+       """Check domain-specific quality criteria."""
+       # Your scoring logic here
+       return Feedback(value=1.0, rationale="Meets criteria")
+   ```
+
+2. Add it to `evaluation/eval_config.yaml` under `core` or `use_case`:
+
+   ```yaml
+   use_case:
+     - name: my_domain_scorer
+       module: scorers
+   ```
+
+3. Run `make eval` -- your scorer will be picked up automatically.
+
+### Viewing Results
+
+Results are logged to MLflow. View them in the MLflow UI under the Traces tab.
+
+### Advanced Evaluation
+
+For failure mode deep-dives, custom scorer patterns, and end-to-end evaluation, see the
+[Agentic Evaluation Enablement Material](https://github.com/red-hat-data-services/red-hat-ai-examples/tree/main/examples/agentic-evaluation).
+
 ## API Endpoints
 
 ### POST /chat/completions

--- a/agents/langgraph/templates/human_in_the_loop/evaluation/eval_config.yaml
+++ b/agents/langgraph/templates/human_in_the_loop/evaluation/eval_config.yaml
@@ -1,0 +1,69 @@
+# Evaluation scorer configuration.
+#
+# Each scorer entry requires:
+#   name:   Class or function name to import
+#   module: Python module to import from
+#
+# Optional:
+#   enabled_by_env: Only load this scorer if the specified env var is set to "true"
+#   model_env:      Read the judge model from this env var instead of EVAL_JUDGE_MODEL
+#
+# Sources:
+#   MLflow scorers:     module: mlflow.genai.scorers
+#   Third-party:        module: mlflow.genai.scorers.<framework> (any MLflow-integrated framework, e.g., deepeval, ragas, phoenix etc.)
+#   Custom (scorers.py): module: scorers (custom built scorers)
+
+scorers:
+  # Core scorers — cover universal failure modes, apply to all agents.
+  # These come pre-configured. Remove only if you have a specific reason.
+  core:
+    - name: Safety
+      module: mlflow.genai.scorers
+
+    - name: RelevanceToQuery
+      module: mlflow.genai.scorers
+
+    - name: Completeness
+      module: mlflow.genai.scorers
+
+    - name: Correctness
+      module: mlflow.genai.scorers
+
+    - name: ToolCallCorrectness
+      module: mlflow.genai.scorers
+
+    - name: ToolCallEfficiency
+      module: mlflow.genai.scorers
+
+    - name: PIILeakage
+      module: mlflow.genai.scorers.deepeval
+      enabled_by_env: EVAL_ENABLE_PII
+      model_env: EVAL_PII_MODEL
+
+  # Use-case specific scorers — add scorers relevant to your agent's domain.
+  # Can be MLflow, third-party, or custom (defined in scorers.py).
+  use_case:
+    # RAG agents — uncomment these:
+    # - name: RetrievalGroundedness
+    #   module: mlflow.genai.scorers
+    #
+    # - name: RetrievalRelevance
+    #   module: mlflow.genai.scorers
+    #
+    # - name: RetrievalSufficiency
+    #   module: mlflow.genai.scorers
+    #
+    # Third-party example:
+    # - name: Faithfulness
+    #   module: mlflow.genai.scorers.deepeval
+    #
+    # Custom scorer (defined in scorers.py):
+    # - name: my_domain_scorer
+    #   module: scorers
+
+  # Domain-specific rules for the Guidelines scorer.
+  # Customize these for your agent's expected behavior.
+  guidelines:
+    - "The response should be helpful and directly address the user's question"
+    - "The response should not fabricate information or present uncertain claims as facts"
+    - "The response should use the appropriate tools when needed rather than guessing"

--- a/agents/langgraph/templates/human_in_the_loop/evaluation/eval_data.yaml
+++ b/agents/langgraph/templates/human_in_the_loop/evaluation/eval_data.yaml
@@ -1,0 +1,40 @@
+# Golden queries for MLflow GenAI evaluation.
+#
+# Add your test queries below. Each query is sent to the running agent,
+# and the resulting trace is scored by the configured scorers.
+#
+# IMPORTANT: Avoid queries that trigger HITL interrupts (e.g., "create a file")
+# unless your evaluation flow explicitly handles approval/resume.
+#
+# Fields:
+#   inputs:       Dict with the user query (required)
+#   expectations: Dict with ground truth (required for Correctness scorer)
+#     expected_facts:    List of facts the response should contain
+#     expected_response: Reference response text
+#
+# Trace-based scorers (ToolCallCorrectness, ToolCallEfficiency)
+# extract data from MLflow traces automatically -- no expected tools needed here.
+#
+# Keep queries single-turn and choose prompts that complete without human approval.
+
+queries:
+  # Example: query that requires a tool call
+  # - inputs:
+  #     question: "Your test question here"
+  #   expectations:
+  #     expected_facts:
+  #       - "Expected fact 1"
+  #       - "Expected fact 2"
+
+  # Example: query that should NOT trigger a tool call
+  # - inputs:
+  #     question: "A simple greeting or general question"
+  #   expectations:
+  #     expected_response: "A friendly response without using any tools"
+
+  # Example: edge case
+  # - inputs:
+  #     question: "A query that tests error handling or boundaries"
+  #   expectations:
+  #     expected_facts:
+  #       - "Expected behavior description"

--- a/agents/langgraph/templates/human_in_the_loop/evaluation/run_eval.py
+++ b/agents/langgraph/templates/human_in_the_loop/evaluation/run_eval.py
@@ -1,0 +1,427 @@
+"""MLflow GenAI evaluation script.
+
+Reads existing traces from MLflow and evaluates them using scorers
+configured in eval_config.yaml.
+
+Usage:
+    make eval
+"""
+
+import importlib
+import inspect
+import json
+import os
+import time
+from pathlib import Path
+
+import httpx
+import mlflow
+import yaml
+from dotenv import load_dotenv
+from mlflow.genai.scorers import Guidelines
+
+
+def load_eval_config(path: str | None = None) -> dict:
+    """Load scorer configuration from YAML."""
+    if path is None:
+        path = str(Path(__file__).parent / "eval_config.yaml")
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+def load_eval_data(path: str | None = None) -> list[dict]:
+    """Load golden queries with expectations from YAML."""
+    if path is None:
+        path = str(Path(__file__).parent / "eval_data.yaml")
+    with open(path) as f:
+        data = yaml.safe_load(f) or {}
+    return data.get("queries") or []
+
+
+def _find_duplicate_questions(eval_data: list[dict]) -> list[str]:
+    """Return duplicate question text from eval data, preserving first duplicate order."""
+    seen = set()
+    duplicates = []
+
+    for query in eval_data:
+        question = query["inputs"]["question"]
+        if question in seen and question not in duplicates:
+            duplicates.append(question)
+        seen.add(question)
+
+    return duplicates
+
+
+def validate_eval_data(eval_data: list[dict]) -> None:
+    """Validate eval data before sending requests to the agent."""
+    duplicate_questions = _find_duplicate_questions(eval_data)
+    if duplicate_questions:
+        print("ERROR: Duplicate questions found in evaluation/eval_data.yaml.")
+        print(
+            "Trace matching uses exact question text, so each golden query must be unique."
+        )
+        for question in duplicate_questions:
+            print(f"  - {question}")
+        raise SystemExit(1)
+
+
+def _get_int_env(name: str, default: int) -> int:
+    """Read an integer env var, exiting with a friendly message if invalid or negative."""
+    value = os.getenv(name, str(default))
+    try:
+        result = int(value)
+    except ValueError:
+        print(f"ERROR: {name}={value!r} is not a valid integer.")
+        raise SystemExit(1)
+    if result < 0:
+        print(f"ERROR: {name}={result} must not be negative.")
+        raise SystemExit(1)
+    return result
+
+
+def generate_traces(eval_data: list[dict], agent_url: str) -> None:
+    """Send golden queries to the running agent to generate traces."""
+    request_timeout = _get_int_env("EVAL_REQUEST_TIMEOUT", 60)
+    print(f"Sending {len(eval_data)} golden queries to {agent_url}...")
+    for query in eval_data:
+        question = query["inputs"]["question"]
+        try:
+            response = httpx.post(
+                f"{agent_url}/chat/completions",
+                json={
+                    "messages": [{"role": "user", "content": question}],
+                    "stream": False,
+                },
+                timeout=request_timeout,
+            )
+            response.raise_for_status()
+        except httpx.ConnectError:
+            print(
+                f"\nERROR: Could not connect to agent at {agent_url}."
+                "\nIs the agent running? Start it with: make run-app"
+            )
+            raise SystemExit(1)
+        except httpx.TimeoutException:
+            print(
+                f"\nERROR: Agent at {agent_url} did not respond within {request_timeout}s."
+                "\nThe agent may be overloaded or the model endpoint may be slow."
+            )
+            raise SystemExit(1)
+        except httpx.HTTPStatusError as e:
+            print(f"\nERROR: Agent returned HTTP {e.response.status_code}.")
+            print("Check the agent logs for details.")
+            raise SystemExit(1)
+        except httpx.RequestError as e:
+            print(f"\nERROR: Request to {agent_url} failed: {e}")
+            raise SystemExit(1)
+        print(f"  -> {question}")
+    print(f"Generated {len(eval_data)} traces.\n")
+
+
+def _extract_question(trace):
+    """Extract the user question from a trace's request data."""
+    try:
+        request = json.loads(trace.data.request)
+        return request["messages"][0]["content"]
+    except (json.JSONDecodeError, KeyError, IndexError, TypeError):
+        return None
+
+
+def attach_expectations(traces, eval_data):
+    """Match traces to golden queries by content and log expectations.
+
+    Each golden query's question is matched against the question extracted
+    from trace.data.request using exact string comparison. This is immune
+    to interleaved traces from concurrent agent traffic.
+
+    Returns a mapping of matched trace IDs to expectation names logged for each trace.
+    """
+    expectation_names_by_trace_id = {}
+
+    for query in eval_data:
+        question = query["inputs"]["question"]
+        for trace in traces:
+            if trace.info.trace_id in expectation_names_by_trace_id:
+                continue
+            if _extract_question(trace) == question:
+                expectations = query.get("expectations", {})
+                for name, value in expectations.items():
+                    mlflow.log_expectation(
+                        trace_id=trace.info.trace_id,
+                        name=name,
+                        value=value,
+                    )
+                expectation_names_by_trace_id[trace.info.trace_id] = set(
+                    expectations.keys()
+                )
+                break
+
+    print(
+        f"Matched {len(expectation_names_by_trace_id)}/{len(traces)} traces "
+        "to golden queries with expectations."
+    )
+    return expectation_names_by_trace_id
+
+
+def _trace_has_expectations(trace, expected_names: set[str]) -> bool:
+    """Return whether a re-fetched trace includes all expected expectation names."""
+    if not expected_names:
+        return True
+
+    assessments = trace.search_assessments(type="expectation")
+    assessment_names = {getattr(assessment, "name", None) for assessment in assessments}
+    return expected_names.issubset(assessment_names)
+
+
+def refetch_matched_traces_with_expectations(
+    experiment_id: str,
+    baseline_ms: int,
+    expectation_names_by_trace_id: dict[str, set[str]],
+    timeout: int,
+    poll_interval: int,
+):
+    """Re-fetch matched traces until logged expectations are visible."""
+    deadline = time.monotonic() + timeout
+    matched_ids = set(expectation_names_by_trace_id)
+    matched_traces = []
+
+    while True:
+        traces = mlflow.search_traces(
+            locations=[experiment_id],
+            return_type="list",
+            filter_string=f"trace.timestamp_ms > {baseline_ms}",
+        )
+        matched_traces = [t for t in traces if t.info.trace_id in matched_ids]
+        ready_traces = [
+            trace
+            for trace in matched_traces
+            if _trace_has_expectations(
+                trace, expectation_names_by_trace_id[trace.info.trace_id]
+            )
+        ]
+
+        if len(ready_traces) == len(matched_ids):
+            return ready_traces
+
+        if time.monotonic() >= deadline:
+            missing = matched_ids - {t.info.trace_id for t in ready_traces}
+            print(
+                "ERROR: Timed out waiting for logged expectations to become "
+                f"visible on {len(missing)} trace(s)."
+            )
+            raise SystemExit(1)
+
+        time.sleep(poll_interval)
+
+
+def filter_matching_traces_or_exit(
+    traces,
+    golden_questions: set[str],
+    expected_count: int,
+    trace_timeout: int,
+    experiment_name: str,
+):
+    """Filter traces to golden-query matches, failing if the batch is incomplete."""
+    matched_traces = [t for t in traces if _extract_question(t) in golden_questions]
+
+    if not traces:
+        print(f"ERROR: No traces found in experiment '{experiment_name}' for this run.")
+        print("Ensure the agent is running with tracing enabled, then re-run eval.")
+        raise SystemExit(1)
+
+    if len(matched_traces) < expected_count:
+        print(
+            f"ERROR: Expected {expected_count} matching traces but only found "
+            f"{len(matched_traces)} after {trace_timeout}s."
+        )
+        print(
+            "Some queries may not have been recorded or traces may still be incomplete."
+        )
+        raise SystemExit(1)
+
+    return matched_traces
+
+
+def resolve_scorer(entry: dict, judge_model: str):
+    """Resolve a scorer entry from config into a scorer instance."""
+    env_flag = entry.get("enabled_by_env")
+    if env_flag and os.getenv(env_flag, "").lower() != "true":
+        return None
+
+    model = judge_model
+    if entry.get("model_env"):
+        model = os.getenv(entry["model_env"], model)
+
+    module = importlib.import_module(entry["module"])
+    cls_or_obj = getattr(module, entry["name"])
+
+    if inspect.isclass(cls_or_obj):
+        try:
+            init_params = inspect.signature(cls_or_obj.__init__).parameters
+        except (TypeError, ValueError):
+            init_params = {}
+        accepts_model = "model" in init_params or any(
+            p.kind == inspect.Parameter.VAR_KEYWORD for p in init_params.values()
+        )
+        return cls_or_obj(model=model) if accepts_model else cls_or_obj()
+    return cls_or_obj
+
+
+def _add_scorer(scorers: list, entry: dict, judge_model: str) -> None:
+    """Resolve a scorer entry and append it, skipping with a warning on config errors."""
+    try:
+        s = resolve_scorer(entry, judge_model)
+    except (ModuleNotFoundError, AttributeError, TypeError, KeyError) as e:
+        name = entry.get("name") if isinstance(entry, dict) else "<invalid entry>"
+        print(f"WARNING: Could not load scorer '{name}': {e}. Skipping.")
+        return
+    if s:
+        scorers.append(s)
+
+
+def get_scorers(config: dict, judge_model: str) -> list:
+    """Build the scorer list from eval_config.yaml."""
+    scorers = []
+    scorer_config = config.get("scorers", {})
+
+    for entry in scorer_config.get("core") or []:
+        _add_scorer(scorers, entry, judge_model)
+
+    for entry in scorer_config.get("use_case") or []:
+        _add_scorer(scorers, entry, judge_model)
+
+    guidelines = scorer_config.get("guidelines") or []
+    if guidelines:
+        scorers.append(
+            Guidelines(
+                name="domain_guidelines",
+                model=judge_model,
+                guidelines=guidelines,
+            )
+        )
+
+    return scorers
+
+
+def main():
+    """Read traces from MLflow, attach expectations, and evaluate with scorers."""
+    load_dotenv()
+
+    judge_model = os.getenv("EVAL_JUDGE_MODEL", "openai:/gpt-4o-mini")
+    judge_api_key = os.getenv("EVAL_JUDGE_API_KEY")
+    judge_base_url = os.getenv("EVAL_JUDGE_BASE_URL")
+    provider = judge_model.split(":/")[0] if ":/" in judge_model else "openai"
+
+    if judge_api_key:
+        os.environ[f"{provider.upper()}_API_KEY"] = judge_api_key
+    if judge_base_url:
+        env_var = f"{provider.upper()}_BASE_URL"
+        os.environ[env_var] = judge_base_url
+        print(f"  Set {env_var} for judge model base URL")
+
+    tracking_uri = os.getenv("MLFLOW_TRACKING_URI")
+    if not tracking_uri:
+        print("ERROR: MLFLOW_TRACKING_URI is not set. Cannot read traces.")
+        print("Set it in .env and ensure the agent has been run with tracing enabled.")
+        raise SystemExit(1)
+
+    mlflow.set_tracking_uri(tracking_uri)
+
+    experiment_name = os.getenv("MLFLOW_EXPERIMENT_NAME")
+    if not experiment_name:
+        print("ERROR: MLFLOW_EXPERIMENT_NAME is not set.")
+        raise SystemExit(1)
+
+    experiment = mlflow.get_experiment_by_name(experiment_name)
+    if experiment is None:
+        print(f"ERROR: Experiment '{experiment_name}' not found on MLflow server.")
+        print("Run the agent first to create traces, then re-run eval.")
+        raise SystemExit(1)
+
+    mlflow.set_experiment(experiment_name)
+
+    config = load_eval_config()
+    scorers = get_scorers(config, judge_model)
+    print(f"Loaded {len(scorers)} scorers from eval_config.yaml.")
+
+    eval_data = load_eval_data()
+    if not eval_data:
+        print("ERROR: No golden queries in evaluation/eval_data.yaml.")
+        print("Add at least one query under 'queries:' before running make eval.")
+        raise SystemExit(1)
+
+    validate_eval_data(eval_data)
+    golden_questions = {q["inputs"]["question"] for q in eval_data}
+
+    agent_url = os.getenv("AGENT_URL", "http://localhost:8000")
+
+    existing = mlflow.search_traces(
+        locations=[experiment.experiment_id],
+        return_type="list",
+        max_results=1,
+        order_by=["timestamp_ms DESC"],
+    )
+    baseline_ms = existing[0].info.timestamp_ms if existing else 0
+
+    generate_traces(eval_data, agent_url)
+
+    expected_count = len(eval_data)
+    trace_timeout = _get_int_env("EVAL_TRACE_TIMEOUT", 60)
+    poll_interval = max(_get_int_env("EVAL_POLL_INTERVAL", 4), 1)
+    max_attempts = max(trace_timeout // poll_interval, 1)
+
+    traces = []
+    for attempt in range(max_attempts):
+        traces = mlflow.search_traces(
+            locations=[experiment.experiment_id],
+            return_type="list",
+            filter_string=f"trace.timestamp_ms > {baseline_ms}",
+        )
+        if len(traces) >= expected_count:
+            matched = [t for t in traces if _extract_question(t) in golden_questions]
+            if len(matched) >= expected_count:
+                break
+        time.sleep(poll_interval)
+
+    traces = filter_matching_traces_or_exit(
+        traces=traces,
+        golden_questions=golden_questions,
+        expected_count=expected_count,
+        trace_timeout=trace_timeout,
+        experiment_name=experiment_name,
+    )
+    print(f"Found {len(traces)} matching traces from this run to evaluate.")
+
+    expectation_names_by_trace_id = attach_expectations(traces, eval_data)
+    traces = refetch_matched_traces_with_expectations(
+        experiment_id=experiment.experiment_id,
+        baseline_ms=baseline_ms,
+        expectation_names_by_trace_id=expectation_names_by_trace_id,
+        timeout=trace_timeout,
+        poll_interval=poll_interval,
+    )
+
+    if not traces:
+        print("ERROR: No traces matched golden queries. Skipping evaluation.")
+        print("This can happen if traces were not fully written when matching ran.")
+        raise SystemExit(1)
+
+    print(f"Evaluating {len(traces)} traces with {len(scorers)} scorers...")
+
+    with mlflow.start_run(run_name="eval-run"):
+        results = mlflow.genai.evaluate(
+            data=traces,
+            scorers=scorers,
+        )
+
+    print("\n" + "=" * 60)
+    print("EVALUATION RESULTS")
+    print("=" * 60)
+    for metric_name, value in sorted(results.metrics.items()):
+        print(f"  {metric_name}: {value}")
+    print("=" * 60)
+    print(f"\nDetailed results logged to MLflow experiment: {experiment_name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/agents/langgraph/templates/human_in_the_loop/evaluation/run_eval.py
+++ b/agents/langgraph/templates/human_in_the_loop/evaluation/run_eval.py
@@ -95,6 +95,19 @@ def generate_traces(eval_data: list[dict], agent_url: str) -> None:
                 timeout=request_timeout,
             )
             response.raise_for_status()
+            body = response.json()
+            choices = body.get("choices") or []
+            if choices:
+                finish_reason = choices[0].get("finish_reason")
+                if finish_reason == "pending_approval":
+                    print(
+                        f"\nERROR: Agent returned 'pending_approval' for: {question}"
+                        "\nThe HITL template requires human approval for this query."
+                        "\nEval cannot score incomplete responses. Either approve the "
+                        "pending request or adjust eval_data.yaml to avoid queries "
+                        "that trigger approval."
+                    )
+                    raise SystemExit(1)
         except httpx.ConnectError:
             print(
                 f"\nERROR: Could not connect to agent at {agent_url}."
@@ -131,8 +144,9 @@ def attach_expectations(traces, eval_data):
     """Match traces to golden queries by content and log expectations.
 
     Each golden query's question is matched against the question extracted
-    from trace.data.request using exact string comparison. This is immune
-    to interleaved traces from concurrent agent traffic.
+    from trace.data.request using exact string comparison. Interleaved
+    traces from concurrent traffic with different questions are ignored,
+    but concurrent requests with identical question text could mis-associate.
 
     Returns a mapping of matched trace IDs to expectation names logged for each trace.
     """
@@ -368,10 +382,10 @@ def main():
     expected_count = len(eval_data)
     trace_timeout = _get_int_env("EVAL_TRACE_TIMEOUT", 60)
     poll_interval = max(_get_int_env("EVAL_POLL_INTERVAL", 4), 1)
-    max_attempts = max(trace_timeout // poll_interval, 1)
+    deadline = time.monotonic() + trace_timeout
 
     traces = []
-    for attempt in range(max_attempts):
+    while True:
         traces = mlflow.search_traces(
             locations=[experiment.experiment_id],
             return_type="list",
@@ -381,7 +395,9 @@ def main():
             matched = [t for t in traces if _extract_question(t) in golden_questions]
             if len(matched) >= expected_count:
                 break
-        time.sleep(poll_interval)
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(min(poll_interval, max(deadline - time.monotonic(), 0)))
 
     traces = filter_matching_traces_or_exit(
         traces=traces,

--- a/agents/langgraph/templates/human_in_the_loop/evaluation/scorers.py
+++ b/agents/langgraph/templates/human_in_the_loop/evaluation/scorers.py
@@ -1,0 +1,19 @@
+"""Custom scorers for this agent.
+
+Define your scorers here and add their function name to eval_config.yaml
+under scorers.core or scorers.use_case to activate them.
+
+See: https://mlflow.org/docs/latest/genai/eval-monitor/scorers/custom
+"""
+
+from mlflow.genai.scorers import scorer  # noqa: F401
+
+# Example:
+#
+# from mlflow.entities import Feedback
+#
+# @scorer
+# def my_domain_scorer(*, inputs, outputs, expectations=None, trace=None):
+#     """Check domain-specific quality criteria."""
+#     # Your scoring logic here
+#     return Feedback(value=1.0, rationale="Meets criteria")

--- a/agents/langgraph/templates/human_in_the_loop/pyproject.toml
+++ b/agents/langgraph/templates/human_in_the_loop/pyproject.toml
@@ -30,6 +30,15 @@ tracing = [
 ]
 dev = [
     "pytest>=9.0.2",
+    "mlflow>=3.11.0",
+    "pyyaml>=6.0",
+    "httpx>=0.27",
+]
+eval = [
+    "mlflow[kubernetes]>=3.11.0",
+    "pyyaml>=6.0",
+    "httpx>=0.27",
+    "deepeval>=4.2,<5",
 ]
 
 [tool.setuptools.packages.find]

--- a/agents/langgraph/templates/human_in_the_loop/tests/test_eval.py
+++ b/agents/langgraph/templates/human_in_the_loop/tests/test_eval.py
@@ -1,0 +1,445 @@
+"""Tests for evaluation/run_eval.py — config loading, data loading, scorer resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip(
+    "mlflow", reason="eval dependencies not installed (install with --extra eval)"
+)
+
+import json  # noqa: E402
+import sys  # noqa: E402
+import textwrap  # noqa: E402
+from pathlib import Path  # noqa: E402
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+import yaml  # noqa: E402
+
+EVAL_DIR = Path(__file__).resolve().parents[1] / "evaluation"
+sys.path.insert(0, str(EVAL_DIR.parent))
+
+from evaluation.run_eval import (  # noqa: E402
+    attach_expectations,
+    filter_matching_traces_or_exit,
+    get_scorers,
+    load_eval_config,
+    load_eval_data,
+    refetch_matched_traces_with_expectations,
+    resolve_scorer,
+    validate_eval_data,
+)
+
+# ---------------------------------------------------------------------------
+# load_eval_config
+# ---------------------------------------------------------------------------
+
+
+class TestLoadEvalConfig:
+    def test_loads_default_config(self) -> None:
+        config = load_eval_config()
+        assert "scorers" in config
+        assert "core" in config["scorers"]
+        assert "guidelines" in config["scorers"]
+
+    def test_loads_from_custom_path(self, tmp_path: Path) -> None:
+        custom = tmp_path / "custom.yaml"
+        custom.write_text(
+            yaml.dump({"scorers": {"core": [], "use_case": [], "guidelines": []}})
+        )
+        config = load_eval_config(str(custom))
+        assert config["scorers"]["core"] == []
+
+    def test_core_scorers_have_name_and_module(self) -> None:
+        config = load_eval_config()
+        for entry in config["scorers"]["core"]:
+            assert "name" in entry, f"Missing 'name' in core scorer: {entry}"
+            assert "module" in entry, f"Missing 'module' in core scorer: {entry}"
+
+
+# ---------------------------------------------------------------------------
+# load_eval_data
+# ---------------------------------------------------------------------------
+
+
+class TestLoadEvalData:
+    def test_returns_empty_list_when_queries_is_none(self, tmp_path: Path) -> None:
+        """Regression: YAML `queries:` with no items parses as None, not []."""
+        data_file = tmp_path / "eval_data.yaml"
+        data_file.write_text("queries:\n")
+        result = load_eval_data(str(data_file))
+        assert result == []
+
+    def test_returns_empty_list_when_key_missing(self, tmp_path: Path) -> None:
+        data_file = tmp_path / "eval_data.yaml"
+        data_file.write_text("other_key: value\n")
+        result = load_eval_data(str(data_file))
+        assert result == []
+
+    def test_returns_queries_list(self, tmp_path: Path) -> None:
+        data_file = tmp_path / "eval_data.yaml"
+        data_file.write_text(
+            textwrap.dedent("""\
+                queries:
+                  - inputs:
+                      question: "What is 2+2?"
+                    expectations:
+                      expected_facts:
+                        - "4"
+            """)
+        )
+        result = load_eval_data(str(data_file))
+        assert len(result) == 1
+        assert result[0]["inputs"]["question"] == "What is 2+2?"
+
+    def test_loads_default_placeholder_data(self) -> None:
+        result = load_eval_data()
+        assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# validate_eval_data
+# ---------------------------------------------------------------------------
+
+
+class TestValidateEvalData:
+    def test_allows_unique_questions(self) -> None:
+        eval_data = [
+            {"inputs": {"question": "Q1"}},
+            {"inputs": {"question": "Q2"}},
+        ]
+        validate_eval_data(eval_data)
+
+    def test_rejects_duplicate_questions(self) -> None:
+        eval_data = [
+            {"inputs": {"question": "Q1"}},
+            {"inputs": {"question": "Q1"}},
+        ]
+        with pytest.raises(SystemExit) as exc_info:
+            validate_eval_data(eval_data)
+        assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# resolve_scorer
+# ---------------------------------------------------------------------------
+
+
+class TestResolveScorer:
+    def test_skips_scorer_when_env_flag_not_set(self) -> None:
+        entry = {
+            "name": "PIILeakage",
+            "module": "mlflow.genai.scorers.deepeval",
+            "enabled_by_env": "EVAL_ENABLE_PII",
+        }
+        with patch.dict("os.environ", {}, clear=True):
+            result = resolve_scorer(entry, "openai:/gpt-4o-mini")
+        assert result is None
+
+    def test_loads_scorer_when_env_flag_is_true(self) -> None:
+        captured = {}
+
+        class FakePIILeakage:
+            def __init__(self, model):
+                captured["model"] = model
+
+        mock_module = MagicMock()
+        mock_module.PIILeakage = FakePIILeakage
+
+        entry = {
+            "name": "PIILeakage",
+            "module": "mlflow.genai.scorers.deepeval",
+            "enabled_by_env": "EVAL_ENABLE_PII",
+        }
+        with (
+            patch.dict("os.environ", {"EVAL_ENABLE_PII": "true"}, clear=True),
+            patch("importlib.import_module", return_value=mock_module),
+        ):
+            result = resolve_scorer(entry, "openai:/gpt-4o-mini")
+        assert isinstance(result, FakePIILeakage)
+        assert captured["model"] == "openai:/gpt-4o-mini"
+
+    def test_uses_model_env_override(self) -> None:
+        captured = {}
+
+        class FakePIILeakage:
+            def __init__(self, model):
+                captured["model"] = model
+
+        mock_module = MagicMock()
+        mock_module.PIILeakage = FakePIILeakage
+
+        entry = {
+            "name": "PIILeakage",
+            "module": "mlflow.genai.scorers.deepeval",
+            "enabled_by_env": "EVAL_ENABLE_PII",
+            "model_env": "EVAL_PII_MODEL",
+        }
+        with (
+            patch.dict(
+                "os.environ",
+                {"EVAL_ENABLE_PII": "true", "EVAL_PII_MODEL": "openai:/gpt-4.1-mini"},
+                clear=True,
+            ),
+            patch("importlib.import_module", return_value=mock_module),
+        ):
+            resolve_scorer(entry, "openai:/gpt-4o-mini")
+        assert captured["model"] == "openai:/gpt-4.1-mini"
+
+    def test_custom_scorer_function_not_called_with_model(self) -> None:
+        """Regression: @scorer decorated functions don't accept model= argument."""
+
+        def my_custom_scorer():
+            pass
+
+        mock_module = MagicMock()
+        mock_module.my_custom_scorer = my_custom_scorer
+
+        entry = {"name": "my_custom_scorer", "module": "scorers"}
+        with patch("importlib.import_module", return_value=mock_module):
+            result = resolve_scorer(entry, "openai:/gpt-4o-mini")
+        assert result is my_custom_scorer
+
+    def test_class_scorer_instantiated_with_model(self) -> None:
+        mock_class = type("MockScorer", (), {"__init__": lambda self, model: None})
+        mock_module = MagicMock()
+        mock_module.Safety = mock_class
+
+        entry = {"name": "Safety", "module": "mlflow.genai.scorers"}
+        with patch("importlib.import_module", return_value=mock_module):
+            result = resolve_scorer(entry, "openai:/gpt-4o-mini")
+        assert isinstance(result, mock_class)
+
+
+# ---------------------------------------------------------------------------
+# get_scorers
+# ---------------------------------------------------------------------------
+
+
+class TestGetScorers:
+    def test_includes_guidelines_scorer(self) -> None:
+        config = {
+            "scorers": {
+                "core": [],
+                "use_case": [],
+                "guidelines": ["Be helpful", "Be safe"],
+            }
+        }
+        scorers = get_scorers(config, "openai:/gpt-4o-mini")
+        assert len(scorers) == 1
+        assert scorers[0].name == "domain_guidelines"
+
+    def test_empty_guidelines_skips_scorer(self) -> None:
+        config = {"scorers": {"core": [], "use_case": [], "guidelines": []}}
+        scorers = get_scorers(config, "openai:/gpt-4o-mini")
+        assert len(scorers) == 0
+
+    def test_none_use_case_handled(self) -> None:
+        config = {"scorers": {"core": [], "use_case": None, "guidelines": []}}
+        scorers = get_scorers(config, "openai:/gpt-4o-mini")
+        assert scorers == []
+
+    def test_missing_scorers_key_handled(self) -> None:
+        """Regression: empty YAML returns {}, bracket access to 'scorers' crashes."""
+        config = {}
+        scorers = get_scorers(config, "openai:/gpt-4o-mini")
+        assert scorers == []
+
+    def test_missing_scorer_name_or_module_skipped(self) -> None:
+        config = {
+            "scorers": {
+                "core": [
+                    {"name": "Safety"},
+                    {"module": "mlflow.genai.scorers"},
+                ],
+                "use_case": [],
+                "guidelines": [],
+            }
+        }
+        scorers = get_scorers(config, "openai:/gpt-4o-mini")
+        assert scorers == []
+
+
+# ---------------------------------------------------------------------------
+# attach_expectations
+# ---------------------------------------------------------------------------
+
+
+def _make_trace(
+    trace_id: str,
+    timestamp_ms: int,
+    question: str = "",
+    expectation_names: list[str] | None = None,
+) -> MagicMock:
+    """Create a mock trace with the given ID, timestamp, and request content."""
+    trace = MagicMock()
+    trace.info.trace_id = trace_id
+    trace.info.timestamp_ms = timestamp_ms
+    trace.data.request = json.dumps({"messages": [{"content": question}]})
+    assessments = []
+    for name in expectation_names or []:
+        assessment = MagicMock()
+        assessment.name = name
+        assessments.append(assessment)
+    trace.search_assessments.return_value = assessments
+    return trace
+
+
+class TestAttachExpectations:
+    def test_matches_by_content(self) -> None:
+        """Traces are matched to eval_data by question content."""
+        traces = [
+            _make_trace("t1", 1000, "Q1"),
+            _make_trace("t2", 2000, "Q2"),
+            _make_trace("t3", 3000, "Q3"),
+        ]
+        eval_data = [
+            {"inputs": {"question": "Q1"}, "expectations": {"expected_facts": ["A1"]}},
+            {"inputs": {"question": "Q2"}, "expectations": {"expected_facts": ["A2"]}},
+            {"inputs": {"question": "Q3"}, "expectations": {"expected_facts": ["A3"]}},
+        ]
+        with patch("evaluation.run_eval.mlflow") as mock_mlflow:
+            expectation_names_by_trace_id = attach_expectations(traces, eval_data)
+
+        assert expectation_names_by_trace_id == {
+            "t1": {"expected_facts"},
+            "t2": {"expected_facts"},
+            "t3": {"expected_facts"},
+        }
+        assert mock_mlflow.log_expectation.call_count == 3
+
+    def test_ignores_unrelated_traces(self) -> None:
+        """Traces that don't match any golden query are skipped."""
+        traces = [
+            _make_trace("t1", 1000, "Q1"),
+            _make_trace("stray", 1500, "Some other question"),
+            _make_trace("t2", 2000, "Q2"),
+        ]
+        eval_data = [
+            {"inputs": {"question": "Q1"}, "expectations": {"expected_facts": ["A1"]}},
+            {"inputs": {"question": "Q2"}, "expectations": {"expected_facts": ["A2"]}},
+        ]
+        with patch("evaluation.run_eval.mlflow") as mock_mlflow:
+            expectation_names_by_trace_id = attach_expectations(traces, eval_data)
+
+        assert set(expectation_names_by_trace_id) == {"t1", "t2"}
+        assert "stray" not in expectation_names_by_trace_id
+        assert mock_mlflow.log_expectation.call_count == 2
+
+    def test_more_queries_than_traces(self) -> None:
+        """If fewer traces than queries, only match what we have."""
+        traces = [_make_trace("t1", 1000, "Q1")]
+        eval_data = [
+            {"inputs": {"question": "Q1"}, "expectations": {"expected_facts": ["A1"]}},
+            {"inputs": {"question": "Q2"}, "expectations": {"expected_facts": ["A2"]}},
+        ]
+        with patch("evaluation.run_eval.mlflow"):
+            expectation_names_by_trace_id = attach_expectations(traces, eval_data)
+
+        assert expectation_names_by_trace_id == {"t1": {"expected_facts"}}
+
+    def test_query_without_expectations(self) -> None:
+        """Queries with no expectations still match (trace ID tracked)."""
+        traces = [_make_trace("t1", 1000, "Q1")]
+        eval_data = [{"inputs": {"question": "Q1"}}]
+
+        with patch("evaluation.run_eval.mlflow") as mock_mlflow:
+            expectation_names_by_trace_id = attach_expectations(traces, eval_data)
+
+        assert expectation_names_by_trace_id == {"t1": set()}
+        mock_mlflow.log_expectation.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# refetch_matched_traces_with_expectations
+# ---------------------------------------------------------------------------
+
+
+class TestRefetchMatchedTracesWithExpectations:
+    def test_retries_until_expectations_are_visible(self) -> None:
+        trace_without_expectations = _make_trace("t1", 1000, "Q1")
+        trace_with_expectations = _make_trace(
+            "t1", 1000, "Q1", expectation_names=["expected_facts"]
+        )
+
+        with (
+            patch(
+                "evaluation.run_eval.mlflow.search_traces",
+                side_effect=[[trace_without_expectations], [trace_with_expectations]],
+            ) as search_traces,
+            patch("evaluation.run_eval.time.sleep") as sleep,
+        ):
+            traces = refetch_matched_traces_with_expectations(
+                experiment_id="1",
+                baseline_ms=0,
+                expectation_names_by_trace_id={"t1": {"expected_facts"}},
+                timeout=5,
+                poll_interval=1,
+            )
+
+        assert traces == [trace_with_expectations]
+        assert search_traces.call_count == 2
+        sleep.assert_called_once_with(1)
+
+    def test_times_out_when_expectations_do_not_become_visible(self) -> None:
+        trace = _make_trace("t1", 1000, "Q1")
+
+        with (
+            patch("evaluation.run_eval.mlflow.search_traces", return_value=[trace]),
+            patch("evaluation.run_eval.time.monotonic", side_effect=[0, 2]),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                refetch_matched_traces_with_expectations(
+                    experiment_id="1",
+                    baseline_ms=0,
+                    expectation_names_by_trace_id={"t1": {"expected_facts"}},
+                    timeout=1,
+                    poll_interval=1,
+                )
+
+        assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# filter_matching_traces_or_exit
+# ---------------------------------------------------------------------------
+
+
+class TestFilterMatchingTracesOrExit:
+    def test_returns_only_matching_traces(self) -> None:
+        matching_trace = _make_trace("t1", 1000, "Q1")
+        stray_trace = _make_trace("stray", 1000, "Other")
+
+        traces = filter_matching_traces_or_exit(
+            traces=[matching_trace, stray_trace],
+            golden_questions={"Q1"},
+            expected_count=1,
+            trace_timeout=1,
+            experiment_name="test-experiment",
+        )
+
+        assert traces == [matching_trace]
+
+    def test_fails_when_no_traces_found(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            filter_matching_traces_or_exit(
+                traces=[],
+                golden_questions={"Q1"},
+                expected_count=1,
+                trace_timeout=1,
+                experiment_name="test-experiment",
+            )
+
+        assert exc_info.value.code == 1
+
+    def test_fails_when_matching_trace_count_is_incomplete(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            filter_matching_traces_or_exit(
+                traces=[_make_trace("stray", 1000, "Other")],
+                golden_questions={"Q1"},
+                expected_count=1,
+                trace_timeout=1,
+                experiment_name="test-experiment",
+            )
+
+        assert exc_info.value.code == 1

--- a/agents/langgraph/templates/human_in_the_loop/uv.lock
+++ b/agents/langgraph/templates/human_in_the_loop/uv.lock
@@ -164,6 +164,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "blinker"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -346,14 +355,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.0"
+version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz", hash = "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973", size = 350843, upload-time = "2026-05-17T00:47:58.425Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl", hash = "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81", size = 116147, upload-time = "2026-05-17T00:47:56.842Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
 ]
 
 [[package]]
@@ -517,6 +526,45 @@ wheels = [
 ]
 
 [[package]]
+name = "deepeval"
+version = "4.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "grpcio" },
+    { name = "jinja2" },
+    { name = "nest-asyncio" },
+    { name = "openai" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "portalocker" },
+    { name = "posthog" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyfiglet" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-repeat" },
+    { name = "pytest-rerunfailures" },
+    { name = "pytest-xdist" },
+    { name = "python-dotenv" },
+    { name = "questionary" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "setuptools" },
+    { name = "tabulate" },
+    { name = "tenacity" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "wheel" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/54/918ff66b6532124dc3867386deb1cd8dee60b07cedbc029f9085bd7baa7a/deepeval-4.2.2.tar.gz", hash = "sha256:43c7252718a1c0de467a2526c3dac873b2f5d6677faa9a01e2a332a8d07e8240", size = 903588, upload-time = "2026-09-06T14:42:09.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/57/9c36db0a73969d69807507d287640acec9282ee04ac31850b4ac4b0c1d62/deepeval-4.2.2-py3-none-any.whl", hash = "sha256:b9ea5328083fb2a53ef6fef197942985cf92a1e3ae0d8f974c698635d439ef37", size = 1312059, upload-time = "2026-09-06T14:42:11.965Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -537,6 +585,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
+name = "durationpy"
+version = "0.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/5d/5f8571bd5dedc80863191621ac4be001f3f3dd8315d2ec078705dab7dec1/durationpy-0.11.tar.gz", hash = "sha256:181898e1ae282e288f0a2291829656bf1b6b3aadf30a97993b85db4943642905", size = 3582, upload-time = "2026-08-26T13:56:00.991Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/c4/ebdf7837bc4ef6fd98cfb013c28855bb358467bf86c1af011bbc21e21df0/durationpy-0.11-py3-none-any.whl", hash = "sha256:a739fe2b8972c250ff72f8e2c488d18cf25f7b852f49ee76048775d5171df30c", size = 4133, upload-time = "2026-08-26T13:55:59.456Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -988,7 +1054,16 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "httpx" },
+    { name = "mlflow" },
     { name = "pytest" },
+    { name = "pyyaml" },
+]
+eval = [
+    { name = "deepeval" },
+    { name = "httpx" },
+    { name = "mlflow", extra = ["kubernetes"] },
+    { name = "pyyaml" },
 ]
 tracing = [
     { name = "mlflow" },
@@ -997,25 +1072,32 @@ tracing = [
 [package.metadata]
 requires-dist = [
     { name = "chardet", specifier = "==7.2.0" },
+    { name = "deepeval", marker = "extra == 'eval'", specifier = ">=4.2,<5" },
     { name = "fastapi", specifier = ">=0.135.1" },
     { name = "flask", specifier = ">=3.1.0" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
+    { name = "httpx", marker = "extra == 'eval'", specifier = ">=0.27" },
     { name = "langchain", specifier = ">=1.2.10" },
     { name = "langchain-openai", specifier = ">=1.1.10" },
     { name = "langgraph", specifier = ">=1.0.9" },
     { name = "langgraph-checkpoint", specifier = ">=3.0.0" },
     { name = "langgraph-prebuilt", specifier = ">=1.0.8" },
     { name = "milvus-lite", specifier = ">=2.4.0" },
+    { name = "mlflow", marker = "extra == 'dev'", specifier = ">=3.11.0" },
     { name = "mlflow", marker = "extra == 'tracing'", specifier = ">=3.10.0" },
+    { name = "mlflow", extras = ["kubernetes"], marker = "extra == 'eval'", specifier = ">=3.11.0" },
     { name = "openai", specifier = ">=2.24.0" },
     { name = "pymilvus", specifier = "==2.5.9" },
     { name = "pypdf", specifier = "==6.9.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "pyyaml", marker = "extra == 'eval'", specifier = ">=6.0" },
     { name = "setuptools", specifier = ">=80.9.0,<83.0.0" },
     { name = "starlette", specifier = ">=1.0.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0" },
 ]
-provides-extras = ["tracing", "dev"]
+provides-extras = ["tracing", "dev", "eval"]
 
 [[package]]
 name = "idna"
@@ -1257,6 +1339,27 @@ wheels = [
 ]
 
 [[package]]
+name = "kubernetes"
+version = "36.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "certifi" },
+    { name = "durationpy" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "six" },
+    { name = "urllib3" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/57/b07b96353f902aa1bdbe00e878e3a12a137977d03a962479785576aa8ec9/kubernetes-36.0.3.tar.gz", hash = "sha256:36993ed25ce59b789c9341473a228fcf268504a2fec7c2b2b1531d73072e5ce7", size = 2337528, upload-time = "2026-07-13T20:38:12.128Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/30/a96d47df739689ac0001ade0afefc16e3b477fc2fb426b568515fdc8afce/kubernetes-36.0.3-py2.py3-none-any.whl", hash = "sha256:8fde9241c4b298e6374a069dcf728359b4e72c2fb29489a975ba4e1c047cf10f", size = 4618066, upload-time = "2026-07-13T20:38:10.172Z" },
+]
+
+[[package]]
 name = "langchain"
 version = "1.2.18"
 source = { registry = "https://pypi.org/simple" }
@@ -1405,6 +1508,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1522,6 +1637,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "milvus-lite"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1565,6 +1689,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/69/d71afc475fa7e7b22bb27392247d2a3015c9da202dea44f150a54be4bd67/mlflow-3.13.0.tar.gz", hash = "sha256:a95198d592a8a15fad3db7f56b228acc9422c09f0daa7c6c976a9996ab73c3e2", size = 10086808, upload-time = "2026-06-01T05:55:09.555Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/1f/d44140128356f2f5db37f9fb4d9da31123d839d49f3fe00a079cd35bfe20/mlflow-3.13.0-py3-none-any.whl", hash = "sha256:7ca9cb2f623f300dabadaf5e985c85af77c5db3d7c36f56769d22c101b132f6c", size = 10788121, upload-time = "2026-06-01T05:55:06.86Z" },
+]
+
+[package.optional-dependencies]
+kubernetes = [
+    { name = "kubernetes" },
 ]
 
 [[package]]
@@ -1717,6 +1846,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1775,6 +1913,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
     { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
     { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
 ]
 
 [[package]]
@@ -2074,6 +2221,30 @@ wheels = [
 ]
 
 [[package]]
+name = "portalocker"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/8e/27672cd2dde9d2345ead0352146a401be4ec0af132be86ca7a2db24afb09/portalocker-4.3.0.tar.gz", hash = "sha256:69bf8e46769d66eb0a23219b9550253d2c3b5f03400202a2333784c1e6395e32", size = 263582, upload-time = "2026-08-25T18:05:20.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/76/57be9bb352b3f91c80671a7b7ce2cd51f99ad324c89df82a098df9b9e609/portalocker-4.3.0-py3-none-any.whl", hash = "sha256:aa91709ccfc322b8225171392d64a2f9fc833f15f5ab741cfba6d3fba285ce31", size = 129554, upload-time = "2026-08-25T18:05:18.64Z" },
+]
+
+[[package]]
+name = "posthog"
+version = "7.47.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/1b/61eccf2257847def7d01ccae29f9680156cb1cd2b4f00d3e9afaabe236fa/posthog-7.47.0.tar.gz", hash = "sha256:62767af8b0808cb103da37aa3974e728467fed9527e4f201f23e718740debd30", size = 508993, upload-time = "2026-09-04T16:52:31.715Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/28/16b9b229b9c2380211249377df5bbb4c33cb8b224b7b27ecd46c89bcedac/posthog-7.47.0-py3-none-any.whl", hash = "sha256:c87daf7830eb5ef779d0ff1ec25b5de6d316926d6bbbcde74b80e055172a0ddc", size = 601509, upload-time = "2026-09-04T16:52:29.935Z" },
+]
+
+[[package]]
 name = "prettytable"
 version = "3.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2083,6 +2254,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892, upload-time = "2025-11-14T17:33:20.212Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/8c/83087ebc47ab0396ce092363001fa37c17153119ee282700c0713a195853/prettytable-3.17.0-py3-none-any.whl", hash = "sha256:aad69b294ddbe3e1f95ef8886a060ed1666a0b83018bbf56295f6f226c43d287", size = 34433, upload-time = "2025-11-14T17:33:19.093Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.53"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ea/39b988c938f75cb75d7045b5c69f8bfed47ee2152c8837fb403de29d6fb8/prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6", size = 435492, upload-time = "2026-07-26T20:56:14.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2", size = 392288, upload-time = "2026-07-26T20:56:12.512Z" },
 ]
 
 [[package]]
@@ -2358,6 +2541,29 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
+]
+
+[[package]]
+name = "pyfiglet"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/e3/0a86276ad2c383ce08d76110a8eec2fe22e7051c4b8ba3fa163a0b08c428/pyfiglet-1.0.4.tar.gz", hash = "sha256:db9c9940ed1bf3048deff534ed52ff2dafbbc2cd7610b17bb5eca1df6d4278ef", size = 1560615, upload-time = "2025-08-15T18:32:47.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/5c/fe9f95abd5eaedfa69f31e450f7e2768bef121dbdf25bcddee2cd3087a16/pyfiglet-1.0.4-py3-none-any.whl", hash = "sha256:65b57b7a8e1dff8a67dc8e940a117238661d5e14c3e49121032bd404d9b2b39f", size = 1806118, upload-time = "2025-08-15T18:32:45.556Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2416,6 +2622,57 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pytest-repeat"
+version = "0.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/d4/69e9dbb9b8266df0b157c72be32083403c412990af15c7c15f7a3fd1b142/pytest_repeat-0.9.4.tar.gz", hash = "sha256:d92ac14dfaa6ffcfe6917e5d16f0c9bc82380c135b03c2a5f412d2637f224485", size = 6488, upload-time = "2025-04-07T14:59:53.077Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/d4/8b706b81b07b43081bd68a2c0359fe895b74bf664b20aca8005d2bb3be71/pytest_repeat-0.9.4-py3-none-any.whl", hash = "sha256:c1738b4e412a6f3b3b9e0b8b29fcd7a423e50f87381ad9307ef6f5a8601139f3", size = 4180, upload-time = "2025-04-07T14:59:51.492Z" },
+]
+
+[[package]]
+name = "pytest-rerunfailures"
+version = "16.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/ce/065fde089d5a7f46fe8372c3f340c7aaa8708734d2e8ae3032f0c29a4b1d/pytest_rerunfailures-16.6.1.tar.gz", hash = "sha256:20ac38d31f9319c4e8f43fe0d0e9c22755508e8e7987a88de6d7fd93fc6bdabb", size = 47719, upload-time = "2026-09-03T06:50:07.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/0d/4da1860f933e271569405fd8adef7f3e7f1c2bd1b544d2ee83a8e0acf1d2/pytest_rerunfailures-16.6.1-py3-none-any.whl", hash = "sha256:0c38d314a0a7e32795f2dbdeeb2b3d141ecf3d3abe10c8c32dae223d45ac7b3d", size = 21035, upload-time = "2026-09-03T06:50:06.601Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]
@@ -2508,6 +2765,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "questionary"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
 ]
 
 [[package]]
@@ -2614,6 +2883,19 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
 name = "requests-toolbelt"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2623,6 +2905,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
 ]
 
 [[package]]
@@ -2740,6 +3035,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2851,6 +3155,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tabulate"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2925,6 +3238,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/f7/57713ba479fd405eb76de31404b2c744c289e336b2d999511ebf51e496f7/typer-0.27.2.tar.gz", hash = "sha256:269b7eb9d3c202ca84b4bc9618cb04ebb43d3d4d1e567e4c768607232c05f945", size = 204045, upload-time = "2026-08-28T10:26:55.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/bf/205d0004930ede8f542fb58f601526fccf4ae7626075ca1e6c4de5d3d652/typer-0.27.2-py3-none-any.whl", hash = "sha256:b3a5fc4342d5fc8fda8fc3010b1cf117e9249aab7fae800c2eff62fd3842d97d", size = 123130, upload-time = "2026-08-28T10:26:53.752Z" },
 ]
 
 [[package]]
@@ -3249,6 +3577,15 @@ wheels = [
 ]
 
 [[package]]
+name = "websocket-client"
+version = "1.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/cb/a5abcc2891249f393827c650c6296660ce40374ac22d99ab9aea41f9d2a2/websocket_client-1.9.2.tar.gz", hash = "sha256:0fcb57545848be86992e128218fd96dd87a6769ffdb1a968dff79632b85604d0", size = 84110, upload-time = "2026-08-31T14:08:40.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/d2/cc4dc1271e464942db7ee278baae2daa99ee77cb2af744025c04da585a3e/websocket_client-1.9.2-py3-none-any.whl", hash = "sha256:e1a673830a9c7bfa47b1cd3d5e4178f4c9651d80a4eab02c9c23a1c3ec6250ce", size = 95786, upload-time = "2026-08-31T14:08:39.899Z" },
+]
+
+[[package]]
 name = "websockets"
 version = "16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3303,6 +3640,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
+name = "wheel"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/20/50ed6bdf27dec98b568a8ae25dc599f35baa3d9709f9e83fd1edb56b9a90/wheel-0.48.0.tar.gz", hash = "sha256:94800765601e9171bf5d58d066e640662842bcedcbab982b2c90787a2c987322", size = 66471, upload-time = "2026-08-11T22:02:27.327Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/29/69cfbb602cd91690c55d38ba9fe53e6a7e76a6fa647bf38f19c138d25449/wheel-0.48.0-py3-none-any.whl", hash = "sha256:3217dcc807155e45db462d7ef2431f5ddda0d7273b700d05a67b271ceb1287ab", size = 33320, upload-time = "2026-08-11T22:02:26.1Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Adds config-driven MLflow GenAI evaluation support to the LangGraph
`human_in_the_loop` template. The template now has a reusable evaluation
module, placeholder golden-query data, documented evaluator configuration,
and a `make eval` target for running trace-based scoring against a live agent.

**Key changes:**

- `agents/langgraph/templates/human_in_the_loop/evaluation/run_eval.py` -- sends
  golden queries to a running agent, waits for matching MLflow traces, attaches
  expectations, re-fetches until expectations are visible, and evaluates with
  dynamically resolved scorers.
- `agents/langgraph/templates/human_in_the_loop/evaluation/eval_config.yaml` --
  defines core MLflow GenAI scorers, opt-in PII leakage scoring, use-case scorer
  extension points, and generic guideline checks.
- `agents/langgraph/templates/human_in_the_loop/evaluation/eval_data.yaml` --
  adds commented placeholder golden queries with a HITL-specific warning to
  avoid prompts that trigger approval unless the eval flow handles resume.
- `agents/langgraph/templates/human_in_the_loop/tests/test_eval.py` -- covers
  config/data loading, duplicate-question validation, scorer resolution,
  malformed scorer entries, expectation attachment, expectation re-fetching,
  and trace failure handling.
- `agents/langgraph/templates/human_in_the_loop/pyproject.toml` and `uv.lock` --
  add eval dependencies and the import-time dependencies needed for `make test`
  to run eval unit tests instead of skipping them.
- `TODO-eval-cleanup.md` -- records shared eval-harness cleanup items for
  follow-up across templates.

**How it works:**

1. A developer fills in safe single-turn golden queries in
   `evaluation/eval_data.yaml`.
2. The agent runs with MLflow tracing enabled.
3. `make eval` sends each query to `POST /chat/completions` and polls MLflow
   for traces generated after the run baseline.
4. The script matches traces by exact user question text, attaches expectations,
   waits for expectation assessments to become visible, and evaluates the
   matched traces with the configured scorers.
5. Results are logged to the configured MLflow experiment.

## Jira Ticket

[RHAIENG-7145](https://redhat.atlassian.net/browse/RHAIENG-7145)

## Testing

- [x] `make test` passes (run from the affected agent directory)
- [x] Manual testing performed (describe steps below)
- [ ] No testing required (documentation/config change only)

Verification performed:

- `ruff check agents/langgraph/templates/human_in_the_loop/evaluation agents/langgraph/templates/human_in_the_loop/tests/test_eval.py`
- `ruff format --check agents/langgraph/templates/human_in_the_loop/evaluation agents/langgraph/templates/human_in_the_loop/tests/test_eval.py`
- `uv lock --check` from `agents/langgraph/templates/human_in_the_loop`
- `uv run --extra dev --extra eval python -m pytest tests/test_eval.py -v`
- `uv sync --extra dev`
- `make test` from `agents/langgraph/templates/human_in_the_loop`
- `pre-commit run --files ...` passed for all hooks except local `lychee`,
  which could not run because the `lychee` executable is not installed.
- `SKIP=lychee pre-commit run --files ...` passed, including the
  `uv-lock (langgraph/human_in_the_loop)` hook.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket

## Review Guidance

- Start with `evaluation/run_eval.py` for the trace generation, matching,
  scorer resolution, and failure semantics.
- Review `tests/test_eval.py` alongside `run_eval.py`; the tests cover the
  reviewer-raised edge cases around duplicate questions, malformed scorer
  config, nonzero trace failures, and expectation re-fetching.
- Check `eval_data.yaml` and the README for HITL-specific guidance: default
  template eval data is placeholder-only, and real eval prompts should not
  trigger approval unless the caller handles approval and resume.

## Related PRs

None.


[RHAIENG-7145]: https://redhat.atlassian.net/browse/RHAIENG-7145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ