### PR TITLE
feat(ci): show gate/agent status summary in QG pipeline Slack alert (RHAIENG-6543)

### DIFF
--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -29,6 +29,10 @@ inputs:
   status:
     description: "Notification status label, for example failure or cancelled"
     required: true
+  summary_text:
+    description: "Pre-rendered mrkdwn summary to show instead of the generic failed-jobs list"
+    required: false
+    default: ""
   preview:
     description: "If true, print the payload instead of sending it"
     required: false
@@ -39,6 +43,7 @@ runs:
   steps:
     - name: Collect failed jobs
       id: collect-failed-jobs
+      if: inputs.summary_text == ''
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
@@ -83,6 +88,7 @@ runs:
         DASHBOARD_URL: ${{ inputs.dashboard_url }}
         REPOSITORY: ${{ inputs.repository }}
         FAILED_JOBS_JSON: ${{ steps.collect-failed-jobs.outputs.failed_jobs_json }}
+        SUMMARY_TEXT: ${{ inputs.summary_text }}
       run: |
         set -euo pipefail
 

--- a/.github/actions/notify-slack/render_payload.sh
+++ b/.github/actions/notify-slack/render_payload.sh
@@ -78,7 +78,7 @@ jq -n \
   --arg ref_name "${REF_NAME}" \
   --arg repository "${REPOSITORY}" \
   --arg timestamp "${TIMESTAMP}" \
-  --arg failed_jobs_text "${DETAILS_TEXT}" \
+  --arg details_text "${DETAILS_TEXT}" \
   --arg links_text "${LINKS_TEXT}" \
   '{
     text: $fallback_text,
@@ -128,7 +128,7 @@ jq -n \
             type: "section",
             text: {
               type: "mrkdwn",
-              text: $failed_jobs_text
+              text: $details_text
             }
           },
           {

--- a/.github/actions/notify-slack/render_payload.sh
+++ b/.github/actions/notify-slack/render_payload.sh
@@ -17,12 +17,18 @@ REPOSITORY="${REPOSITORY:?REPOSITORY is required}"
 STATUS="${STATUS:-failure}"
 TIMESTAMP="${TIMESTAMP:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
 FAILED_JOBS_JSON="${FAILED_JOBS_JSON:-[]}"
+SUMMARY_TEXT="${SUMMARY_TEXT:-}"
 
 if ! jq -e 'type == "array"' <<<"${FAILED_JOBS_JSON}" >/dev/null 2>&1; then
   FAILED_JOBS_JSON='[]'
 fi
 
 case "${STATUS}" in
+  success)
+    COLOR="#2eb67d"
+    TITLE="CI Success: ${WORKFLOW_NAME}"
+    STATUS_LABEL="Passed"
+    ;;
   failure | failed | timed_out)
     COLOR="#d00000"
     TITLE="CI Failure: ${WORKFLOW_NAME}"
@@ -40,19 +46,25 @@ case "${STATUS}" in
     ;;
 esac
 
-FAILED_JOBS_TEXT="$(
-  jq -nr --argjson jobs "${FAILED_JOBS_JSON}" '
-    if ($jobs | length) == 0 then
-      "*Failed jobs*\n- Job details unavailable"
-    elif ($jobs | length) <= 10 then
-      "*Failed jobs*\n" + ($jobs | map("- `" + . + "`") | join("\n"))
-    else
-      "*Failed jobs*\n"
-      + ($jobs[:10] | map("- `" + . + "`") | join("\n"))
-      + "\n- ... and \((($jobs | length) - 10)) more"
-    end
-  '
-)"
+if [[ -n "${SUMMARY_TEXT}" ]]; then
+  # Caller supplied its own rendered summary (e.g. a gate/agent status
+  # breakdown) — use it verbatim instead of the generic failed-jobs list.
+  DETAILS_TEXT="${SUMMARY_TEXT}"
+else
+  DETAILS_TEXT="$(
+    jq -nr --argjson jobs "${FAILED_JOBS_JSON}" '
+      if ($jobs | length) == 0 then
+        "*Failed jobs*\n- Job details unavailable"
+      elif ($jobs | length) <= 10 then
+        "*Failed jobs*\n" + ($jobs | map("- `" + . + "`") | join("\n"))
+      else
+        "*Failed jobs*\n"
+        + ($jobs[:10] | map("- `" + . + "`") | join("\n"))
+        + "\n- ... and \((($jobs | length) - 10)) more"
+      end
+    '
+  )"
+fi
 
 LINKS_TEXT="<${RUN_URL}|View workflow run> | <${DASHBOARD_URL}|View CI dashboard>"
 FALLBACK_TEXT="CI ${STATUS_LABEL}: ${WORKFLOW_NAME} on ${REF_NAME}"
@@ -66,7 +78,7 @@ jq -n \
   --arg ref_name "${REF_NAME}" \
   --arg repository "${REPOSITORY}" \
   --arg timestamp "${TIMESTAMP}" \
-  --arg failed_jobs_text "${FAILED_JOBS_TEXT}" \
+  --arg failed_jobs_text "${DETAILS_TEXT}" \
   --arg links_text "${LINKS_TEXT}" \
   '{
     text: $fallback_text,

--- a/.github/scripts/build_qg_summary.sh
+++ b/.github/scripts/build_qg_summary.sh
@@ -21,7 +21,12 @@ QG4_RESULT="${QG4_RESULT:?QG4_RESULT is required}"
 QG7_RESULT="${QG7_RESULT:?QG7_RESULT is required}"
 QG4_OUTCOMES_DIR="${QG4_OUTCOMES_DIR:-qg4-outcomes}"
 QG7_OUTCOMES_DIR="${QG7_OUTCOMES_DIR:-qg7-outcomes}"
-MAX_AGENT_ROWS="${MAX_AGENT_ROWS:-40}"
+# Slack section blocks cap text at 3000 characters; this is the budget for
+# the *entire* summary_text (gate summary + agent table together), since
+# both land in one section block. Row count alone can't bound this — agent
+# name length varies — so the table is truncated by character budget, not a
+# fixed row count.
+TOTAL_CHAR_BUDGET="${TOTAL_CHAR_BUDGET:-2900}"
 
 # Agents that pass QG4 but are intentionally excluded from QG7 behavioral
 # evals. Set via the QG7_EXCLUDED_AGENTS_JSON workflow-level env var in
@@ -130,8 +135,8 @@ filter_valid_json() {
 # because this function is invoked inside a `$(...)` subshell, so any
 # variables it sets wouldn't be visible back in the caller's scope.
 build_agent_table() {
-  local qg7_json="$1"
-  shift
+  local qg7_json="$1" char_budget="$2"
+  shift 2
   local -a qg4_files=("$@")
 
   local rows
@@ -161,24 +166,48 @@ build_agent_table() {
   local total_count
   total_count="$(jq 'length' <<<"${rows}")"
 
-  local table_body
-  table_body="$(
-    while IFS=$'\t' read -r name qg4_status qg7_status; do
-      qg4_sym="$(agent_status_icon "${qg4_status}")"
-      qg7_sym="$(agent_status_icon "${qg7_status}")"
-      note="$(agent_status_note "${qg7_status}")"
-      printf '%-34s %-2s   %-2s   %s\n' "${name}" "${qg4_sym}" "${qg7_sym}" "${note}"
-    done < <(jq -r --argjson limit "${MAX_AGENT_ROWS}" '.[:$limit] | .[] | [.name, .qg4, .qg7] | @tsv' <<<"${rows}")
-  )"
+  local header
+  header="$(printf '%-34s %-4s %-4s' "agent" "qg4" "qg7")"
+  # Fixed overhead around the table: "*Agent Results*\n```\n" + header line +
+  # "\n" + closing "```", plus a little slack for the header line itself.
+  local chrome_len=$(( ${#header} + 32 ))
 
-  if [[ "${total_count}" -gt "${MAX_AGENT_ROWS}" ]]; then
+  local -a row_lines=()
+  while IFS=$'\t' read -r name qg4_status qg7_status; do
+    qg4_sym="$(agent_status_icon "${qg4_status}")"
+    qg7_sym="$(agent_status_icon "${qg7_status}")"
+    note="$(agent_status_note "${qg7_status}")"
+    row_lines+=("$(printf '%-34s %-2s   %-2s   %s' "${name}" "${qg4_sym}" "${qg7_sym}" "${note}")")
+  done < <(jq -r '.[] | [.name, .qg4, .qg7] | @tsv' <<<"${rows}")
+
+  # Reserve room for the truncation trailer up front so it's never the thing
+  # that pushes the block over budget.
+  local trailer_reserve=70
+  local shown=0
+  local running_len=${chrome_len}
+  local -a included=()
+  local line line_len
+  for line in "${row_lines[@]+"${row_lines[@]}"}"; do
+    line_len=$(( ${#line} + 1 ))
+    if (( running_len + line_len + trailer_reserve > char_budget )); then
+      break
+    fi
+    included+=("${line}")
+    running_len=$(( running_len + line_len ))
+    shown=$(( shown + 1 ))
+  done
+
+  local table_body=""
+  if [[ ${#included[@]} -gt 0 ]]; then
+    table_body="$(printf '%s\n' "${included[@]}")"
+  fi
+  if (( shown < total_count )); then
     table_body="${table_body}
-... and $((total_count - MAX_AGENT_ROWS)) more agent(s), see workflow run for the full matrix"
+... and $((total_count - shown)) more agent(s), see workflow run for the full matrix"
   fi
 
   # shellcheck disable=SC2016 # backticks here are a literal Slack code-fence, not command substitution
-  printf '*Agent Results*\n```\n%-34s %-4s %-4s\n%s\n```' \
-    "agent" "qg4" "qg7" "${table_body}"
+  printf '*Agent Results*\n```\n%s\n%s\n```' "${header}" "${table_body}"
 }
 
 shopt -s nullglob
@@ -206,23 +235,29 @@ if [[ ${#valid_qg7_files[@]} -gt 0 ]]; then
   qg7_json="$(jq -s '[.[] | {(.name): .status}] | add // {}' "${valid_qg7_files[@]}" 2>/dev/null)" || qg7_json='{}'
 fi
 
+warnings=()
+[[ "${invalid_qg4_count}" -gt 0 ]] && warnings+=("⚠️ ${invalid_qg4_count} QG4 outcome file(s) could not be parsed and were excluded")
+[[ "${invalid_qg7_count}" -gt 0 ]] && warnings+=("⚠️ ${invalid_qg7_count} QG7 outcome file(s) could not be parsed and were excluded")
+warnings_text=""
+for warning in "${warnings[@]+"${warnings[@]}"}"; do
+  warnings_text="${warnings_text}
+${warning}"
+done
+
 agent_table=""
 if [[ ${#all_qg4_files[@]} -gt 0 ]]; then
   if [[ ${#valid_qg4_files[@]} -gt 0 ]]; then
-    if ! agent_table="$(build_agent_table "${qg7_json}" "${valid_qg4_files[@]}")"; then
+    # Budget the agent table against what's left after the gate summary and
+    # any warning lines, since all of it lands in one Slack section block.
+    remaining_budget=$(( TOTAL_CHAR_BUDGET - ${#gate_summary} - ${#warnings_text} - 4 ))
+    [[ "${remaining_budget}" -lt 200 ]] && remaining_budget=200
+    if ! agent_table="$(build_agent_table "${qg7_json}" "${remaining_budget}" "${valid_qg4_files[@]}")"; then
       agent_table=$'*Agent Results*\n_agent-level summary unavailable (unexpected error building the table) — see workflow run for details_'
     fi
   else
     agent_table=$'*Agent Results*\n_agent-level summary unavailable (no readable outcome data) — see workflow run for details_'
   fi
-
-  warnings=()
-  [[ "${invalid_qg4_count}" -gt 0 ]] && warnings+=("⚠️ ${invalid_qg4_count} QG4 outcome file(s) could not be parsed and were excluded")
-  [[ "${invalid_qg7_count}" -gt 0 ]] && warnings+=("⚠️ ${invalid_qg7_count} QG7 outcome file(s) could not be parsed and were excluded")
-  for warning in "${warnings[@]+"${warnings[@]}"}"; do
-    agent_table="${agent_table}
-${warning}"
-  done
+  agent_table="${agent_table}${warnings_text}"
 fi
 
 if [[ -n "${agent_table}" ]]; then

--- a/.github/scripts/build_qg_summary.sh
+++ b/.github/scripts/build_qg_summary.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Build the quality-gates-pipeline Slack summary: a gate-level status block
+# (QG1/QG2/QG4/QG7) plus a per-agent QG4/QG7 matrix. Prints Slack mrkdwn to
+# stdout.
+
+set -euo pipefail
+
+command -v jq >/dev/null 2>&1 || {
+  echo "jq is required to build the QG summary" >&2
+  exit 1
+}
+
+QG1_RESULT="${QG1_RESULT:?QG1_RESULT is required}"
+QG2_RESULT="${QG2_RESULT:?QG2_RESULT is required}"
+QG4_RESULT="${QG4_RESULT:?QG4_RESULT is required}"
+QG7_RESULT="${QG7_RESULT:?QG7_RESULT is required}"
+QG4_OUTCOMES_DIR="${QG4_OUTCOMES_DIR:-qg4-outcomes}"
+QG7_OUTCOMES_DIR="${QG7_OUTCOMES_DIR:-qg7-outcomes}"
+
+# Agents that pass QG4 but are intentionally excluded from QG7 behavioral
+# evals. Keep in sync with the qg7_excluded list in the collect-qg4 job of
+# quality-gates-pipeline.yml.
+QG7_EXCLUDED='[
+  "langgraph/examples/guardrailed_agent",
+  "langgraph/templates/agentic_rag"
+]'
+
+gate_icon() {
+  case "$1" in
+    success) echo "✅" ;;
+    skipped) echo "⏭️" ;;
+    *) echo "❌" ;;
+  esac
+}
+
+gate_line() {
+  local label="$1" result="$2" note="${3:-}"
+  local icon
+  icon="$(gate_icon "${result}")"
+  if [[ -n "${note}" ]]; then
+    echo "${icon} ${label}: ${result} (${note})"
+  else
+    echo "${icon} ${label}: ${result}"
+  fi
+}
+
+qg2_note=""
+[[ "${QG2_RESULT}" == "skipped" ]] && qg2_note="blocked by QG1"
+qg4_note=""
+[[ "${QG4_RESULT}" == "skipped" ]] && qg4_note="blocked by QG1/QG2"
+qg7_note=""
+[[ "${QG7_RESULT}" == "skipped" ]] && qg7_note="no agents eligible"
+
+gate_summary="$(
+  {
+    echo "*Gate Summary*"
+    gate_line "QG1 — Cluster Readiness" "${QG1_RESULT}"
+    gate_line "QG2 — Platform Readiness" "${QG2_RESULT}" "${qg2_note}"
+    gate_line "QG4 — Deployment Health" "${QG4_RESULT}" "${qg4_note}"
+    gate_line "QG7 — Behavioral Evals" "${QG7_RESULT}" "${qg7_note}"
+  }
+)"
+
+agent_symbol() {
+  case "$1" in
+    success) echo "✅" ;;
+    failure) echo "❌" ;;
+    *) echo "⏭️" ;;
+  esac
+}
+
+agent_note() {
+  case "$1" in
+    blocked_fail) echo "blocked: failed QG4" ;;
+    blocked_skip) echo "QG4 skipped" ;;
+    excluded) echo "excluded from QG7" ;;
+    not_run) echo "QG7 did not run" ;;
+    *) echo "" ;;
+  esac
+}
+
+shopt -s nullglob
+qg4_files=("${QG4_OUTCOMES_DIR}"/qg4-outcome-*/result.json)
+
+agent_table=""
+if [[ ${#qg4_files[@]} -gt 0 ]]; then
+  qg7_files=("${QG7_OUTCOMES_DIR}"/qg7-outcome-*/result.json)
+  if [[ ${#qg7_files[@]} -gt 0 ]]; then
+    qg7_json="$(jq -s '[.[] | {(.name): .status}] | add // {}' "${qg7_files[@]}")"
+  else
+    qg7_json='{}'
+  fi
+
+  rows="$(
+    jq -s --argjson excluded "${QG7_EXCLUDED}" --argjson qg7 "${qg7_json}" '
+      map(
+        . as $a
+        | ($a.dir | ltrimstr("agents/")) as $qg7_id
+        | ($qg7_id | IN($excluded[])) as $is_excluded
+        | {
+            name: $a.name,
+            qg4: $a.status,
+            qg7: (
+              if $a.status == "skipped" then "blocked_skip"
+              elif $a.status != "success" then "blocked_fail"
+              elif $is_excluded then "excluded"
+              elif ($qg7 | has($a.name)) then $qg7[$a.name]
+              else "not_run"
+              end
+            )
+          }
+      )
+      | sort_by(.name)
+    ' "${qg4_files[@]}"
+  )"
+
+  table_body="$(
+    while IFS=$'\t' read -r name qg4_status qg7_status; do
+      qg4_sym="$(agent_symbol "${qg4_status}")"
+      qg7_sym="$(agent_symbol "${qg7_status}")"
+      note="$(agent_note "${qg7_status}")"
+      printf '%-34s %-2s   %-2s   %s\n' "${name}" "${qg4_sym}" "${qg7_sym}" "${note}"
+    done < <(jq -r '.[] | [.name, .qg4, .qg7] | @tsv' <<<"${rows}")
+  )"
+
+  agent_table="$(
+    # shellcheck disable=SC2016 # backticks here are a literal Slack code-fence, not command substitution
+    printf '*Agent Results*\n```\n%-34s %-4s %-4s\n%s\n```' \
+      "agent" "qg4" "qg7" "${table_body}"
+  )"
+fi
+
+if [[ -n "${agent_table}" ]]; then
+  printf '%s\n\n%s\n' "${gate_summary}" "${agent_table}"
+else
+  printf '%s\n' "${gate_summary}"
+fi

--- a/.github/scripts/build_qg_summary.sh
+++ b/.github/scripts/build_qg_summary.sh
@@ -2,6 +2,11 @@
 # Build the quality-gates-pipeline Slack summary: a gate-level status block
 # (QG1/QG2/QG4/QG7) plus a per-agent QG4/QG7 matrix. Prints Slack mrkdwn to
 # stdout.
+#
+# Never lets a malformed outcome artifact abort the whole summary: the gate
+# summary always renders, and the agent table degrades to a placeholder
+# rather than crashing the script (a crash here would otherwise silence the
+# entire Slack alert — see the caller in quality-gates-pipeline.yml).
 
 set -euo pipefail
 
@@ -16,19 +21,28 @@ QG4_RESULT="${QG4_RESULT:?QG4_RESULT is required}"
 QG7_RESULT="${QG7_RESULT:?QG7_RESULT is required}"
 QG4_OUTCOMES_DIR="${QG4_OUTCOMES_DIR:-qg4-outcomes}"
 QG7_OUTCOMES_DIR="${QG7_OUTCOMES_DIR:-qg7-outcomes}"
+MAX_AGENT_ROWS="${MAX_AGENT_ROWS:-40}"
 
 # Agents that pass QG4 but are intentionally excluded from QG7 behavioral
-# evals. Keep in sync with the qg7_excluded list in the collect-qg4 job of
-# quality-gates-pipeline.yml.
-QG7_EXCLUDED='[
-  "langgraph/examples/guardrailed_agent",
-  "langgraph/templates/agentic_rag"
-]'
+# evals. Set via the QG7_EXCLUDED_AGENTS_JSON workflow-level env var in
+# quality-gates-pipeline.yml — the single source of truth shared with the
+# collect-qg4 job. The literal default below only matters for standalone/test
+# runs where that env var isn't set.
+QG7_EXCLUDED_AGENTS_JSON="${QG7_EXCLUDED_AGENTS_JSON:-[\"langgraph/examples/guardrailed_agent\", \"langgraph/templates/agentic_rag\"]}"
+if QG7_EXCLUDED="$(jq -ce 'if type == "array" then . else error("not an array") end' <<<"${QG7_EXCLUDED_AGENTS_JSON}" 2>/dev/null)"; then
+  :
+else
+  echo "::warning::QG7_EXCLUDED_AGENTS_JSON is not a valid JSON array; treating QG7 exclusion list as empty" >&2
+  QG7_EXCLUDED='[]'
+fi
 
-gate_icon() {
+# Icon for a gate-level (QG1/QG2/QG4/QG7) needs.*.result value.
+gate_status_icon() {
   case "$1" in
     success) echo "✅" ;;
     skipped) echo "⏭️" ;;
+    cancelled | timed_out) echo "⏱️" ;;
+    # failure, or anything unrecognized — treat as a hard failure.
     *) echo "❌" ;;
   esac
 }
@@ -36,7 +50,7 @@ gate_icon() {
 gate_line() {
   local label="$1" result="$2" note="${3:-}"
   local icon
-  icon="$(gate_icon "${result}")"
+  icon="$(gate_status_icon "${result}")"
   if [[ -n "${note}" ]]; then
     echo "${icon} ${label}: ${result} (${note})"
   else
@@ -61,36 +75,66 @@ gate_summary="$(
   }
 )"
 
-agent_symbol() {
+# Icon for a per-agent qg4/qg7 cell value (see the "qg7:" derivation below
+# for the full set of possible values — includes synthetic ones like
+# "blocked_fail" alongside real job.status values).
+agent_status_icon() {
   case "$1" in
     success) echo "✅" ;;
     failure) echo "❌" ;;
+    cancelled | timed_out) echo "⏱️" ;;
+    # blocked_fail, blocked_skip, excluded, not_run, skipped — none of these
+    # mean QG7 ran and failed, so render as "didn't run" rather than a red X.
     *) echo "⏭️" ;;
   esac
 }
 
-agent_note() {
+agent_status_note() {
   case "$1" in
     blocked_fail) echo "blocked: failed QG4" ;;
     blocked_skip) echo "QG4 skipped" ;;
     excluded) echo "excluded from QG7" ;;
     not_run) echo "QG7 did not run" ;;
+    cancelled) echo "cancelled" ;;
+    timed_out) echo "timed out" ;;
     *) echo "" ;;
   esac
 }
 
-shopt -s nullglob
-qg4_files=("${QG4_OUTCOMES_DIR}"/qg4-outcome-*/result.json)
+# Filters the given files down to valid JSON ones. Sets the globals
+# FILTER_VALID_FILES (array) and FILTER_INVALID_COUNT — deliberately not
+# `local -n` namerefs (bash 4.3+ only) since this needs to run under bash
+# 3.2 (macOS's default /bin/bash). Must be called directly, not inside a
+# `$(...)`/`<(...)` subshell, or these global assignments won't be visible
+# to the caller. A single truncated/corrupt outcome artifact should not
+# take down the whole summary.
+filter_valid_json() {
+  FILTER_VALID_FILES=()
+  FILTER_INVALID_COUNT=0
+  local f
+  for f in "$@"; do
+    if jq empty "${f}" >/dev/null 2>&1; then
+      FILTER_VALID_FILES+=("${f}")
+    else
+      FILTER_INVALID_COUNT=$((FILTER_INVALID_COUNT + 1))
+      echo "::warning::Skipping unparseable outcome file: ${f}" >&2
+    fi
+  done
+}
 
-agent_table=""
-if [[ ${#qg4_files[@]} -gt 0 ]]; then
-  qg7_files=("${QG7_OUTCOMES_DIR}"/qg7-outcome-*/result.json)
-  if [[ ${#qg7_files[@]} -gt 0 ]]; then
-    qg7_json="$(jq -s '[.[] | {(.name): .status}] | add // {}' "${qg7_files[@]}")"
-  else
-    qg7_json='{}'
-  fi
+# Builds the "*Agent Results*" code-fenced table from a pre-validated QG4
+# file list and pre-computed QG7 status map. Isolated in a function so a
+# caller can catch a failure here (e.g. an unexpected jq error) and fall
+# back to a placeholder instead of letting the whole script — and the Slack
+# alert with it — die. File validation happens in the caller (not here)
+# because this function is invoked inside a `$(...)` subshell, so any
+# variables it sets wouldn't be visible back in the caller's scope.
+build_agent_table() {
+  local qg7_json="$1"
+  shift
+  local -a qg4_files=("$@")
 
+  local rows
   rows="$(
     jq -s --argjson excluded "${QG7_EXCLUDED}" --argjson qg7 "${qg7_json}" '
       map(
@@ -114,20 +158,71 @@ if [[ ${#qg4_files[@]} -gt 0 ]]; then
     ' "${qg4_files[@]}"
   )"
 
+  local total_count
+  total_count="$(jq 'length' <<<"${rows}")"
+
+  local table_body
   table_body="$(
     while IFS=$'\t' read -r name qg4_status qg7_status; do
-      qg4_sym="$(agent_symbol "${qg4_status}")"
-      qg7_sym="$(agent_symbol "${qg7_status}")"
-      note="$(agent_note "${qg7_status}")"
+      qg4_sym="$(agent_status_icon "${qg4_status}")"
+      qg7_sym="$(agent_status_icon "${qg7_status}")"
+      note="$(agent_status_note "${qg7_status}")"
       printf '%-34s %-2s   %-2s   %s\n' "${name}" "${qg4_sym}" "${qg7_sym}" "${note}"
-    done < <(jq -r '.[] | [.name, .qg4, .qg7] | @tsv' <<<"${rows}")
+    done < <(jq -r --argjson limit "${MAX_AGENT_ROWS}" '.[:$limit] | .[] | [.name, .qg4, .qg7] | @tsv' <<<"${rows}")
   )"
 
-  agent_table="$(
-    # shellcheck disable=SC2016 # backticks here are a literal Slack code-fence, not command substitution
-    printf '*Agent Results*\n```\n%-34s %-4s %-4s\n%s\n```' \
-      "agent" "qg4" "qg7" "${table_body}"
-  )"
+  if [[ "${total_count}" -gt "${MAX_AGENT_ROWS}" ]]; then
+    table_body="${table_body}
+... and $((total_count - MAX_AGENT_ROWS)) more agent(s), see workflow run for the full matrix"
+  fi
+
+  # shellcheck disable=SC2016 # backticks here are a literal Slack code-fence, not command substitution
+  printf '*Agent Results*\n```\n%-34s %-4s %-4s\n%s\n```' \
+    "agent" "qg4" "qg7" "${table_body}"
+}
+
+shopt -s nullglob
+all_qg4_files=("${QG4_OUTCOMES_DIR}"/qg4-outcome-*/result.json)
+all_qg7_files=("${QG7_OUTCOMES_DIR}"/qg7-outcome-*/result.json)
+
+valid_qg4_files=()
+invalid_qg4_count=0
+if [[ ${#all_qg4_files[@]} -gt 0 ]]; then
+  filter_valid_json "${all_qg4_files[@]}"
+  valid_qg4_files=("${FILTER_VALID_FILES[@]+"${FILTER_VALID_FILES[@]}"}")
+  invalid_qg4_count="${FILTER_INVALID_COUNT}"
+fi
+
+valid_qg7_files=()
+invalid_qg7_count=0
+if [[ ${#all_qg7_files[@]} -gt 0 ]]; then
+  filter_valid_json "${all_qg7_files[@]}"
+  valid_qg7_files=("${FILTER_VALID_FILES[@]+"${FILTER_VALID_FILES[@]}"}")
+  invalid_qg7_count="${FILTER_INVALID_COUNT}"
+fi
+
+qg7_json='{}'
+if [[ ${#valid_qg7_files[@]} -gt 0 ]]; then
+  qg7_json="$(jq -s '[.[] | {(.name): .status}] | add // {}' "${valid_qg7_files[@]}" 2>/dev/null)" || qg7_json='{}'
+fi
+
+agent_table=""
+if [[ ${#all_qg4_files[@]} -gt 0 ]]; then
+  if [[ ${#valid_qg4_files[@]} -gt 0 ]]; then
+    if ! agent_table="$(build_agent_table "${qg7_json}" "${valid_qg4_files[@]}")"; then
+      agent_table=$'*Agent Results*\n_agent-level summary unavailable (unexpected error building the table) — see workflow run for details_'
+    fi
+  else
+    agent_table=$'*Agent Results*\n_agent-level summary unavailable (no readable outcome data) — see workflow run for details_'
+  fi
+
+  warnings=()
+  [[ "${invalid_qg4_count}" -gt 0 ]] && warnings+=("⚠️ ${invalid_qg4_count} QG4 outcome file(s) could not be parsed and were excluded")
+  [[ "${invalid_qg7_count}" -gt 0 ]] && warnings+=("⚠️ ${invalid_qg7_count} QG7 outcome file(s) could not be parsed and were excluded")
+  for warning in "${warnings[@]+"${warnings[@]}"}"; do
+    agent_table="${agent_table}
+${warning}"
+  done
 fi
 
 if [[ -n "${agent_table}" ]]; then

--- a/.github/scripts/tests/test_build_qg_summary.py
+++ b/.github/scripts/tests/test_build_qg_summary.py
@@ -114,6 +114,109 @@ def test_agent_matrix_reflects_qg4_and_qg7_outcomes(tmp_path):
     assert "excluded from QG7" in output
 
 
+def test_malformed_outcome_file_does_not_crash_script(tmp_path):
+    qg4_dir = tmp_path / "qg4-outcomes"
+    qg7_dir = tmp_path / "qg7-outcomes"
+    qg4_dir.mkdir()
+    qg7_dir.mkdir()
+
+    write_outcome(
+        qg4_dir,
+        "agent-good",
+        {
+            "name": "agent-good",
+            "dir": "agents/langgraph/templates/agent_good",
+            "status": "success",
+        },
+    )
+    bad_dir = qg4_dir / "qg4-outcome-agent-bad"
+    bad_dir.mkdir(parents=True)
+    (bad_dir / "result.json").write_text(
+        '{"name":"agent-bad","dir":"agents/lang', encoding="utf-8"
+    )
+
+    output = run_summary(
+        {
+            "QG1_RESULT": "success",
+            "QG2_RESULT": "success",
+            "QG4_RESULT": "failure",
+            "QG7_RESULT": "skipped",
+        },
+        qg4_dir,
+        qg7_dir,
+    )
+
+    assert "Gate Summary" in output
+    assert "agent-good" in output
+    assert "could not be parsed" in output
+
+
+def test_agent_table_truncates_beyond_row_cap(tmp_path):
+    qg4_dir = tmp_path / "qg4-outcomes"
+    qg7_dir = tmp_path / "qg7-outcomes"
+    qg4_dir.mkdir()
+    qg7_dir.mkdir()
+
+    for i in range(10):
+        write_outcome(
+            qg4_dir,
+            f"agent-{i:02d}",
+            {
+                "name": f"agent-{i:02d}",
+                "dir": f"agents/langgraph/templates/agent_{i:02d}",
+                "status": "success",
+            },
+        )
+
+    output = run_summary(
+        {
+            "QG1_RESULT": "success",
+            "QG2_RESULT": "success",
+            "QG4_RESULT": "success",
+            "QG7_RESULT": "skipped",
+            "MAX_AGENT_ROWS": "3",
+        },
+        qg4_dir,
+        qg7_dir,
+    )
+
+    assert "agent-00" in output
+    assert "agent-02" in output
+    assert "agent-09" not in output
+    assert "and 7 more agent(s)" in output
+
+
+def test_cancelled_agent_rendered_distinctly_from_skipped(tmp_path):
+    qg4_dir = tmp_path / "qg4-outcomes"
+    qg7_dir = tmp_path / "qg7-outcomes"
+    qg4_dir.mkdir()
+    qg7_dir.mkdir()
+
+    write_outcome(
+        qg4_dir,
+        "agent-cancelled",
+        {
+            "name": "agent-cancelled",
+            "dir": "agents/langgraph/templates/agent_cancelled",
+            "status": "cancelled",
+        },
+    )
+
+    output = run_summary(
+        {
+            "QG1_RESULT": "success",
+            "QG2_RESULT": "success",
+            "QG4_RESULT": "cancelled",
+            "QG7_RESULT": "skipped",
+        },
+        qg4_dir,
+        qg7_dir,
+    )
+
+    assert "⏱️" in output
+    assert "agent-cancelled" in output
+
+
 def test_agent_not_run_when_qg7_outcomes_missing(tmp_path):
     qg4_dir = tmp_path / "qg4-outcomes"
     qg7_dir = tmp_path / "qg7-outcomes"

--- a/.github/scripts/tests/test_build_qg_summary.py
+++ b/.github/scripts/tests/test_build_qg_summary.py
@@ -151,7 +151,7 @@ def test_malformed_outcome_file_does_not_crash_script(tmp_path):
     assert "could not be parsed" in output
 
 
-def test_agent_table_truncates_beyond_row_cap(tmp_path):
+def test_agent_table_truncates_beyond_char_budget(tmp_path):
     qg4_dir = tmp_path / "qg4-outcomes"
     qg7_dir = tmp_path / "qg7-outcomes"
     qg4_dir.mkdir()
@@ -174,7 +174,7 @@ def test_agent_table_truncates_beyond_row_cap(tmp_path):
             "QG2_RESULT": "success",
             "QG4_RESULT": "success",
             "QG7_RESULT": "skipped",
-            "MAX_AGENT_ROWS": "3",
+            "TOTAL_CHAR_BUDGET": "550",
         },
         qg4_dir,
         qg7_dir,
@@ -183,7 +183,45 @@ def test_agent_table_truncates_beyond_row_cap(tmp_path):
     assert "agent-00" in output
     assert "agent-02" in output
     assert "agent-09" not in output
-    assert "and 7 more agent(s)" in output
+    assert "more agent(s)" in output
+    assert len(output) <= 3000
+
+
+def test_agent_table_stays_under_slack_limit_with_many_long_names(tmp_path):
+    qg4_dir = tmp_path / "qg4-outcomes"
+    qg7_dir = tmp_path / "qg7-outcomes"
+    qg4_dir.mkdir()
+    qg7_dir.mkdir()
+
+    # Mirrors the longest real agent name in the repo's QG4 matrix
+    # (vanilla-python-openai-responses-agent, 37 chars) at a scale (100
+    # agents) approaching the repo's long-term template count target.
+    long_name = "vanilla-python-openai-responses-agent"
+    for i in range(100):
+        name = f"{long_name}-{i:03d}"
+        write_outcome(
+            qg4_dir,
+            name,
+            {
+                "name": name,
+                "dir": f"agents/vanilla_python/templates/{name}",
+                "status": "success",
+            },
+        )
+
+    output = run_summary(
+        {
+            "QG1_RESULT": "success",
+            "QG2_RESULT": "success",
+            "QG4_RESULT": "success",
+            "QG7_RESULT": "skipped",
+        },
+        qg4_dir,
+        qg7_dir,
+    )
+
+    assert len(output) <= 3000
+    assert "more agent(s)" in output
 
 
 def test_cancelled_agent_rendered_distinctly_from_skipped(tmp_path):

--- a/.github/scripts/tests/test_build_qg_summary.py
+++ b/.github/scripts/tests/test_build_qg_summary.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Tests for the quality-gates-pipeline Slack summary builder."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / ".github" / "scripts" / "build_qg_summary.sh"
+
+
+def write_outcome(directory: Path, name: str, payload: dict) -> None:
+    prefix = "qg4-outcome" if "qg4" in directory.name else "qg7-outcome"
+    outcome_dir = directory / f"{prefix}-{name}"
+    outcome_dir.mkdir(parents=True, exist_ok=True)
+    (outcome_dir / "result.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def run_summary(env_overrides: dict, qg4_dir: Path, qg7_dir: Path) -> str:
+    env = os.environ.copy()
+    env.update(env_overrides)
+    env["QG4_OUTCOMES_DIR"] = str(qg4_dir)
+    env["QG7_OUTCOMES_DIR"] = str(qg7_dir)
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return result.stdout
+
+
+def test_gate_summary_only_when_qg4_never_ran(tmp_path):
+    qg4_dir = tmp_path / "qg4-outcomes"
+    qg7_dir = tmp_path / "qg7-outcomes"
+    qg4_dir.mkdir()
+    qg7_dir.mkdir()
+
+    output = run_summary(
+        {
+            "QG1_RESULT": "failure",
+            "QG2_RESULT": "skipped",
+            "QG4_RESULT": "skipped",
+            "QG7_RESULT": "skipped",
+        },
+        qg4_dir,
+        qg7_dir,
+    )
+
+    assert "Gate Summary" in output
+    assert "QG1" in output and "failure" in output
+    assert "blocked by QG1" in output
+    assert "Agent Results" not in output
+
+
+def test_agent_matrix_reflects_qg4_and_qg7_outcomes(tmp_path):
+    qg4_dir = tmp_path / "qg4-outcomes"
+    qg7_dir = tmp_path / "qg7-outcomes"
+    qg4_dir.mkdir()
+    qg7_dir.mkdir()
+
+    write_outcome(
+        qg4_dir,
+        "langgraph-react-agent",
+        {
+            "name": "langgraph-react-agent",
+            "dir": "agents/langgraph/templates/react_agent",
+            "status": "success",
+        },
+    )
+    write_outcome(
+        qg4_dir,
+        "langgraph-hitl-agent",
+        {
+            "name": "langgraph-hitl-agent",
+            "dir": "agents/langgraph/templates/human_in_the_loop",
+            "status": "failure",
+        },
+    )
+    write_outcome(
+        qg4_dir,
+        "langgraph-guardrailed-agent",
+        {
+            "name": "langgraph-guardrailed-agent",
+            "dir": "agents/langgraph/examples/guardrailed_agent",
+            "status": "success",
+        },
+    )
+    write_outcome(
+        qg7_dir,
+        "langgraph-react-agent",
+        {"name": "langgraph-react-agent", "status": "success"},
+    )
+
+    output = run_summary(
+        {
+            "QG1_RESULT": "success",
+            "QG2_RESULT": "success",
+            "QG4_RESULT": "failure",
+            "QG7_RESULT": "success",
+        },
+        qg4_dir,
+        qg7_dir,
+    )
+
+    assert "Agent Results" in output
+    assert "langgraph-react-agent" in output
+    assert "blocked: failed QG4" in output
+    assert "excluded from QG7" in output
+
+
+def test_agent_not_run_when_qg7_outcomes_missing(tmp_path):
+    qg4_dir = tmp_path / "qg4-outcomes"
+    qg7_dir = tmp_path / "qg7-outcomes"
+    qg4_dir.mkdir()
+    qg7_dir.mkdir()
+
+    write_outcome(
+        qg4_dir,
+        "langgraph-react-agent",
+        {
+            "name": "langgraph-react-agent",
+            "dir": "agents/langgraph/templates/react_agent",
+            "status": "success",
+        },
+    )
+
+    output = run_summary(
+        {
+            "QG1_RESULT": "success",
+            "QG2_RESULT": "success",
+            "QG4_RESULT": "success",
+            "QG7_RESULT": "skipped",
+        },
+        qg4_dir,
+        qg7_dir,
+    )
+
+    assert "QG7 did not run" in output

--- a/.github/scripts/tests/test_notify_slack.py
+++ b/.github/scripts/tests/test_notify_slack.py
@@ -63,6 +63,65 @@ def test_render_payload_includes_failed_jobs_and_links():
     )
 
 
+def test_render_payload_uses_summary_text_when_provided():
+    env = os.environ.copy()
+    env.update(
+        {
+            "WORKFLOW_NAME": "Quality Gates Pipeline",
+            "EVENT_NAME": "schedule",
+            "REF_NAME": "main",
+            "STATUS": "failure",
+            "RUN_URL": "https://github.com/example/repo/actions/runs/123",
+            "DASHBOARD_URL": "https://red-hat-data-services.github.io/agentic-starter-kits/",
+            "REPOSITORY": "red-hat-data-services/agentic-starter-kits",
+            "FAILED_JOBS_JSON": json.dumps(["QG4: langgraph-hitl-agent"]),
+            "SUMMARY_TEXT": "*Gate Summary*\n✅ QG1: success\n❌ QG4: failure",
+            "TIMESTAMP": "2026-07-09T07:30:00Z",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(RENDER_SCRIPT)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    payload_text = json.dumps(json.loads(result.stdout))
+    assert "Gate Summary" in payload_text
+    assert "QG4: langgraph-hitl-agent" not in payload_text
+
+
+def test_render_payload_success_status_is_green():
+    env = os.environ.copy()
+    env.update(
+        {
+            "WORKFLOW_NAME": "Quality Gates Pipeline",
+            "EVENT_NAME": "schedule",
+            "REF_NAME": "main",
+            "STATUS": "success",
+            "RUN_URL": "https://github.com/example/repo/actions/runs/123",
+            "DASHBOARD_URL": "https://red-hat-data-services.github.io/agentic-starter-kits/",
+            "REPOSITORY": "red-hat-data-services/agentic-starter-kits",
+            "SUMMARY_TEXT": "*Gate Summary*\n✅ QG1: success",
+            "TIMESTAMP": "2026-07-09T07:30:00Z",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(RENDER_SCRIPT)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["attachments"][0]["color"] == "#2eb67d"
+    assert "CI Success" in json.dumps(payload)
+
+
 def test_notify_preview_prints_payload(tmp_path):
     payload_path = tmp_path / "payload.json"
     payload_path.write_text(

--- a/.github/scripts/tests/test_orchestrator_contract.py
+++ b/.github/scripts/tests/test_orchestrator_contract.py
@@ -153,3 +153,68 @@ def test_notify_slack_if_condition_matches_simulator_assumption():
         "!cancelled() && github.repository == 'red-hat-data-services/agentic-starter-kits' "
         "&& (github.event_name != 'workflow_dispatch' || github.ref_name == 'main')"
     )
+
+
+def _send_slack_notification_if() -> str:
+    jobs = _load_jobs()
+    step = next(
+        step
+        for step in jobs["notify-slack"]["steps"]
+        if step.get("name") == "Send Slack notification"
+    )
+    return step["if"]
+
+
+def _evaluate_send_notification_if(
+    should_notify: bool, status: str, notify_on_success: str | None
+) -> bool:
+    # Mirrors the exact expression in quality-gates-pipeline.yml so a future
+    # edit that changes the boolean logic fails this test instead of only
+    # being caught by eyeballing the diff. vars.QG_NOTIFY_ON_SUCCESS reads
+    # as an empty string when the repo variable is unset (not 'false').
+    expr = _send_slack_notification_if()
+    expr = expr.replace(
+        "steps.gate.outputs.should_notify == 'true'", str(should_notify)
+    )
+    expr = expr.replace(
+        "steps.gate.outputs.status == 'success'", str(status == "success")
+    )
+    expr = expr.replace(
+        "vars.QG_NOTIFY_ON_SUCCESS == 'true'",
+        str(notify_on_success == "true"),
+    )
+    expr = expr.replace("&&", " and ").replace("||", " or ")
+    return bool(eval(expr, {"__builtins__": {}}, {}))  # noqa: S307
+
+
+def test_send_notification_fires_on_should_notify():
+    assert _evaluate_send_notification_if(
+        should_notify=True, status="failure", notify_on_success=None
+    )
+
+
+def test_send_notification_silent_on_success_by_default():
+    assert not _evaluate_send_notification_if(
+        should_notify=False, status="success", notify_on_success=None
+    )
+
+
+def test_send_notification_silent_on_success_when_var_explicitly_false():
+    assert not _evaluate_send_notification_if(
+        should_notify=False, status="success", notify_on_success="false"
+    )
+
+
+def test_send_notification_fires_on_success_when_opted_in():
+    assert _evaluate_send_notification_if(
+        should_notify=False, status="success", notify_on_success="true"
+    )
+
+
+def test_send_notification_opt_in_var_does_not_fire_on_non_success_status():
+    # QG_NOTIFY_ON_SUCCESS should never cause a *second* notification for a
+    # failure that should_notify.sh already decided not to report (e.g. a
+    # pull_request run) — the override only ever adds success notifications.
+    assert not _evaluate_send_notification_if(
+        should_notify=False, status="failure", notify_on_success="true"
+    )

--- a/.github/workflows/quality-gates-pipeline.yml
+++ b/.github/workflows/quality-gates-pipeline.yml
@@ -379,6 +379,28 @@ jobs:
           path: btest-results/**
           if-no-files-found: warn
 
+      - name: Record QG7 outcome
+        if: always()
+        shell: bash
+        env:
+          AGENT_NAME: ${{ matrix.agent.name }}
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          set -euo pipefail
+          mkdir -p qg7-outcome
+          jq -n \
+            --arg name "${AGENT_NAME}" \
+            --arg status "${JOB_STATUS}" \
+            '{name: $name, status: $status}' \
+            > qg7-outcome/result.json
+
+      - name: Upload QG7 outcome
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: qg7-outcome-${{ matrix.agent.name }}
+          path: qg7-outcome/result.json
+
       - name: Logout
         if: always()
         run: oc logout || true
@@ -401,6 +423,40 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Download QG4 outcome artifacts
+        if: needs.qg4.result != 'skipped'
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: qg4-outcome-*
+          path: qg4-outcomes/
+
+      - name: Download QG7 outcome artifacts
+        if: needs.qg7.result != 'skipped'
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: qg7-outcome-*
+          path: qg7-outcomes/
+
+      - name: Build QG summary
+        id: summary
+        shell: bash
+        env:
+          QG1_RESULT: ${{ needs.qg1.result }}
+          QG2_RESULT: ${{ needs.qg2.result }}
+          QG4_RESULT: ${{ needs.qg4.result }}
+          QG7_RESULT: ${{ needs.qg7.result }}
+        run: |
+          set -euo pipefail
+          summary_text="$(bash .github/scripts/build_qg_summary.sh)"
+          delimiter="summary-$(openssl rand -hex 8)"
+          {
+            echo "summary_text<<${delimiter}"
+            echo "${summary_text}"
+            echo "${delimiter}"
+          } >> "${GITHUB_OUTPUT}"
+
       - name: Decide notification status
         id: gate
         env:
@@ -410,8 +466,25 @@ jobs:
         run: |
           bash .github/actions/notify-slack/should_notify.sh >> "${GITHUB_OUTPUT}"
 
+      # Lets an all-green run still post a (green) summary when opted in via
+      # the QG_NOTIFY_ON_SUCCESS repo variable — should_notify.sh only ever
+      # fires on failure/timed_out/cancelled by design.
+      - name: Apply success-notification override
+        id: override
+        env:
+          SHOULD_NOTIFY: ${{ steps.gate.outputs.should_notify }}
+          STATUS: ${{ steps.gate.outputs.status }}
+          NOTIFY_ON_SUCCESS: ${{ vars.QG_NOTIFY_ON_SUCCESS || 'false' }}
+        run: |
+          set -euo pipefail
+          should_notify="${SHOULD_NOTIFY}"
+          if [[ "${STATUS}" == "success" && "${NOTIFY_ON_SUCCESS}" == "true" ]]; then
+            should_notify=true
+          fi
+          echo "should_notify=${should_notify}" >> "${GITHUB_OUTPUT}"
+
       - name: Send Slack notification
-        if: steps.gate.outputs.should_notify == 'true'
+        if: steps.override.outputs.should_notify == 'true'
         uses: ./.github/actions/notify-slack
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -425,3 +498,4 @@ jobs:
           run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           dashboard_url: https://red-hat-data-services.github.io/agentic-starter-kits/
           status: ${{ steps.gate.outputs.status }}
+          summary_text: ${{ steps.summary.outputs.summary_text }}

--- a/.github/workflows/quality-gates-pipeline.yml
+++ b/.github/workflows/quality-gates-pipeline.yml
@@ -29,6 +29,16 @@ on:
 permissions:
   contents: read
 
+env:
+  # Agents that pass QG4 but should not run QG7 behavioral evals. This is
+  # intentionally separate from EXCLUDED_AGENTS in deploy_agents.py — QG4
+  # and QG7 gate different things and may exclude different agents.
+  # Single source of truth for both the collect-qg4 job (which builds QG7's
+  # matrix) and notify-slack's summary script — collect-qg4 doesn't check
+  # out the repo, so this lives here rather than in a checked-in file.
+  QG7_EXCLUDED_AGENTS_JSON: >-
+    ["langgraph/examples/guardrailed_agent", "langgraph/templates/agentic_rag"]
+
 jobs:
   # ── Stage 0a: QG1 — Cluster readiness ──────────────────────────────────
   qg1:
@@ -257,13 +267,9 @@ jobs:
             exit 0
           fi
 
-          # Agents that pass QG4 but should not run QG7 behavioral evals.
-          # This is intentionally separate from EXCLUDED_AGENTS in deploy_agents.py —
-          # QG4 and QG7 gate different things and may exclude different agents.
-          qg7_excluded='[
-            "langgraph/examples/guardrailed_agent",
-            "langgraph/templates/agentic_rag"
-          ]'
+          # See QG7_EXCLUDED_AGENTS_JSON at the top of this workflow file —
+          # shared with build_qg_summary.sh (used by notify-slack).
+          qg7_excluded="${QG7_EXCLUDED_AGENTS_JSON}"
 
           all_passing=$(jq -s '[.[] | select(.status == "success") | {name: .name, qg7_id: (.dir | ltrimstr("agents/"))}]' "${result_files[@]}")
           pass_list=$(echo "${all_passing}" | jq --argjson excluded "${qg7_excluded}" \
@@ -439,8 +445,15 @@ jobs:
           pattern: qg7-outcome-*
           path: qg7-outcomes/
 
+      # continue-on-error + if: always() so a bug in build_qg_summary.sh (bad
+      # jq input, unexpected artifact contents, etc.) degrades to a bare
+      # alert via the empty summary_text fallback in render_payload.sh,
+      # instead of skipping every step after it and silencing the alert
+      # entirely — the one failure mode this job absolutely cannot have.
       - name: Build QG summary
         id: summary
+        if: always()
+        continue-on-error: true
         shell: bash
         env:
           QG1_RESULT: ${{ needs.qg1.result }}
@@ -459,6 +472,7 @@ jobs:
 
       - name: Decide notification status
         id: gate
+        if: always()
         env:
           EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
@@ -466,25 +480,15 @@ jobs:
         run: |
           bash .github/actions/notify-slack/should_notify.sh >> "${GITHUB_OUTPUT}"
 
-      # Lets an all-green run still post a (green) summary when opted in via
-      # the QG_NOTIFY_ON_SUCCESS repo variable — should_notify.sh only ever
-      # fires on failure/timed_out/cancelled by design.
-      - name: Apply success-notification override
-        id: override
-        env:
-          SHOULD_NOTIFY: ${{ steps.gate.outputs.should_notify }}
-          STATUS: ${{ steps.gate.outputs.status }}
-          NOTIFY_ON_SUCCESS: ${{ vars.QG_NOTIFY_ON_SUCCESS || 'false' }}
-        run: |
-          set -euo pipefail
-          should_notify="${SHOULD_NOTIFY}"
-          if [[ "${STATUS}" == "success" && "${NOTIFY_ON_SUCCESS}" == "true" ]]; then
-            should_notify=true
-          fi
-          echo "should_notify=${should_notify}" >> "${GITHUB_OUTPUT}"
-
+      # An all-green run still posts a (green) summary when opted in via the
+      # QG_NOTIFY_ON_SUCCESS repo variable — should_notify.sh only ever
+      # fires on failure/timed_out/cancelled by design. Folded into this
+      # step's `if:` directly rather than a separate step re-deriving the
+      # boolean, since should_notify.sh already computes everything else.
       - name: Send Slack notification
-        if: steps.override.outputs.should_notify == 'true'
+        if: >-
+          steps.gate.outputs.should_notify == 'true' ||
+          (steps.gate.outputs.status == 'success' && vars.QG_NOTIFY_ON_SUCCESS == 'true')
         uses: ./.github/actions/notify-slack
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/docs/ci-alert-policy.md
+++ b/docs/ci-alert-policy.md
@@ -105,7 +105,7 @@ marks the remaining signals as non-canonical supporting alerts.
 | `Inner Loop Gating` | `eval-gating.yml` | Canonical | `QG7` | `push` on `main` when matching behavioral/eval paths change, `workflow_dispatch` on `main` | Shared CI route / `@aaet-tooling-experience` |
 | `QG1: Cluster Readiness` | `qg1-cluster-readiness.yml` | Canonical | `QG1` | `schedule`, `workflow_dispatch` on `main` | Shared CI route / `@aaet-tooling-experience` |
 | `QG2: Platform Readiness` | `qg2-platform-readiness.yml` | Canonical | `QG2` | `schedule`, `workflow_dispatch` on `main` | Shared CI route / `@aaet-tooling-experience` |
-| `Quality Gates Pipeline` | `quality-gates-pipeline.yml` | Canonical | `QG4` / `QG7` | `schedule`, `workflow_dispatch` on `main` | Shared CI route / `@aaet-tooling-experience` |
+| `Quality Gates Pipeline` | `quality-gates-pipeline.yml` | Canonical | `QG1` / `QG2` / `QG4` / `QG7` | `schedule`, `workflow_dispatch` on `main` | Shared CI route / `@aaet-tooling-experience` |
 | `QG4: Agent Deployment Integration Tests` | `agent-deployment-test.yaml` | Canonical | `QG4` | `workflow_dispatch` on `main` | Shared CI route / `@aaet-tooling-experience` |
 
 `agent-deployment-test.yaml` no longer has a `schedule` trigger — nightly QG4

--- a/docs/ci-alert-runbook.md
+++ b/docs/ci-alert-runbook.md
@@ -12,7 +12,7 @@ This runbook covers the shared-branch CI Slack alerts for
 | `Inner Loop Gating` | Canonical | `QG7` | `push` on `main` when matching eval/behavioral paths change, `workflow_dispatch` on `main` |
 | `QG1: Cluster Readiness` | Canonical | `QG1` | `schedule`, `workflow_dispatch` on `main` |
 | `QG2: Platform Readiness` | Canonical | `QG2` | `schedule`, `workflow_dispatch` on `main` |
-| `Quality Gates Pipeline` | Canonical | `QG4` / `QG7` | `schedule`, `workflow_dispatch` on `main` |
+| `Quality Gates Pipeline` | Canonical | `QG1` / `QG2` / `QG4` / `QG7` | `schedule`, `workflow_dispatch` on `main` |
 | `QG4: Agent Deployment Integration Tests` | Canonical | `QG4` | `workflow_dispatch` on `main` |
 
 `agent-deployment-test.yaml` is manual-only (no `schedule` trigger) — nightly
@@ -45,8 +45,11 @@ mint `serviceaccounts/token` in `ci-testing`.
 
 - One Slack alert is emitted per qualifying workflow run.
 - The alert is emitted after the workflow conclusion is known.
-- Matrix failures are aggregated into one workflow-level alert with a failed-job list.
-- If the GitHub jobs API lookup fails, the alert still sends without job detail.
+- Matrix failures are aggregated into one workflow-level alert with a failed-job list,
+  except `Quality Gates Pipeline`, which instead shows a QG1/QG2/QG4/QG7 gate-status
+  line plus a per-agent QG4/QG7 pass-fail matrix in place of the generic job list.
+- If the GitHub jobs API lookup fails, the alert still sends without job detail
+  (not applicable to `Quality Gates Pipeline`, which does not query that API).
 
 ## Severity Interpretation
 
@@ -85,7 +88,8 @@ should inspect the GitHub Actions run directly.
 
 1. Open the workflow run link from Slack and confirm the run is a qualifying
    shared-branch failure.
-2. Review the failed-job list in Slack; if it is missing, use the workflow run
+2. Review the failed-job list in Slack (or, for `Quality Gates Pipeline`, the
+   gate-status and per-agent matrix); if it is missing, use the workflow run
    page because the alert may have sent without job detail.
 3. Use the workflow logs to decide whether the failure is transient, already
    known, or a new defect.


### PR DESCRIPTION
## Description

Redesigns the Quality Gates Pipeline's final Slack alert (`notify-slack` job) to show a QG1/QG2/QG4/QG7 gate-status summary plus a per-agent QG4/QG7 pass-fail matrix (✅/❌/⏭️/⏱️), instead of the generic "list of failed job names" pulled from the GitHub Jobs API. The single-message approach was a deliberate scope decision made with the ticket owner during implementation: rather than adding separate per-stage "immediate" alerts (as originally scoped), we consolidated on one comprehensive final message that always fires regardless of which gate a run reaches, to avoid duplicate/noisy alerts for the same failure.

### Changes

- `qg7` job now records a per-agent outcome artifact (`qg7-outcome-<agent>`), mirroring the existing `qg4` pattern, so the summary can show QG7 status per agent.
- New `.github/scripts/build_qg_summary.sh` builds the gate-status block and (only when QG4 actually ran) the per-agent matrix from the QG1/QG2/QG4/QG7 job results and the outcome artifacts. Validates each outcome artifact's JSON before use and degrades to a placeholder/warning instead of crashing on malformed data (see "Fixes from review" below).
- `notify-slack` job downloads both outcome artifact sets and calls the new script before deciding whether to notify. The existing `should_notify.sh` gating logic is unchanged — it already correctly aggregates matrix-level failures across QG1/QG2/QG4/QG7.
- Added an optional `QG_NOTIFY_ON_SUCCESS` repo variable: when `'true'`, an all-green run also posts a (green) summary — satisfying the "or configurable" part of the AC, default is silent-on-success like today. Folded directly into the "Send Slack notification" step's `if:` rather than a separate step.
- The QG7-exclusion list (agents that pass QG4 but skip QG7) is now a single `QG7_EXCLUDED_AGENTS_JSON` workflow-level `env:` value, read by both the `collect-qg4` job and `build_qg_summary.sh`, instead of two hardcoded copies kept in sync by comment.
- `.github/actions/notify-slack` gains an optional `summary_text` input: when supplied, it replaces the generic failed-jobs section (and skips that GitHub API call). Every other caller of this action (`agent-tests.yml`, `code-quality.yml`, `eval-gating.yml`, the standalone `qg1`/`qg2` workflows) doesn't pass it, so their behavior is unchanged.
- Fixed two now-stale lines in `docs/ci-alert-policy.md` / `docs/ci-alert-runbook.md` (severity fingerprint for `Quality Gates Pipeline` was `QG4`/`QG7`, now `QG1`/`QG2`/`QG4`/`QG7`; noted the QG-pipeline-specific message format).

### Note on branch history

This branch is built on top of #340 (RHAIENG-7210, not yet merged), which integrates QG1/QG2 into this same workflow — this ticket's gate-summary design assumes QG1/QG2 exist in the pipeline. #340's three commits are cherry-picked in here cleanly (no conflicts). **This PR should be reviewed/merged after #340**, or rebased to drop the now-duplicate commits once #340 lands.

### Fixes from review

A first review pass flagged several issues, addressed as follows:

- **Critical — a malformed/truncated outcome artifact could silence the entire alert:** `build_qg_summary.sh` now validates each outcome file's JSON before use, skips unreadable ones with a visible `⚠️` note instead of crashing, and the risky table-building logic is isolated so an unexpected error degrades to a placeholder rather than aborting the script. At the workflow level, the `Build QG summary` step got `continue-on-error: true` + `if: always()`, and `Decide notification status` got `if: always()`, so a summary-generation failure can no longer prevent the Slack notification step from running.
- **Redundant boolean re-derivation:** removed the separate "Apply success-notification override" step; `QG_NOTIFY_ON_SUCCESS` is now evaluated directly in the `if:` of "Send Slack notification".
- **Duplicated QG7-exclusion list:** moved to a single `QG7_EXCLUDED_AGENTS_JSON` workflow-level env var (see Changes above).
- **Cancelled/timed-out agents rendered identically to routine skips:** added distinct `⏱️` handling in both `gate_status_icon()` and `agent_status_icon()`.
- **Stale jq arg name in `render_payload.sh`:** renamed `failed_jobs_text` → `details_text` to match its broader purpose post-refactor.
- **Skipped, with reasoning:** (1) reconciling against a hardcoded "expected agent list" to flag artifact-download failures — would add a *third* place with the agent list to keep in sync, working against the exclusion-list dedup above, for a rare edge case already visible in job logs; (2) merging the QG4/QG7 outcome artifacts into one blob to avoid `collect-qg4`/`notify-slack` re-downloading the same per-agent artifacts — real but minor CI-minutes optimization, not correctness; (3) an end-to-end test of the composite action's `if: inputs.summary_text == ''` skip branch — noted as a known coverage gap, hard to unit test without an actions-runner harness.
- **Timing claim caveat:** the "per-stage failures already surface reasonably fast today" reasoning behind dropping the separate immediate-alert job is based on tracing the workflow's `needs`/`if` DAG (confirmed by `test_orchestrator_dag_simulation.py`'s skip-propagation model), not a live-run wall-clock measurement — treat it as "logically unblocked quickly," not a timed guarantee.

### Fixes from re-review

A follow-up review pass caught one issue my first fix didn't fully close, plus a coverage gap:

- **Row cap didn't actually bound Slack's 3000-char limit:** a fixed `MAX_AGENT_ROWS=40` doesn't account for agent name length — verified that 40 rows of realistic-length names (e.g. `vanilla-python-openai-responses-agent`, the longest in the repo today) already exceeds 3000 characters. Replaced the row-count cap with a character-budget-based truncation: the script tracks the actual rendered length against a `TOTAL_CHAR_BUDGET` (default 2900, leaving headroom below Slack's limit), reserving room for the gate summary, any warning lines, and the truncation trailer, and stops adding agent rows once the budget is spent. Added a test with 100 long-named synthetic agents asserting the output stays ≤3000 characters.
- **No test coverage for the `if:` condition on "Send Slack notification":** added direct tests in `test_orchestrator_contract.py` that parse the actual `if:` expression string from the workflow file and evaluate it against the should_notify/status/`QG_NOTIFY_ON_SUCCESS` combinations, so a future edit to that boolean logic fails a test instead of only being caught by review.

## Jira Ticket

RHAIENG-6543

## Testing

- [x] `make test` passes (run from the affected agent directory) — N/A, no agent code changed; ran the relevant script test suite instead
- [x] Manual testing performed (describe steps below)
- [ ] No testing required (documentation/config change only)

Manual/automated verification performed:
- `actionlint` clean across the entire repo (`.github/workflows/*.yml`, all composite actions)
- `shellcheck` clean on all touched/new bash scripts
- `uv run pytest .github/scripts/tests/` — 161/161 passing, including 8 tests in `test_build_qg_summary.py` (malformed-JSON resilience, char-budget truncation at scale with long names, cancelled-status rendering, plus the original 3) and 5 new `if:`-expression tests in `test_orchestrator_contract.py`
- Manually ran `build_qg_summary.sh` against fixture scenarios: all-pass, QG1-fails-nothing-downstream-runs, partial QG4+QG7 failure, a truncated/malformed outcome file (confirmed graceful degradation, exit 0), and 100 synthetic agents with realistic long names (confirmed output stays under 3000 characters — verified via bash's `${#var}`/Python's `len()`, both count Unicode codepoints; `wc -c` counts UTF-8 bytes and isn't the right comparison here)
- `ruff check` / `ruff format --check` clean on touched Python test files

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of the linked Jira ticket (if not, explain in Description)

Scope note: the ticket's "per-stage notify-slack job fires immediately when any agent fails a gate" AC was intentionally dropped in favor of the single comprehensive final alert described above — this was discussed and agreed with the ticket owner during implementation to avoid duplicate alerts for the same underlying failure.

## Review Guidance

**Key areas for review:**
- `build_qg_summary.sh` — the jq logic mapping each agent's QG4 status + QG7-exclusion + QG7 outcome to a single display status (`blocked_fail` / `blocked_skip` / `excluded` / `not_run` / pass-through), and the malformed-JSON / row-cap resilience logic
- The `notify-slack` job's new step ordering in `quality-gates-pipeline.yml` (artifact downloads → build summary → decide notification → send), and the `continue-on-error`/`always()` resilience chain
- `QG_NOTIFY_ON_SUCCESS` — confirm the default (silent on success) matches expectations

**Safe to skim:**
- The three `RHAIENG-7210` commits (QG1/QG2 integration) — already reviewed on #340
- Doc fixes in `ci-alert-policy.md` / `ci-alert-runbook.md`

## Related PRs

Depends on / includes: #340 (RHAIENG-7210)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
