### PR TITLE
fix(tests): raise google_adk latency threshold to 12.0s (RHAIENG-7426)

### DIFF
--- a/tests/behavioral/configs/thresholds.yaml
+++ b/tests/behavioral/configs/thresholds.yaml
@@ -77,7 +77,7 @@ langgraph_guardrailed:
 google_adk:
   tool_selection_accuracy: 0.85
   response_coherence_accuracy: 0.75
-  max_latency_p95: 8.0
+  max_latency_p95: 12.0
   pass_at_k: 8
 
 a2a_langgraph_crewai:


### PR DESCRIPTION
## Summary
- The google_adk behavioral latency test (`test_latency_under_threshold`) was flaking in CI because `max_latency_p95` in `tests/behavioral/configs/thresholds.yaml` was set too low at 8.0s.
- Raises `google_adk.max_latency_p95` from 8.0 to 12.0, mirroring the same class of fix applied to `autogen_mcp` in #358.

Jira: [RHAIENG-7426](https://redhat.atlassian.net/browse/RHAIENG-7426)

Failing CI run: https://github.com/red-hat-data-services/agentic-starter-kits/actions/runs/34306623558/job/102328901634

## Test plan
- [ ] CI behavioral tests pass for `google_adk` on this PR

[RHAIENG-7426]: https://redhat.atlassian.net/browse/RHAIENG-7426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ