### PR TITLE
fix(evals): retry transient gateway errors (RHAIENG-7488)

### DIFF
--- a/agents/langgraph/templates/human_in_the_loop/tests/behavioral/conftest.py
+++ b/agents/langgraph/templates/human_in_the_loop/tests/behavioral/conftest.py
@@ -131,6 +131,7 @@ def run_eval(
         model: str | None = None,
         approval: str | None = None,
         enrich: bool = True,
+        transient_retries: int = 0,
     ) -> TaskResult:
         config = TaskConfig(
             agent_url=agent_url,
@@ -140,6 +141,7 @@ def run_eval(
             max_tokens_budget=max_tokens_budget,
             model=model,
             stream=STREAM,
+            transient_retries=transient_retries,
         )
         request_start_ms = int(time.time() * 1000)
         result = await run_task(config, client=http_client)

--- a/agents/langgraph/templates/human_in_the_loop/tests/behavioral/test_cost_latency.py
+++ b/agents/langgraph/templates/human_in_the_loop/tests/behavioral/test_cost_latency.py
@@ -20,7 +20,9 @@ async def test_latency_under_threshold(
     """Response latency must stay within the p95 threshold."""
     max_latency = hitl_thresholds["max_latency_p95"]
     query = "Hello, how are you?"
-    result = await run_eval(query)
+    # This stateless probe is safe to replay if the OpenShift route briefly
+    # returns a transient gateway error.
+    result = await run_eval(query, transient_retries=2)
     assert result.success, f"Agent request failed: {result.error}"
 
     score = score_latency(result, max_latency)

--- a/agents/langgraph/templates/human_in_the_loop/tests/behavioral/test_retry_config.py
+++ b/agents/langgraph/templates/human_in_the_loop/tests/behavioral/test_retry_config.py
@@ -1,0 +1,36 @@
+"""Regression tests for the HITL behavioral evaluation wrapper."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import conftest
+import pytest
+from harness.runner import TaskConfig, TaskResult
+
+
+async def test_run_eval_forwards_transient_retries(
+    run_eval: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The stateless latency probe can opt in to gateway-error retries."""
+    captured_config: TaskConfig | None = None
+
+    async def fake_run_task(config: TaskConfig, client: Any = None) -> TaskResult:
+        nonlocal captured_config
+        captured_config = config
+        return TaskResult(
+            response="ok",
+            tool_calls=[],
+            latency_seconds=0.0,
+            tokens_used=None,
+            raw_response={},
+            success=True,
+        )
+
+    monkeypatch.setattr(conftest, "run_task", fake_run_task)
+
+    result = await run_eval("Hello", transient_retries=2)
+
+    assert result.success
+    assert captured_config is not None
+    assert captured_config.transient_retries == 2

--- a/evals/harness/runner.py
+++ b/evals/harness/runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -12,6 +13,11 @@ from typing import Any, Literal
 import httpx
 
 logger = logging.getLogger(__name__)
+
+# Retrying a POST can duplicate agent work, so retries are disabled by default
+# and intentionally limited to transient gateway responses when explicitly enabled.
+_TRANSIENT_STATUS_CODES = frozenset({502, 503, 504})
+_TRANSIENT_RETRY_BACKOFF_SECONDS = 0.25
 
 # Flow ID must contain only alphanumeric characters, hyphens, and underscores
 _FLOW_ID_PATTERN = re.compile(r"[a-zA-Z0-9_-]+")
@@ -49,6 +55,7 @@ class TaskConfig:
     api_format: Literal["chat_completions", "langflow_run"] = "chat_completions"
     flow_id: str | None = None
     extra_headers: dict[str, str] = field(default_factory=dict)
+    transient_retries: int = 0
 
 
 @dataclass
@@ -296,6 +303,9 @@ async def run_task(
     Langflow ``/api/v1/run/<flow_id>``), measures latency, extracts
     tool calls and token usage.
     """
+    if config.transient_retries < 0:
+        raise ValueError("transient_retries must be non-negative")
+
     own_client = client is None
     if own_client:
         client = httpx.AsyncClient()
@@ -327,16 +337,36 @@ async def run_task(
     headers = config.extra_headers or None
     start = time.monotonic()
     try:
-        if not is_langflow and config.stream:
-            response_data = await _run_streaming(
-                client, url, payload, config.timeout_seconds, headers=headers
-            )
-        else:
-            resp = await client.post(
-                url, json=payload, headers=headers, timeout=config.timeout_seconds
-            )
-            resp.raise_for_status()
-            response_data = resp.json()
+        for attempt in range(config.transient_retries + 1):
+            try:
+                if not is_langflow and config.stream:
+                    response_data = await _run_streaming(
+                        client, url, payload, config.timeout_seconds, headers=headers
+                    )
+                else:
+                    resp = await client.post(
+                        url,
+                        json=payload,
+                        headers=headers,
+                        timeout=config.timeout_seconds,
+                    )
+                    resp.raise_for_status()
+                    response_data = resp.json()
+                break
+            except httpx.HTTPStatusError as exc:
+                if (
+                    exc.response.status_code not in _TRANSIENT_STATUS_CODES
+                    or attempt == config.transient_retries
+                ):
+                    raise
+                logger.warning(
+                    "Transient HTTP %d from %s (attempt %d/%d); retrying.",
+                    exc.response.status_code,
+                    url,
+                    attempt + 1,
+                    config.transient_retries + 1,
+                )
+                await asyncio.sleep(_TRANSIENT_RETRY_BACKOFF_SECONDS * (attempt + 1))
 
         latency = time.monotonic() - start
 

--- a/evals/harness/tests/test_runner_langflow.py
+++ b/evals/harness/tests/test_runner_langflow.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -195,6 +195,18 @@ class TestExtractLangflowToolCalls:
 class TestRunTaskLangflow:
     """Tests for run_task() with api_format='langflow_run'."""
 
+    def test_negative_transient_retries_raises(self):
+        config = TaskConfig(
+            agent_url="http://agent:8080",
+            query="test",
+            api_format="langflow_run",
+            flow_id="f-1",
+            transient_retries=-1,
+        )
+
+        with pytest.raises(ValueError, match="transient_retries must be non-negative"):
+            asyncio.run(run_task(config))
+
     def test_missing_flow_id_raises(self):
         """run_task raises ValueError when flow_id is not set."""
         config = TaskConfig(
@@ -291,6 +303,54 @@ class TestRunTaskLangflow:
 
         assert result.success is False
         assert result.error is not None and "500" in result.error
+
+    def test_opted_in_retry_retries_transient_gateway_error(self):
+        """An explicitly replay-safe task retries a 503 once before succeeding."""
+        config = TaskConfig(
+            agent_url="http://agent:8080",
+            query="test",
+            api_format="langflow_run",
+            flow_id="f-1",
+            transient_retries=1,
+        )
+        transient_error = httpx.HTTPStatusError(
+            "Service Unavailable",
+            request=httpx.Request("POST", "http://agent:8080/api/v1/run/f-1"),
+            response=httpx.Response(503, text="Service Unavailable"),
+        )
+        success_response = MagicMock()
+        success_response.raise_for_status = MagicMock()
+        success_response.json.return_value = {"outputs": []}
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=[transient_error, success_response])
+
+        with patch("harness.runner.asyncio.sleep", new_callable=AsyncMock) as sleep:
+            result = asyncio.run(run_task(config, client=mock_client))
+
+        assert result.success is True
+        assert mock_client.post.await_count == 2
+        sleep.assert_awaited_once_with(0.25)
+
+    def test_default_does_not_retry_transient_gateway_error(self):
+        """Potentially stateful tasks remain single-attempt by default."""
+        config = TaskConfig(
+            agent_url="http://agent:8080",
+            query="test",
+            api_format="langflow_run",
+            flow_id="f-1",
+        )
+        error = httpx.HTTPStatusError(
+            "Service Unavailable",
+            request=httpx.Request("POST", "http://agent:8080/api/v1/run/f-1"),
+            response=httpx.Response(503, text="Service Unavailable"),
+        )
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=error)
+
+        result = asyncio.run(run_task(config, client=mock_client))
+
+        assert result.success is False
+        assert mock_client.post.await_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/behavioral/conftest.py
+++ b/tests/behavioral/conftest.py
@@ -139,6 +139,7 @@ def run_eval(
         max_tokens_budget: int | None = None,
         model: str | None = None,
         thread_id: str | None = None,
+        transient_retries: int = 0,
     ) -> TaskResult:
         config = TaskConfig(
             agent_url=agent_url,
@@ -149,6 +150,7 @@ def run_eval(
             model=model,
             stream=STREAM,
             thread_id=thread_id,
+            transient_retries=transient_retries,
         )
         return await run_task(config, client=http_client)
 


### PR DESCRIPTION
## Description

Adds conservative, opt-in retries for transient OpenShift gateway failures in the shared behavioral-evaluation harness. Retries are disabled by default and are enabled only for the stateless Human-in-the-Loop latency probe.

## Jira Ticket

RHAIENG-7488

## Testing

- [x] `uv run pytest evals/harness/tests/test_runner_langflow.py`
- [x] `ruff check evals/harness/runner.py evals/harness/tests/test_runner_langflow.py tests/behavioral/conftest.py agents/langgraph/templates/human_in_the_loop/tests/behavioral/test_cost_latency.py`
- [x] `ruff format --check evals/harness/runner.py evals/harness/tests/test_runner_langflow.py tests/behavioral/conftest.py agents/langgraph/templates/human_in_the_loop/tests/behavioral/test_cost_latency.py`

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] No `.env` or secret files are included in this PR
- [x] All changes are within scope of RHAIENG-7488

## Review Guidance

The retry is intentionally opt-in because replaying POST requests may duplicate agent work. Only 502, 503, and 504 are retried; total elapsed retry time remains included in the latency result.